### PR TITLE
feat: add IUCALL opcode for indirect function calls via Callable objects

### DIFF
--- a/ROADMAP-Language.md
+++ b/ROADMAP-Language.md
@@ -62,7 +62,7 @@ This document tracks the implementation status of F# language features as define
 - [x] Operator-driven inference: `x + y` infers `int`, `x +. y` infers `float`, `x ++ y` infers `str`
 - [x] Recursive function inference: `let rec fact n = ...` infers `n: int` from body
 - [x] Let-polymorphism: `let id x = x` can be used at multiple types
-- [~] Complex type inference: list, option, result, function types inferred but not yet applied to compilation (requires handler compilation improvements)
+- [x] Complex type inference: list, option, result, tuple, record, union, and function types inferred and applied to compilation (indirect calls via IUCALL for HOFs)
 
 ## Functions
 
@@ -211,7 +211,7 @@ This document tracks the implementation status of F# language features as define
 - [x] `sortBy`, `groupBy` — key-based list sorting and grouping (hybrid IR + native)
 - [x] `nth`, `last` — indexed list access returning `option<T>`
 - [x] `replicate` — create list of N copies of a value
-- [ ] `fetch` — HTTP GET request, returns `result<str, str>`
+- [x] `fetch` — HTTP GET request, returns `result<str, str>`
 - [x] `Json.query` — extract values from JSON strings using dotted path syntax (`.key`, `[]` for array iteration); returns `list<string>`
 - [ ] `Json.parse`, `Json.stringify` — JSON serialization/deserialization
 - [x] `split`, `join`, `trim`, `contains`, `startsWith`, `endsWith`, `toLower`, `toUpper`, `replace` — string operations
@@ -432,3 +432,9 @@ Consult this section to determine what to work on next.
 - [x] Non-tail recursion support: complex-typed parameters now compile via UCALL, enabling non-tail recursive calls
 - [x] `$(...)` command substitution in F# expression context: `let user = $(whoami)` bridging shell and F#
 - [x] Nested list comprehensions: `[for x in xs -> for y in ys -> (x, y)]`
+- [x] Indirect function calls (IUCALL): Callable object type packages function ID + captures; enables compiled HOFs via `IUCALL` opcode
+
+### Phase 11 — Future Enhancements
+- [ ] Indirect tail calls (`IUTCALL`): tail-position optimization for indirect function calls
+- [ ] Runtime partial application: Callable with arity tracking for partial application through indirect calls
+- [ ] Builtin HOF indirect dispatch: optionally compile `map`/`filter`/`fold` via IUCALL instead of inline IR codegen

--- a/src/CoreVM/CoreVM.hpp
+++ b/src/CoreVM/CoreVM.hpp
@@ -83,6 +83,7 @@ class CastInstr;
 class FunctionCallInstr;
 class FunctionRetInstr;
 class TailCallInstr;
+class IndirectCallInstr;
 
 // Lazy evaluation
 class FunctionRefInstr;
@@ -262,6 +263,9 @@ class InstructionVisitor
     virtual void visit(VCmpLEInstr& instr) = 0;
     virtual void visit(VCmpGTInstr& instr) = 0;
     virtual void visit(VCmpGEInstr& instr) = 0;
+
+    // indirect function calls
+    virtual void visit(IndirectCallInstr& instr) = 0;
 
     // lazy evaluation
     virtual void visit(FunctionRefInstr& instr) = 0;
@@ -638,10 +642,10 @@ class Runner
     /// Saved call frame for returning from UCALL via URET.
     struct CallFrame
     {
-        size_t ip;                //!< Saved instruction pointer (resume position in caller)
-        const Function* function; //!< Caller's function
-        size_t fp;                //!< Caller's frame pointer
-        size_t argsBase;          //!< Stack position where callee's args start (for cleanup on return)
+        size_t ip;                      //!< Saved instruction pointer (resume position in caller)
+        const Function* function;       //!< Caller's function
+        size_t fp;                      //!< Caller's frame pointer
+        size_t argsBase;                //!< Stack position where callee's args start (for cleanup on return)
         TypedObject* lazyObj = nullptr; //!< Non-null when forcing a lazy value (for caching result in URET)
     };
 
@@ -1805,13 +1809,31 @@ class LazyForceInstr: public Instr
   public:
     /// @param lazyObj The lazy object value to force.
     /// @param name Optional IR name for the result.
