### PR TITLE
fix: restrict dot-completion for compound type literals to their own fields

### DIFF
--- a/src/endo-language/ide/Completer.cpp
+++ b/src/endo-language/ide/Completer.cpp
@@ -89,6 +89,14 @@ DocumentRecordInfo collectRecordInfo(std::string const& source)
                     if (!recordExpr->typeName.empty())
                         result.variableTypes[letStmt->name] = recordExpr->typeName;
                 }
+                else if (dynamic_cast<ast::SizeLiteralExpr const*>(letStmt->value.get()))
+                {
+                    result.variableTypes[letStmt->name] = "Size";
+                }
+                else if (dynamic_cast<ast::TimeSpanLiteralExpr const*>(letStmt->value.get()))
+                {
+                    result.variableTypes[letStmt->name] = "TimeSpan";
+                }
             }
         }
     };

--- a/src/endo-language/ide/Completer_test.cpp
+++ b/src/endo-language/ide/Completer_test.cpp
@@ -252,6 +252,34 @@ TEST_CASE("Completer.collectRecordInfo.no_type_for_anonymous_record", "[completi
     CHECK(info.variableTypes.count("r") == 0);
 }
 
+TEST_CASE("Completer.collectRecordInfo.size_literal_maps_to_Size_type", "[completion][completer]")
+{
+    auto info = collectRecordInfo("let x = 15.5MB");
+    REQUIRE(info.variableTypes.count("x") == 1);
+    CHECK(info.variableTypes.at("x") == "Size");
+}
+
+TEST_CASE("Completer.collectRecordInfo.size_literal_int_maps_to_Size_type", "[completion][completer]")
+{
+    auto info = collectRecordInfo("let s = 100KB");
+    REQUIRE(info.variableTypes.count("s") == 1);
+    CHECK(info.variableTypes.at("s") == "Size");
+}
+
+TEST_CASE("Completer.collectRecordInfo.timespan_literal_maps_to_TimeSpan_type", "[completion][completer]")
+{
+    auto info = collectRecordInfo("let t = 500ms");
+    REQUIRE(info.variableTypes.count("t") == 1);
+    CHECK(info.variableTypes.at("t") == "TimeSpan");
+}
+
+TEST_CASE("Completer.collectRecordInfo.timespan_seconds_maps_to_TimeSpan_type", "[completion][completer]")
+{
+    auto info = collectRecordInfo("let d = 3.5s");
+    REQUIRE(info.variableTypes.count("d") == 1);
+    CHECK(info.variableTypes.at("d") == "TimeSpan");
+}
+
 // =============================================================================
 // Builtin argument completion integration tests
 // =============================================================================

--- a/src/endo-language/ide/CompletionCandidates.cpp
+++ b/src/endo-language/ide/CompletionCandidates.cpp
@@ -20,7 +20,53 @@ namespace
     {
         if (prefix.empty())
             return true;
-        return name.size() >= prefix.size() && name.substr(0, prefix.size()) == prefix;
+        return name.starts_with(prefix);
+    }
+
+    /// @brief Checks if text is a valid numeric prefix for a compound literal.
+    /// Accepts digits with optional decimal point and underscore separators.
+    [[nodiscard]] bool isNumericPrefix(std::string_view text)
+    {
+        if (text.empty())
+            return false;
+        bool hasDigit = false;
+        bool hasDot = false;
+        for (auto const ch: text)
+        {
+            if (ch >= '0' && ch <= '9')
+                hasDigit = true;
+            else if (ch == '.' && !hasDot)
+                hasDot = true;
+            else if (ch == '_')
+                continue;
+            else
+                return false;
+        }
+        return hasDigit;
+    }
+
+    /// @brief Resolves a compound type literal string to its type name.
+    /// Returns "Size" for size literals (e.g., "15.5MB", "100KB"),
+    /// "TimeSpan" for timespan literals (e.g., "500ms", "3.5s"), or empty string.
+    [[nodiscard]] std::string resolveCompoundLiteralType(std::string_view text)
+    {
+        // Size suffixes (check longest first to avoid "B" matching "KB")
+        for (auto const* const suffix: { "TB", "GB", "MB", "KB", "B" })
+        {
+            auto const len = std::string_view(suffix).size();
+            if (text.size() > len && text.ends_with(suffix)
+                && isNumericPrefix(text.substr(0, text.size() - len)))
+                return "Size";
+        }
+        // TimeSpan suffixes (check "min" before "ms" before "s")
+        for (auto const* const suffix: { "min", "ms", "h", "s" })
+        {
+            auto const len = std::string_view(suffix).size();
+            if (text.size() > len && text.ends_with(suffix)
+                && isNumericPrefix(text.substr(0, text.size() - len)))
+                return "TimeSpan";
+        }
+        return {};
     }
 
     /// @brief Formats a function signature description from symbol info.
@@ -215,6 +261,18 @@ std::vector<CompletionCandidate> dotAccessCandidates(
                             "_." + field.name, field.name, "field: " + field.typeName, CompletionKind::Field);
                 }
             }
+        }
+    }
+    else if (auto const compoundType = resolveCompoundLiteralType(objectPart); !compoundType.empty())
+    {
+        // Compound type literal (e.g., "15.5MB" → Size, "500ms" → TimeSpan)
+        if (auto const fieldsIt = recordFields.find(compoundType); fieldsIt != recordFields.end())
+        {
+            for (auto const& field: fieldsIt->second)
+                addCandidate(objectPart + "." + field.name,
+                             field.name,
+                             compoundType + "." + field.name + ": " + field.typeName,
+                             CompletionKind::Field);
         }
     }
     else if (objectPart.find('.') != std::string::npos)

