### PR TITLE
Add script to fetch dirs from contour repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 target/
 
 compile_commands.json
+/src/vtparser/
+/src/crispy/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(endo VERSION "0.0.0" LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(EnableCcache)
-include(CrushThirdParties)
+include(EndoThirdParties)
 include(PedanticCompiler)
 
 # setting defaults
@@ -33,4 +33,4 @@ endif()
 enable_testing()
 
 add_subdirectory(src)
-CrushThirdPartiesSummary2()
+EndoThirdPartiesSummary2()

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -1,8 +1,8 @@
-# Crush Language Design
+# Endo Language Design
 
 **This file should sketch some example syntax that we'd like to consider supporting.**
 
-This document is used to bootstrap and and formulate the idea of how the Crush's shell syntax might look like.
+This document is used to bootstrap and and formulate the idea of how the Endo's shell syntax might look like.
 
 ## POSIX / Bash-style control flow
 

--- a/cmake/EndoThirdParties.cmake
+++ b/cmake/EndoThirdParties.cmake
@@ -94,32 +94,8 @@ else()
     set(THIRDPARTY_BUILTIN_unicode_core "system package")
 endif()
 
-
 EndoThirdParties_Embed_boxed_cpp()
 set(THIRDPARTY_BUILDIN_boxed_cpp "embedded")
-
-
-if (TARGET boxed-cpp::boxed-cpp)
-    message("TARGET BOXED CPP")
-else()
-    message("NO TARGET BOXED CPP")
-endif()
-
-
-
-if (TARGET unicode::core)
-    message("TARGET unicode core ")
-else()
-    message("NO TARGET unicode core")
-endif()
-
-
-if (TARGET unicode::unicode)
-    message("TARGET unicode unicode ")
-else()
-    message("NO TARGET unicode unicode")
-endif()
-
 
 macro(EndoThirdPartiesSummary2)
     message(STATUS "==============================================================================")

--- a/cmake/EndoThirdParties.cmake
+++ b/cmake/EndoThirdParties.cmake
@@ -2,25 +2,25 @@
 # and is used to inject all the dependencies the operating system's
 # package manager did not provide (not found or too old version).
 
-set(CrushThirdParties_SRCDIR ${PROJECT_SOURCE_DIR}/_deps/sources)
-if(EXISTS "${CrushThirdParties_SRCDIR}/CMakeLists.txt")
-    message(STATUS "Embedding 3rdparty libraries: ${CrushThirdParties_SRCDIR}")
-    add_subdirectory(${CrushThirdParties_SRCDIR})
+set(EndoThirdParties_SRCDIR ${PROJECT_SOURCE_DIR}/_deps/sources)
+if(EXISTS "${EndoThirdParties_SRCDIR}/CMakeLists.txt")
+    message(STATUS "Embedding 3rdparty libraries: ${EndoThirdParties_SRCDIR}")
+    add_subdirectory(${EndoThirdParties_SRCDIR})
 else()
-    message(STATUS "No 3rdparty libraries found at ${CrushThirdParties_SRCDIR}")
+    message(STATUS "No 3rdparty libraries found at ${EndoThirdParties_SRCDIR}")
 endif()
 
-set(LIST CrushThirdParties)
+set(LIST EndoThirdParties)
 macro(Thirdparty_Include_If_MIssing _TARGET _PACKAGE_NAME)
     if(${_PACKAGE_NAME} STREQUAL "")
         set(${_PACKAGE_NAME} ${_TARGET})
     endif()
     if (NOT TARGET ${_TARGET})
         find_package(${_PACKAGE_NAME} REQUIRED)
-        list(APPEND CrushThirdParties ${_TARGET}_SYSDEP)
+        list(APPEND EndoThirdParties ${_TARGET}_SYSDEP)
         set(THIRDPARTY_BUILTIN_${_TARGET} "system package")
     else()
-        list(APPEND CrushThirdParties ${_TARGET}_EMBED)
+        list(APPEND EndoThirdParties ${_TARGET}_EMBED)
         set(THIRDPARTY_BUILTIN_${_TARGET} "embedded")
     endif()
 endmacro()
@@ -32,11 +32,11 @@ endmacro()
 # Thirdparty_Include_If_MIssing(unicode::core)
 # Thirdparty_Include_If_MIssing(yaml-cpp)
 # TODO make me working
-macro(CrushThirdPartiesSummary)
+macro(EndoThirdPartiesSummary)
     message(STATUS "==============================================================================")
-    message(STATUS "    Crush ThirdParties")
+    message(STATUS "    Endo ThirdParties")
     message(STATUS "------------------------------------------------------------------------------")
-    foreach(TP ${CrushThirdParties})
+    foreach(TP ${EndoThirdParties})
         message(STATUS "${TP}\t\t${THIRDPARTY_BUILTIN_${TP}}")
     endforeach()
 endmacro()
@@ -85,7 +85,7 @@ else()
     set(THIRDPARTY_BUILTIN_yaml_cpp "system package")
 endif()
 
-CrushThirdParties_Embed_libunicode()
+EndoThirdParties_Embed_libunicode()
 
 if (TARGET unicode::core)
     set(THIRDPARTY_BUILTIN_unicode_core "embedded")
@@ -94,12 +94,36 @@ else()
     set(THIRDPARTY_BUILTIN_unicode_core "system package")
 endif()
 
-CrushThirdParties_Embed_boxed_cpp()
+
+EndoThirdParties_Embed_boxed_cpp()
 set(THIRDPARTY_BUILDIN_boxed_cpp "embedded")
 
-macro(CrushThirdPartiesSummary2)
+
+if (TARGET boxed-cpp::boxed-cpp)
+    message("TARGET BOXED CPP")
+else()
+    message("NO TARGET BOXED CPP")
+endif()
+
+
+
+if (TARGET unicode::core)
+    message("TARGET unicode core ")
+else()
+    message("NO TARGET unicode core")
+endif()
+
+
+if (TARGET unicode::unicode)
+    message("TARGET unicode unicode ")
+else()
+    message("NO TARGET unicode unicode")
+endif()
+
+
+macro(EndoThirdPartiesSummary2)
     message(STATUS "==============================================================================")
-    message(STATUS "    Crush Shell ThirdParties")
+    message(STATUS "    Endo Shell ThirdParties")
     message(STATUS "------------------------------------------------------------------------------")
     message(STATUS "Catch2              ${THIRDPARTY_BUILTIN_Catch2}")
     message(STATUS "GSL                 ${THIRDPARTY_BUILTIN_GSL}")

--- a/get_contour_dirs.sh
+++ b/get_contour_dirs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+rm -rf ./src/crispy ./src/vtparser ./contour
+git clone -n --depth=1 --filter=tree:0 https://github.com/contour-terminal/contour.git
+cd contour
+git sparse-checkout set --no-cone src/crispy src/vtparser
+git checkout
+cd ..
+mv ./contour/src/crispy ./src/crispy
+mv ./contour/src/vtparser ./src/vtparser
+rm -rf ./contour

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -128,6 +128,14 @@ fetch_and_unpack_boxed()
         boxed_cpp
 }
 