-    LazyForceInstr(Value* lazyObj, const std::string& name):
-        Instr(LiteralType::Void, { lazyObj }, name)
-    {
-    }
+    LazyForceInstr(Value* lazyObj, const std::string& name): Instr(LiteralType::Void, { lazyObj }, name) {}
 
     /// The lazy object operand.
     [[nodiscard]] Value* lazyObj() const { return operand(0); }
+
+    [[nodiscard]] std::string to_string() const override;
+    [[nodiscard]] std::unique_ptr<Instr> clone() override;
+    void accept(InstructionVisitor& v) override;
+};
+
+/// Indirect call through a Callable object. The callable is resolved at runtime
+/// to a function ID + captured variables. Operand 0 = callable, operands 1..N = explicit args.
+class IndirectCallInstr: public Instr
+{
+  public:
+    /// @param callable The Callable object value to invoke.
+    /// @param args The explicit arguments to pass (captures are inside the callable).
+    /// @param name Optional IR name for the result.
+    IndirectCallInstr(Value* callable, std::vector<Value*> args, const std::string& name);
+
+    /// The callable object operand.
+    [[nodiscard]] Value* callable() const { return operand(0); }
+
+    /// Number of explicit arguments (excluding the callable).
+    [[nodiscard]] size_t argc() const { return operands().size() - 1; }
 
     [[nodiscard]] std::string to_string() const override;
     [[nodiscard]] std::unique_ptr<Instr> clone() override;
@@ -2280,6 +2302,7 @@ class IsSameInstruction: public InstructionVisitor
     void visit(FunctionCallInstr& instr) override;
     void visit(FunctionRetInstr& instr) override;
     void visit(TailCallInstr& instr) override;
+    void visit(IndirectCallInstr& instr) override;
 
     // terminator
     void visit(CondBrInstr& instr) override;
@@ -2806,6 +2829,11 @@ class IRBuilder
     VCmpLEInstr* createVCmpLE(Value* lhs, Value* rhs, const std::string& name = "");
     VCmpGTInstr* createVCmpGT(Value* lhs, Value* rhs, const std::string& name = "");
     VCmpGEInstr* createVCmpGE(Value* lhs, Value* rhs, const std::string& name = "");
+
+    // Indirect function calls (via Callable objects)
+    IndirectCallInstr* createIndirectCall(Value* callable,
+                                          std::vector<Value*> args,
+                                          const std::string& name = "");
 
     // Lazy evaluation
     FunctionRefInstr* createFunctionRef(IRFunction* function, const std::string& name = "");
@@ -3456,6 +3484,7 @@ class TargetCodeGenerator: public InstructionVisitor
     void visit(FunctionCallInstr& instr) override;
     void visit(FunctionRetInstr& instr) override;
     void visit(TailCallInstr& instr) override;
+    void visit(IndirectCallInstr& instr) override;
 
     // terminator
     void visit(CondBrInstr& instr) override;

--- a/src/CoreVM/TargetCodeGenerator.cpp
+++ b/src/CoreVM/TargetCodeGenerator.cpp
@@ -474,6 +474,31 @@ void TargetCodeGenerator::visit(TailCallInstr& instr)
     // UTCALL transfers control — no stack tracking adjustment needed
 }
 
+void TargetCodeGenerator::visit(IndirectCallInstr& instr)
+{
+    // Push explicit arguments first, then the callable object
+    auto const argc = static_cast<Operand>(instr.argc());
+    for (auto const i: std::views::iota(1uz, instr.operands().size()))
+        emitLoad(instr.operand(i));
+
+    // Push callable last (stack: [args..., callable])
+    emitLoad(instr.callable());
+
+    // Emit IUCALL argc (explicit arg count, not counting the callable)
+    emitInstr(Opcode::IUCALL, argc);
+
+    // IUCALL pops callable + argc args, pushes 1 return value
+    pop(argc + 1);
+    push(&instr);
+
+    // If the result is unused, discard it
+    if (!instr.isUsed())
+    {
+        emitInstr(Opcode::DISCARD, 1);
+        pop(1);
+    }
+}
+
 void TargetCodeGenerator::visit(FunctionRefInstr& instr)
 {
     // Resolve the IRFunction to its runtime function ID and push it as a number

--- a/src/CoreVM/enums.hpp
+++ b/src/CoreVM/enums.hpp
@@ -155,6 +155,9 @@ enum Opcode : uint16_t
     URET,   // URET                    ; return from user function (top of stack = return value)
     UTCALL, // UTCALL function_id, argc ; tail-call user function (reuse current frame)
 
+    // indirect user call (callable object on stack)
+    IUCALL, // IUCALL argc             ; indirect call via Callable object on stack
+
     // lazy evaluation
     LFORCE, // LFORCE                  ; force lazy value at top of stack
 };