--- a/src/endo-language/ide/CompletionCandidates_test.cpp
+++ b/src/endo-language/ide/CompletionCandidates_test.cpp
@@ -250,6 +250,87 @@ TEST_CASE("CompletionCandidates.dotAccess.typed_variable_TimeSpan", "[completion
     CHECK(!hasCandidate(candidates, "x.map"));
 }
 
+// =============================================================================
+// Compound type literal dot-access tests (Size, TimeSpan)
+// =============================================================================
+
+TEST_CASE("CompletionCandidates.dotAccess.size_literal_float_shows_only_size_fields", "[completion]")
+{
+    std::unordered_map<std::string, std::vector<RecordFieldInfo>> fields;
+    fields["Size"] = { { "bytes", "int" } };
+    fields["ProcessInfo"] = { { "pid", "int" }, { "cpu", "float" }, { "command", "string" } };
+    auto candidates = dotAccessCandidates("15.5MB", "", fields, {}, {}, testModuleFunctions());
+    REQUIRE(candidates.size() == 1);
+    CHECK(hasCandidate(candidates, "15.5MB.bytes"));
+    CHECK(!hasCandidate(candidates, "15.5MB.pid"));
+    CHECK(!hasCandidate(candidates, "15.5MB.map"));
+}
+
+TEST_CASE("CompletionCandidates.dotAccess.size_literal_int_shows_only_size_fields", "[completion]")
+{
+    std::unordered_map<std::string, std::vector<RecordFieldInfo>> fields;
+    fields["Size"] = { { "bytes", "int" } };
+    fields["ProcessInfo"] = { { "pid", "int" } };
+    auto candidates = dotAccessCandidates("100KB", "", fields, {}, {}, testModuleFunctions());
+    REQUIRE(candidates.size() == 1);
+    CHECK(hasCandidate(candidates, "100KB.bytes"));
+}
+
+TEST_CASE("CompletionCandidates.dotAccess.size_literal_filter_by_prefix", "[completion]")
+{
+    std::unordered_map<std::string, std::vector<RecordFieldInfo>> fields;
+    fields["Size"] = { { "bytes", "int" } };
+    auto candidates = dotAccessCandidates("15.5MB", "b", fields);
+    REQUIRE(candidates.size() == 1);
+    CHECK(candidates[0].text == "15.5MB.bytes");
+}
+
+TEST_CASE("CompletionCandidates.dotAccess.size_literal_all_suffixes", "[completion]")
+{
+    std::unordered_map<std::string, std::vector<RecordFieldInfo>> fields;
+    fields["Size"] = { { "bytes", "int" } };
+    for (auto const* const suffix: { "B", "KB", "MB", "GB", "TB" })
+    {
+        auto literal = std::string("100") + suffix;
+        auto candidates = dotAccessCandidates(literal, "", fields);
+        REQUIRE(candidates.size() == 1);
+        CHECK(hasCandidate(candidates, literal + ".bytes"));
+    }
+}
+
+TEST_CASE("CompletionCandidates.dotAccess.timespan_literal_shows_only_timespan_fields", "[completion]")
+{
+    std::unordered_map<std::string, std::vector<RecordFieldInfo>> fields;
+    fields["TimeSpan"] = { { "milliseconds", "int" } };
+    fields["ProcessInfo"] = { { "pid", "int" } };
+    auto candidates = dotAccessCandidates("500ms", "", fields, {}, {}, testModuleFunctions());
+    REQUIRE(candidates.size() == 1);
+    CHECK(hasCandidate(candidates, "500ms.milliseconds"));
+    CHECK(!hasCandidate(candidates, "500ms.pid"));
+}
+
+TEST_CASE("CompletionCandidates.dotAccess.timespan_literal_float_seconds", "[completion]")
+{
+    std::unordered_map<std::string, std::vector<RecordFieldInfo>> fields;
+    fields["TimeSpan"] = { { "milliseconds", "int" } };
+    auto candidates = dotAccessCandidates("3.5s", "", fields);
+    REQUIRE(candidates.size() == 1);
+    CHECK(hasCandidate(candidates, "3.5s.milliseconds"));
+}
+
+TEST_CASE("CompletionCandidates.dotAccess.timespan_literal_all_suffixes", "[completion]")
+{
+    std::unordered_map<std::string, std::vector<RecordFieldInfo>> fields;
+    fields["TimeSpan"] = { { "milliseconds", "int" } };
+    for (auto const* const suffix: { "ms", "s", "min", "h" })
+    {
+        auto literal = std::string("100") + suffix;
+        auto candidates = dotAccessCandidates(literal, "", fields);
+        REQUIRE(candidates.size() == 1);
+        CHECK(hasCandidate(candidates, literal + ".milliseconds"));
+    }
+}
+
 TEST_CASE("CompletionCandidates.dotAccess.stdlib_function_not_qualifiable", "[completion]")
 {
     std::unordered_map<std::string, std::vector<RecordFieldInfo>> fields;


### PR DESCRIPTION
- Size literals (`15.5MB`) and TimeSpan literals (`500ms`) now show only their own fields in dot-completion instead of fields from all registered types
- The decimal point in float literals (e.g., `15.5MB`) was misinterpreted as a nested dot-access separator, and integer literals (e.g., `100KB`) fell through to the generic fallback showing everything
- Extends `collectRecordInfo()` to infer Size/TimeSpan types for let-bindings so `let x = 15.5MB; x.` also gets type-specific completion