+fetch_and_unpack_range()
+{
+    fetch_and_unpack \
+        range-v3-0.12.0 \
+        range-v3-0.12.0.tar.gz \
+        https://github.com/ericniebler/range-v3/archive/refs/tags/0.12.0.tar.gz
+}
+
 prepare_fetch_and_unpack()
 {
     mkdir -p "${SYSDEPS_BASE_DIR}"
@@ -359,6 +367,7 @@ main()
             fetch_and_unpack_gsl
             fetch_and_unpack_yaml_cpp
             fetch_and_unpack_boxed
+            fetch_and_unpack_range
             echo "OS $ID not supported."
             echo "Please install the remaining dependencies manually."
             ;;

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -63,8 +63,8 @@ fetch_and_unpack()
     if test x$MACRO = x; then
         echo "add_subdirectory($NAME EXCLUDE_FROM_ALL)" >> $SYSDEPS_CMAKE_FILE
     else
-        echo "macro(CrushThirdParties_Embed_$MACRO)" >> $SYSDEPS_CMAKE_FILE
-        echo "    add_subdirectory(\${CrushThirdParties_SRCDIR}/$NAME EXCLUDE_FROM_ALL)" >> $SYSDEPS_CMAKE_FILE
+        echo "macro(EndoThirdParties_Embed_$MACRO)" >> $SYSDEPS_CMAKE_FILE
+        echo "    add_subdirectory(\${EndoThirdParties_SRCDIR}/$NAME EXCLUDE_FROM_ALL)" >> $SYSDEPS_CMAKE_FILE
         echo "endmacro()" >> $SYSDEPS_CMAKE_FILE
     fi
 }
@@ -105,7 +105,7 @@ fetch_and_unpack_embeds()
     else
         echo "Hard linking external libunicode source directory to: $LIBUNICODE_SRC_DIR"
         MACRO="libunicode"
-        echo "macro(CrushThirdParties_Embed_$MACRO)" >> $SYSDEPS_CMAKE_FILE
+        echo "macro(EndoThirdParties_Embed_$MACRO)" >> $SYSDEPS_CMAKE_FILE
         echo "    add_subdirectory($LIBUNICODE_SRC_DIR libunicode EXCLUDE_FROM_ALL)" >> $SYSDEPS_CMAKE_FILE
         echo "endmacro()" >> $SYSDEPS_CMAKE_FILE
     fi

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -96,7 +96,7 @@ fetch_and_unpack_gsl()
 fetch_and_unpack_embeds()
 {
     if test x$LIBUNICODE_SRC_DIR = x; then
-        local libunicode_git_sha="b1b017c466038655872e1968acfc6a9880cf5d9f"
+        local libunicode_git_sha="c1474ddc3a90366629d61863628b8d41cd764fa8"
         fetch_and_unpack \
             libunicode-$libunicode_git_sha \
             libunicode-$libunicode_git_sha.tar.gz \
@@ -120,7 +120,7 @@ fetch_and_unpack_yaml_cpp()
 
 fetch_and_unpack_boxed()
 {
-    local boxed_cpp_git_sha="daa702e22e71f3da3eef838e4946b6c3df1f16b1"
+    local boxed_cpp_git_sha="783cb74e95cbe06a52b468a73c14467e8f082cd1"
     fetch_and_unpack \
         boxed-cpp-$boxed_cpp_git_sha \
         boxed-cpp-$boxed_cpp_git_sha.tar.gz \

--- a/src/CoreVM/CMakeLists.txt
+++ b/src/CoreVM/CMakeLists.txt
@@ -53,4 +53,4 @@ target_include_directories(CoreVM PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(CoreVM PUBLIC fmt::fmt-header-only)
+target_link_libraries(CoreVM PUBLIC fmt::fmt-header-only range-v3::range-v3)


### PR DESCRIPTION
This PR : 
* adds script to fetch crispy and vtparser directories from contour project, they are also added to gitignore so you can not change them locally for this project but have to submit pr in contour.
* rangev3 added to install-deps.sh script 
*  complited rename of crush -> endo
* updated versions of dependencies to adhere to contour install-deps script