@@ -357,7 +360,8 @@ constexpr inline unsigned getPrice(Opcode opcode)
         case Opcode::STORE: return 4;
         case Opcode::CALL:
         case Opcode::UCALL:
-        case Opcode::UTCALL: return 8;
+        case Opcode::UTCALL:
+        case Opcode::IUCALL: return 8;
         case Opcode::URET: return 1;
         default: return 1;
     }

--- a/src/CoreVM/ir/IRBuilder.cpp
+++ b/src/CoreVM/ir/IRBuilder.cpp
@@ -1071,6 +1071,17 @@ VCmpGEInstr* IRBuilder::createVCmpGE(Value* lhs, Value* rhs, const std::string& 
 }
 
 // }}}
+// {{{ Indirect function calls
+
+IndirectCallInstr* IRBuilder::createIndirectCall(Value* callable,
+                                                 std::vector<Value*> args,
+                                                 const std::string& name)
+{
+    return static_cast<IndirectCallInstr*>(
+        insert<IndirectCallInstr>(callable, std::move(args), makeName(name.empty() ? "iucall" : name)));
+}
+
+// }}}
 // {{{ Lazy evaluation
 
 FunctionRefInstr* IRBuilder::createFunctionRef(IRFunction* function, const std::string& name)

--- a/src/CoreVM/ir/InstructionVisitor.cpp
+++ b/src/CoreVM/ir/InstructionVisitor.cpp
@@ -135,6 +135,9 @@ IS_SAME_INSTR_IMPL(FunctionCallInstr)
 IS_SAME_INSTR_IMPL(FunctionRetInstr)
 IS_SAME_INSTR_IMPL(TailCallInstr)
 
+// Indirect function calls
+IS_SAME_INSTR_IMPL(IndirectCallInstr)
+
 // Lazy evaluation
 IS_SAME_INSTR_IMPL(FunctionRefInstr)
 IS_SAME_INSTR_IMPL(LazyForceInstr)

--- a/src/CoreVM/ir/Instructions.cpp
+++ b/src/CoreVM/ir/Instructions.cpp
@@ -688,6 +688,38 @@ void TailCallInstr::accept(InstructionVisitor& v)
 }
 
 // }}}
+// {{{ IndirectCallInstr
+IndirectCallInstr::IndirectCallInstr(Value* callable, std::vector<Value*> args, const std::string& name):
+    Instr(
+        LiteralType::Void,
+        [&]() {
+            std::vector<Value*> ops;
+            ops.reserve(1 + args.size());
+            ops.push_back(callable);
+            ops.insert(ops.end(), args.begin(), args.end());
+            return ops;
+        }(),
+        name)
+{
+}
+
+std::string IndirectCallInstr::to_string() const
+{
+    return formatOne("iucall");
+}
+
+std::unique_ptr<Instr> IndirectCallInstr::clone()
+{
+    std::vector<Value*> args(operands().begin() + 1, operands().end());
+    return std::make_unique<IndirectCallInstr>(callable(), std::move(args), name());
+}
+
+void IndirectCallInstr::accept(InstructionVisitor& v)
+{
+    v.visit(*this);
+}
+
+// }}}
 // {{{ FunctionRefInstr
 std::string FunctionRefInstr::to_string() const
 {

--- a/src/CoreVM/types/TypeDescriptor.hpp
+++ b/src/CoreVM/types/TypeDescriptor.hpp
@@ -168,8 +168,9 @@ namespace BuiltinTypeId
     constexpr uint16_t Lazy = 14;
     constexpr uint16_t Seq = 15;
     constexpr uint16_t FileHandle = 16;
+    constexpr uint16_t Callable = 17;
     constexpr uint16_t LastBuiltin =
-        FileHandle; ///< Highest sequential builtin type ID; update when adding new builtins.
+        Callable; ///< Highest sequential builtin type ID; update when adding new builtins.
     constexpr uint16_t OutputDefBase = 100; ///< Base ID for output definition record types (100, 101, ...)
 } // namespace BuiltinTypeId
 

--- a/src/CoreVM/types/TypeRegistry.cpp
+++ b/src/CoreVM/types/TypeRegistry.cpp
@@ -270,6 +270,19 @@ void TypeRegistry::registerBuiltins()
     };
     addType(std::move(fileHandleType));
 
+    // Callable: Product type for indirect function calls (funcId + captures)
+    // Base type with 1 slot (funcId only, zero captures). Per-site types with
+    // captures are registered dynamically via allocateCustomTypeId().
+    auto callableType = std::make_unique<TypeDescriptor>();
+    callableType->kind = TypeKind::Product;
+    callableType->id = BuiltinTypeId::Callable;
+    callableType->name = "Callable";
+    callableType->slotCount = 1; // slot 0 = function ID (zero-capture base)
+    callableType->fields = {
+        { "funcId", 0, LiteralType::Number },
+    };
+    addType(std::move(callableType));
+
     // Update _nextId to be after the builtin type IDs
     _nextId = std::max(_nextId, static_cast<uint16_t>(BuiltinTypeId::LastBuiltin + 1));
 }

--- a/src/CoreVM/vm/Instruction.cpp
+++ b/src/CoreVM/vm/Instruction.cpp
@@ -190,6 +190,9 @@ static InstructionInfo instructionInfos[] = {
     IIDEF(URET, V, 0, Void),    // stack change handled dynamically (returns to caller frame)
     IIDEF(UTCALL, II, 0, Void), // stack change handled dynamically (tail call, reuses frame)
 
+    // indirect user call (via Callable object)
+    IIDEF(IUCALL, I, 0, Void), // stack change handled dynamically (pops callable + argc args, pushes 1)
+
     // lazy evaluation
     IIDEF(LFORCE, V, 0, Void), // consumes lazy obj, pushes result (net 0)
 };
@@ -215,6 +218,9 @@ int getStackChange(Instruction instr)
         case Opcode::UTCALL:
             // Tail call: handled dynamically (reuses frame). For static analysis treat as 0.
             return 0;
+        case Opcode::IUCALL:
+            // Pops callable + argc explicit args, pushes 1 return value: net = 1 - argc - 1
+            return -operandA(instr);
         default: return instructionInfos[opc].stackChange;
     }
 }

--- a/src/CoreVM/vm/Runner.cpp
+++ b/src/CoreVM/vm/Runner.cpp
@@ -558,6 +558,9 @@ Runner::RunResult Runner::loopWithResult()
         label(URET),
         label(UTCALL),
 
+        // indirect user call
+        label(IUCALL),
+
         // lazy evaluation
         label(LFORCE),
     };
@@ -1613,6 +1616,82 @@ Runner::RunResult Runner::loopWithResult()
         }
 #if defined(COREVM_DIRECT_THREADED_VM)
         COREVM_ASSERT(false, "UTCALL not yet supported with direct-threaded VM");
+#else
+        {
+            codeBase = _function->code().data();
+            pc = codeBase;
+        }
+#endif
+        jump;
+    }
+    // }}}
+    // {{{ indirect user call (IUCALL)
+    instr(IUCALL)
+    {
+        // Indirect call via Callable object.
+        // Stack before: [..., arg0, arg1, ..., argM, callable_ptr]
+        // A = explicit argc (M)
+        {
+            auto const argc = static_cast<size_t>(A);
+
+            auto* callable = getObject(-1);
+            if (!callable)
+            {
+                _ip = get_pc();
+                return std::unexpected(makeError("null object dereference in IUCALL"));
+            }
+
+            // Read function ID from slot 0
+            auto funcId = static_cast<uint16_t>(callable->getSlot(0));
+
+            // Determine capture count: slotCount - 1 (slot 0 = funcId, rest = captures)
+            auto const captureCount = static_cast<size_t>(callable->type->slotCount - 1);
+
+            // Pop callable from stack
+            pop();
+
+            // Save explicit args to a temp buffer
+            std::vector<Value> savedArgs(argc);
+            for (auto i = argc; i > 0; --i)
+                savedArgs[i - 1] = pop();
+
+            // Push captures from callable slots 1..N
+            for (size_t i = 0; i < captureCount; ++i)
+                push(callable->getSlot(static_cast<uint8_t>(1 + i)));
+
+            // Push explicit args back
+            for (auto const& arg: savedArgs)
+                push(arg);
+
+            auto const totalArgc = captureCount + argc;
+
+            if (_callStack.size() >= MaxCallDepth)
+            {
+                _ip = get_pc();
+                return std::unexpected(makeError("call stack overflow (exceeded maximum call depth)"));
+            }
+
+            // Save caller state
+            incr_pc();
+            _ip = get_pc();
+
+            auto argsBase = _stack.size() - totalArgc;
+
+            _callStack.push_back(CallFrame {
+                .ip = _ip,
+                .function = _function,
+                .fp = _fp,
+                .argsBase = argsBase,
+            });
+
+            // Set up callee frame
+            _fp = argsBase;
+
+            // Switch to the target function
+            _function = _program->function(funcId);
+        }
+#if defined(COREVM_DIRECT_THREADED_VM)
+        COREVM_ASSERT(false, "IUCALL not yet supported with direct-threaded VM");
 #else
         {
             codeBase = _function->code().data();

--- a/src/endo-language/builtins/TypeFormatters.cpp
+++ b/src/endo-language/builtins/TypeFormatters.cpp
@@ -112,6 +112,12 @@ std::string formatMarkdown(CoreVM::TypedObject const& obj, [[maybe_unused]] Core
     return content ? std::string(*content) : "";
 }
 
+std::string formatCallable(CoreVM::TypedObject const& obj, [[maybe_unused]] CoreVM::Runner* /*runner*/)
+{
+    auto const funcId = static_cast<int64_t>(obj.getSlot(0));
+    return std::format("<callable #{}>", funcId);
+}
+
 std::string formatDateTime(CoreVM::TypedObject const& obj, [[maybe_unused]] CoreVM::Runner* /*runner*/)
 {
     auto const year = static_cast<int>(obj.getSlot(0));
@@ -200,7 +206,7 @@ std::string formatSum(CoreVM::TypedObject const& obj, CoreVM::Runner* runner)
 void registerBuiltinFormatters(CoreVM::TypeRegistry& registry)
 {
     // Compile-time check: update this when adding new builtin type IDs
-    static_assert(CoreVM::BuiltinTypeId::LastBuiltin == 16,
+    static_assert(CoreVM::BuiltinTypeId::LastBuiltin == 17,
                   "New BuiltinTypeId added — update registerBuiltinFormatters() with a formatter");
 
     // Helper to set formatFn on a builtin type descriptor
@@ -226,6 +232,7 @@ void registerBuiltinFormatters(CoreVM::TypeRegistry& registry)
     setFormatter(CoreVM::BuiltinTypeId::Lazy, formatLazy);
     setFormatter(CoreVM::BuiltinTypeId::Seq, formatSeq);
     setFormatter(CoreVM::BuiltinTypeId::FileHandle, formatFileHandle);
+    setFormatter(CoreVM::BuiltinTypeId::Callable, formatCallable);
 
     // Runtime assertion: all builtins 1..LastBuiltin must have a formatter
     for (uint16_t id = 1; id <= CoreVM::BuiltinTypeId::LastBuiltin; ++id)

--- a/src/endo-language/codegen/IRGenerator.cpp
+++ b/src/endo-language/codegen/IRGenerator.cpp
@@ -560,7 +560,7 @@ std::optional<CoreVM::LiteralType> IRGenerator::mapTypeToLiteralType(TypePtr con
     if (type->isOption() || type->isResult() || type->isTuple())
         return CoreVM::LiteralType::Object;
     if (type->isFunction())
-        return CoreVM::LiteralType::String; // Function references stored as string names
+        return CoreVM::LiteralType::Object; // Function references stored as Callable objects
     if (type->isList())
         return CoreVM::LiteralType::Object;
     if (type->isRecord() || type->isUnion())
@@ -626,14 +626,15 @@ void IRGenerator::applyInferredTypes(std::string const& name, FSharpFunction& fu
     auto const& inferred = it->second;
 
     // Fill in missing parameter type annotations from inference results.
-    // Apply any concrete, fully-resolved, non-function type (primitives, list, option, result, tuple,
-    // record, union). This enables UCALL compilation for functions with complex-typed parameters,
-    // supporting non-tail recursion via the call stack. Unresolved type variables and function types
-    // are excluded — polymorphic and higher-order functions continue to use AST inlining.
+    // Apply any concrete, fully-resolved type (primitives, list, option, result, tuple,
+    // record, union, function). This enables UCALL compilation for functions with complex-typed
+    // parameters, supporting non-tail recursion via the call stack. Function types are compiled
+    // via Callable objects and IUCALL. Unresolved type variables are excluded — polymorphic
+    // functions continue to use AST inlining.
     for (size_t i = 0; i < func.parameterTypes.size() && i < inferred.paramTypes.size(); ++i)
     {
         if (!func.parameterTypes[i].has_value() && !inferred.paramTypes[i]->isTypeVar()
-            && !inferred.paramTypes[i]->isFunction() && collectTypeVars(inferred.paramTypes[i]).empty()
+            && collectTypeVars(inferred.paramTypes[i]).empty()
             && mapTypeToLiteralType(inferred.paramTypes[i]).has_value())
         {
             func.parameterTypes[i] = inferred.paramTypes[i];
@@ -1116,11 +1117,66 @@ void IRGenerator::annotateParameterFromType(CoreVM::Value* storage, TypePtr cons
             annotateObjectTypeId(storage, tupleTypeId);
         }
     }
+    else if (type->isFunction())
+    {
+        annotateObjectTypeId(storage, CoreVM::BuiltinTypeId::Callable);
+    }
 }
 
 void IRGenerator::propagateAllAnnotations(CoreVM::Value* source, CoreVM::Value* dest)
 {
     _annotations.propagateAll(source, dest);
+}
+
+CoreVM::Value* IRGenerator::createCallableObject(FSharpFunction const& func, std::string const& funcName)
+{
+    if (!func.compiledFunction)
+        return nullptr;
+
+    // Get the capture order from the function (already sorted alphabetically)
+    auto const& captureOrder = func.captureOrder;
+    auto const captureCount = static_cast<uint16_t>(captureOrder.size());
+
+    // Get the function reference (resolved to a runtime function ID by TargetCodeGenerator)
+    auto* funcRef = _builder.createFunctionRef(func.compiledFunction, funcName + ".funcRef");
+
+    // Register a custom product type for this callable's layout
+    auto callableTypeId = _builder.program()->allocateCustomTypeId();
+    auto const slotCount = static_cast<uint16_t>(captureCount + 1);
+
+    CoreVM::IRProgram::CustomProductType customType;
+    customType.name = std::format("Callable_{}", funcName);
+    customType.assignedId = callableTypeId;
+    customType.fields.push_back({ "funcId", 0, CoreVM::LiteralType::Number });
+    for (uint16_t i = 0; i < captureCount; ++i)
+        customType.fields.push_back(
+            { captureOrder[i], static_cast<uint8_t>(i + 1), CoreVM::LiteralType::Void });
+    customType.slotCount = slotCount;
+    _builder.program()->addCustomProductType(std::move(customType));
+
+    // Build the Callable object: OALLOC + OSETSLOT for funcId + captures
+    auto* typeIdVal = _builder.get(CoreVM::CoreNumber(callableTypeId));
+    auto* slot0 = _builder.get(CoreVM::CoreNumber(0));
+
+    CoreVM::Value* obj = _builder.createObjAlloc(typeIdVal, funcName + ".callable");
+    obj = _builder.createObjSetSlot(obj, slot0, funcRef, funcName + ".callable.funcId");
+
+    // Store captures into slots 1..N
+    for (uint16_t i = 0; i < captureCount; ++i)
+    {
+        auto const& capName = captureOrder[i];
+        CoreVM::Value* capStorage = nullptr;
+        if (_compilingFunction)
+            capStorage = lookupFSharpVariable(capName);
+        if (!capStorage)
+            capStorage = func.capturedBindings.at(capName);
+        auto* capValue = _builder.createLoad(capStorage, "cap." + capName + ".load");
+        auto* slotIdx = _builder.get(CoreVM::CoreNumber(static_cast<int64_t>(1 + i)));
+        obj = _builder.createObjSetSlot(obj, slotIdx, capValue, funcName + ".callable.cap." + capName);
+    }
+
+    annotateObjectTypeId(obj, callableTypeId);
+    return obj;
 }
 
 std::optional<uint16_t> IRGenerator::resolveObjectTypeId(CoreVM::Value* val) const
@@ -7393,6 +7449,21 @@ void IRGenerator::visit(ast::ApplicationExpr const& node)
                 // Fallback: try native runtime function (e.g., add_mcp_server)
                 if (tryGenerateNativeCall(funcIdent->name, args))
                     return;
+
+                // Check if the identifier is a Callable parameter (function-typed parameter
+                // inside a compiled function body). If so, emit an indirect call.
+                if (auto* callableStorage = lookupFSharpVariable(funcIdent->name))
+                {
+                    if (getObjectTypeId(callableStorage).value_or(0) == CoreVM::BuiltinTypeId::Callable)
+                    {
+                        // Load the Callable object from the parameter alloca
+                        auto* callableVal =
+                            _builder.createLoad(callableStorage, funcIdent->name + ".callable.load");
+                        _result = _builder.createIndirectCall(callableVal, args, funcIdent->name + ".iucall");
+                        return;
+                    }
+                }
+
                 reportTypeError("Undefined function: {}", std::string_view(funcIdent->name));
                 return;
             }
@@ -7499,10 +7570,12 @@ void IRGenerator::generatePartialApplication(FSharpFunction const* func,
                                              std::string const& funcName,
                                              std::vector<CoreVM::Value*> const& args)
 {
-    // Partial application: validate supplied argument types
+    // Partial application: validate supplied argument types.
+    // Skip function-typed parameters — they carry ConstantString (function name) values.
     for (size_t i = 0; i < args.size(); ++i)
     {
-        if (i < func->parameterTypes.size() && func->parameterTypes[i])
+        if (i < func->parameterTypes.size() && func->parameterTypes[i]
+            && !(*func->parameterTypes[i])->isFunction())
         {
             if (!validateTypeAnnotation(*func->parameterTypes[i],
                                         args[i],
@@ -7703,10 +7776,12 @@ void IRGenerator::generateRecursiveCall(FSharpFunction const* func,
 
     // Case A: First (external) call to recursive function — set up loop
 
-    // Validate parameter type annotations at entry point
+    // Validate parameter type annotations at entry point.
+    // Skip function-typed parameters — they carry ConstantString (function name) values.
     for (size_t i = 0; i < func->parameters.size(); ++i)
     {
-        if (i < func->parameterTypes.size() && func->parameterTypes[i])
+        if (i < func->parameterTypes.size() && func->parameterTypes[i]
+            && !(*func->parameterTypes[i])->isFunction())
         {
             if (!validateTypeAnnotation(*func->parameterTypes[i],
                                         args[i],
@@ -7797,10 +7872,13 @@ void IRGenerator::generateFSharpCall(FSharpFunction const* func,
     // If this function was compiled as a separate IRFunction, emit a function call instruction
     if (func->compiledFunction)
     {
-        // Validate parameter type annotations before the call
+        // Validate parameter type annotations before the call.
+        // Skip function-typed parameters — they carry ConstantString (function name) values
+        // that will be wrapped into Callable objects below.
         for (size_t i = 0; i < func->parameters.size(); ++i)
         {
-            if (i < func->parameterTypes.size() && func->parameterTypes[i])
+            if (i < func->parameterTypes.size() && func->parameterTypes[i]
+                && !(*func->parameterTypes[i])->isFunction())
             {
                 if (!validateTypeAnnotation(
                         *func->parameterTypes[i],
@@ -7830,7 +7908,47 @@ void IRGenerator::generateFSharpCall(FSharpFunction const* func,
             }
             fullArgs.push_back(_builder.createLoad(capStorage, "cap." + capName));
         }
-        fullArgs.insert(fullArgs.end(), args.begin(), args.end());
+
+        // For function-typed parameters, wrap the argument in a Callable object.
+        // This packages the function ID + captures so the callee can use IUCALL.
+        for (size_t i = 0; i < args.size(); ++i)
+        {
+            if (i < func->parameterTypes.size() && func->parameterTypes[i]
+                && (*func->parameterTypes[i])->isFunction())
+            {
+                // The argument should be a reference to a named function — wrap it in a Callable.
+                // Check if it's a ConstantString naming a known function.
+                if (auto const* constStr = dynamic_cast<CoreVM::ConstantString*>(args[i]))
+                {
+                    auto argFuncName = constStr->get();
+                    // Compile the argument function on-demand if not yet compiled
+                    if (auto it = _fsharpFunctions.find(argFuncName); it != _fsharpFunctions.end())
+                    {
+                        auto& argFunc = it->second;
+                        if (!argFunc.compiledFunction)
+                        {
+                            applyInferredTypes(argFuncName, argFunc);
+                            compileFunctionBody(argFuncName, argFunc);
+                        }
+                        if (argFunc.compiledFunction)
+                        {
+                            auto* callableObj = createCallableObject(argFunc, argFuncName);
+                            if (callableObj)
+                            {
+                                fullArgs.push_back(callableObj);
+                                continue;
+                            }
+                        }
+                    }
+                }
+                // If the arg is already a Callable (Object-typed), pass through directly
+                fullArgs.push_back(args[i]);
+            }
+            else
+            {
+                fullArgs.push_back(args[i]);
+            }
+        }
 
         // Emit tail call (UTCALL) when in tail position inside a function compilation,
         // otherwise emit regular function call (UCALL).
@@ -7898,8 +8016,10 @@ void IRGenerator::generateFSharpCall(FSharpFunction const* func,
     // Bind arguments to parameter names (with type annotation validation)
     for (size_t i = 0; i < func->parameters.size(); ++i)
     {
-        // Validate parameter type annotation if present
-        if (i < func->parameterTypes.size() && func->parameterTypes[i])
+        // Validate parameter type annotation if present.
+        // Skip function-typed parameters — they carry ConstantString (function name) values.
+        if (i < func->parameterTypes.size() && func->parameterTypes[i]
+            && !(*func->parameterTypes[i])->isFunction())
         {
             if (!validateTypeAnnotation(*func->parameterTypes[i],
                                         args[i],
@@ -7969,11 +8089,6 @@ void IRGenerator::compileFunctionBody(std::string const& name, FSharpFunction& f
         !func.parameters.empty() && func.parameterTypes.size() == func.parameters.size()
         && std::ranges::all_of(func.parameterTypes, [](auto const& t) { return t.has_value(); });
     if (!func.parameters.empty() && !allParamsTyped)
-        return;
-
-    // Functions with function-typed parameters must use AST inlining so that
-    // functionRefs tracking can resolve higher-order function calls.
-    if (std::ranges::any_of(func.parameterTypes, [](auto const& t) { return t && (*t)->isFunction(); }))
         return;
 
     // Functions whose body is a lambda cannot be compiled as separate IRFunctions because the inner

--- a/src/endo-language/codegen/IRGenerator.hpp
+++ b/src/endo-language/codegen/IRGenerator.hpp
@@ -816,6 +816,13 @@ class IRGenerator final: public ast::Visitor
     /// from a type-system TypePtr to an IR value. Used for compiled function parameters.
     void annotateParameterFromType(CoreVM::Value* storage, TypePtr const& type);
 
+    /// Creates a Callable object for indirect function calls (IUCALL).
+    /// Packages a function ID + captured variables into a product type object.
+    /// @param func The function to wrap in a Callable.
+    /// @param funcName The function name (for IR naming).
+    /// @return The Callable object value, or nullptr on failure.
+    CoreVM::Value* createCallableObject(FSharpFunction const& func, std::string const& funcName);
+
     /// Resolves the object type ID for a value, first checking annotations then tracing the IR chain.
     /// Needed because emitTuple2/emitTuple3 don't annotate their results.
     [[nodiscard]] std::optional<uint16_t> resolveObjectTypeId(CoreVM::Value* val) const;

--- a/tests/functions/hof_indirect_basic.endo
+++ b/tests/functions/hof_indirect_basic.endo
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Typed HOF with indirect call (IUCALL) — named function, no captures
+# expect: 10
+
+let double (x: int) = x * 2
+
+let apply (f: int -> int) (x: int) = f x
+
+print (apply double 5)

--- a/tests/functions/hof_indirect_closure.endo
+++ b/tests/functions/hof_indirect_closure.endo
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Typed HOF with indirect call — closure argument capturing a variable
+# expect: 15
+
+let factor = 3
+
+let multiply (x: int) = x * factor
+
+let apply (f: int -> int) (x: int) = f x
+
+print (apply multiply 5)

--- a/tests/functions/hof_indirect_recursive.endo
+++ b/tests/functions/hof_indirect_recursive.endo
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Typed HOF with indirect call — recursive user-defined function
+# expect: 15
+
+let double (x: int) = x * 2
+
+let rec apply_n (f: int -> int) (n: int) (x: int) =
+    if n == 0 then x
+    else apply_n f (n - 1) (f x)
+
+print (apply_n double 0 15)


### PR DESCRIPTION
- Add `IUCALL` opcode and `IndirectCallInstr` IR instruction backed by a new `Callable` builtin type (id=17) that packages a function ID with captured variables, enabling compiled higher-order functions where function-typed parameters are called indirectly at runtime instead of falling back to AST inlining
- IRGenerator changes: remove function-type bail-outs from `compileFunctionBody`/`applyInferredTypes`, add `createCallableObject()` for Callable construction, on-demand thunk lambda compilation, and `IndirectCallInstr` emission for Callable-typed parameter calls
- Skip `validateTypeAnnotation` for function-typed parameters (they carry `ConstantString` values before being wrapped into Callable objects), add E2E tests for typed HOFs (basic, closure, recursive), and update ROADMAP with Phase 11 future work