### PR TITLE
add IUTCALL, runtime partial application, and HOF indirect dispatch

### DIFF
--- a/ROADMAP-Language.md
+++ b/ROADMAP-Language.md
@@ -434,7 +434,7 @@ Consult this section to determine what to work on next.
 - [x] Nested list comprehensions: `[for x in xs -> for y in ys -> (x, y)]`
 - [x] Indirect function calls (IUCALL): Callable object type packages function ID + captures; enables compiled HOFs via `IUCALL` opcode
 
-### Phase 11 — Future Enhancements
-- [ ] Indirect tail calls (`IUTCALL`): tail-position optimization for indirect function calls
-- [ ] Runtime partial application: Callable with arity tracking for partial application through indirect calls
-- [ ] Builtin HOF indirect dispatch: optionally compile `map`/`filter`/`fold` via IUCALL instead of inline IR codegen
+### Phase 11 — IUTCALL, Runtime Partial Application, HOF Indirect Dispatch
+- [x] Indirect tail calls (`IUTCALL`): tail-position optimization for indirect function calls via `IndirectTailCallInstr` IR instruction and `IUTCALL` VM opcode
+- [x] Runtime partial application: Callable with arity tracking — under-application produces a new Callable with merged captures instead of crashing
+- [x] Builtin HOF indirect dispatch: `map`/`filter`/`fold`/`reduce`/`each` use `IUCALL` for Callable parameters via `applyHOFFunction` helper, with return type casting for correct boolean dispatch

--- a/src/CoreVM/CoreVM.hpp
+++ b/src/CoreVM/CoreVM.hpp
@@ -84,6 +84,7 @@ class FunctionCallInstr;
 class FunctionRetInstr;
 class TailCallInstr;
 class IndirectCallInstr;
+class IndirectTailCallInstr;
 
 // Lazy evaluation
 class FunctionRefInstr;
@@ -266,6 +267,7 @@ class InstructionVisitor
 
     // indirect function calls
     virtual void visit(IndirectCallInstr& instr) = 0;
+    virtual void visit(IndirectTailCallInstr& instr) = 0;
 
     // lazy evaluation
     virtual void visit(FunctionRefInstr& instr) = 0;
@@ -597,6 +599,10 @@ class Runner
 
     RunResult loopWithResult();
 
+    /// Creates a partial Callable by merging existing captures with new partial args.
+    /// Used by IUCALL/IUTCALL when fewer arguments are supplied than the function expects.
+    TypedObject* createPartialCallable(TypedObject* callable, std::vector<Value> const& partialArgs);
+
     /// Create a RuntimeError at the current instruction's source location
     [[nodiscard]] RuntimeError makeError(std::string message) const;
 
@@ -805,6 +811,20 @@ class ConstantPool
         return functionId < _functionLocationTables.size() ? _functionLocationTables[functionId] : empty;
     }
 
+    /// Stores the parameter count for a compiled function.
+    void setFunctionParameterCount(size_t functionId, size_t count)
+    {
+        if (_functionParamCounts.size() <= functionId)
+            _functionParamCounts.resize(functionId + 1, 0);
+        _functionParamCounts[functionId] = count;
+    }
+
+    /// Retrieves the parameter count for a compiled function.
+    [[nodiscard]] size_t getFunctionParameterCount(size_t functionId) const
+    {
+        return functionId < _functionParamCounts.size() ? _functionParamCounts[functionId] : 0;
+    }
+
     [[nodiscard]] const std::vector<MatchDef>& getMatchDefs() const { return _matchDefs; }
 
     [[nodiscard]] const std::vector<std::string>& getNativeFunctionSignatures() const
@@ -839,6 +859,7 @@ class ConstantPool
     std::vector<std::pair<std::string, std::string>> _modules;
     std::vector<std::pair<std::string, Code>> _functions;
     std::vector<LocationTable> _functionLocationTables;
+    std::vector<size_t> _functionParamCounts;
     std::vector<MatchDef> _matchDefs;
     std::vector<std::string> _nativeFunctionSignatures;
 
@@ -857,6 +878,9 @@ class Program
     const ConstantPool& constants() const noexcept { return _cp; }
 
     ConstantPool& constants() noexcept { return _cp; }
+
+    /// Provides mutable access to the type registry for runtime type registration.
+    TypeRegistry& mutableTypeRegistry() noexcept { return _cp.typeRegistry(); }
 
     // accessors to linked data
     const Match* match(size_t index) const { return _matches[index].get(); }
@@ -930,6 +954,12 @@ class Function
     [[nodiscard]] std::vector<uint64_t>& directThreadedCode() noexcept { return _directThreadedCode; }
 #endif
 
+    /// Number of parameters expected by this function (for partial application detection).
+    [[nodiscard]] size_t parameterCount() const noexcept { return _parameterCount; }
+
+    /// Sets the number of parameters expected by this function.
+    void setParameterCount(size_t count) { _parameterCount = count; }
+
     void disassemble() const noexcept;
 
     /// Set the sparse location table (only stores locations when they change)
@@ -944,6 +974,7 @@ class Function
     Program* _program {};
     std::string _name;
     size_t _stackSize {};
+    size_t _parameterCount {};
     std::vector<Instruction> _code;
     std::unique_ptr<std::vector<std::pair<size_t, SourceLocation>>> _locationTable;
 #if defined(COREVM_DIRECT_THREADED_VM)
@@ -1840,6 +1871,28 @@ class IndirectCallInstr: public Instr
     void accept(InstructionVisitor& v) override;
 };
 
+/// Indirect tail call through a Callable object. Same semantics as IndirectCallInstr
+/// but reuses the current frame (no CallFrame push). Result type is Void since
+/// tail calls transfer control and don't produce a value in the current frame.
+class IndirectTailCallInstr: public Instr
+{
+  public:
+    /// @param callable The Callable object value to invoke.
+    /// @param args The explicit arguments to pass (captures are inside the callable).
+    /// @param name Optional IR name.
+    IndirectTailCallInstr(Value* callable, std::vector<Value*> args, const std::string& name);
+
+    /// The callable object operand.
+    [[nodiscard]] Value* callable() const { return operand(0); }
+
+    /// Number of explicit arguments (excluding the callable).
+    [[nodiscard]] size_t argc() const { return operands().size() - 1; }
+
+    [[nodiscard]] std::string to_string() const override;
+    [[nodiscard]] std::unique_ptr<Instr> clone() override;
+    void accept(InstructionVisitor& v) override;
+};
+
 class CastInstr: public Instr
 {
   public:
@@ -2303,6 +2356,7 @@ class IsSameInstruction: public InstructionVisitor
     void visit(FunctionRetInstr& instr) override;
     void visit(TailCallInstr& instr) override;
     void visit(IndirectCallInstr& instr) override;
+    void visit(IndirectTailCallInstr& instr) override;
 
     // terminator
     void visit(CondBrInstr& instr) override;
@@ -2834,6 +2888,9 @@ class IRBuilder
     IndirectCallInstr* createIndirectCall(Value* callable,
                                           std::vector<Value*> args,
                                           const std::string& name = "");
+    IndirectTailCallInstr* createIndirectTailCall(Value* callable,
+                                                  std::vector<Value*> args,
+                                                  const std::string& name = "");
 
     // Lazy evaluation
     FunctionRefInstr* createFunctionRef(IRFunction* function, const std::string& name = "");
@@ -3485,6 +3542,7 @@ class TargetCodeGenerator: public InstructionVisitor
     void visit(FunctionRetInstr& instr) override;
     void visit(TailCallInstr& instr) override;
     void visit(IndirectCallInstr& instr) override;
+    void visit(IndirectTailCallInstr& instr) override;
 
     // terminator
     void visit(CondBrInstr& instr) override;

--- a/src/CoreVM/TargetCodeGenerator.cpp
+++ b/src/CoreVM/TargetCodeGenerator.cpp
@@ -224,6 +224,9 @@ void TargetCodeGenerator::generate(IRFunction* function)
 
     _cp.getFunction(_functionId).second = std::move(_code);
 
+    // Store parameter count for runtime partial application detection
+    _cp.setFunctionParameterCount(_functionId, function->parameterCount());
+
     // Store the sparse location table for this function
     if (!_locationTable.empty())
         _cp.setFunctionLocationTable(_functionId, std::move(_locationTable));
@@ -497,6 +500,22 @@ void TargetCodeGenerator::visit(IndirectCallInstr& instr)
         emitInstr(Opcode::DISCARD, 1);
         pop(1);
     }
+}
+
+void TargetCodeGenerator::visit(IndirectTailCallInstr& instr)
+{
+    // Push explicit arguments first, then the callable object
+    auto const argc = static_cast<Operand>(instr.argc());
+    for (auto const i: std::views::iota(1uz, instr.operands().size()))
+        emitLoad(instr.operand(i));
+
+    // Push callable last (stack: [args..., callable])
+    emitLoad(instr.callable());
+
+    // Emit IUTCALL argc (explicit arg count, not counting the callable)
+    emitInstr(Opcode::IUTCALL, argc);
+
+    // IUTCALL transfers control — no stack tracking adjustment needed (like UTCALL)
 }
 
 void TargetCodeGenerator::visit(FunctionRefInstr& instr)

--- a/src/CoreVM/enums.hpp
+++ b/src/CoreVM/enums.hpp
@@ -156,7 +156,8 @@ enum Opcode : uint16_t
     UTCALL, // UTCALL function_id, argc ; tail-call user function (reuse current frame)
 
     // indirect user call (callable object on stack)
-    IUCALL, // IUCALL argc             ; indirect call via Callable object on stack
+    IUCALL,  // IUCALL argc             ; indirect call via Callable object on stack
+    IUTCALL, // IUTCALL argc            ; indirect tail call via Callable object on stack
 
     // lazy evaluation
     LFORCE, // LFORCE                  ; force lazy value at top of stack
@@ -361,7 +362,8 @@ constexpr inline unsigned getPrice(Opcode opcode)
         case Opcode::CALL:
         case Opcode::UCALL:
         case Opcode::UTCALL:
-        case Opcode::IUCALL: return 8;
+        case Opcode::IUCALL:
+        case Opcode::IUTCALL: return 8;
         case Opcode::URET: return 1;
         default: return 1;
     }

--- a/src/CoreVM/ir/IRBuilder.cpp
+++ b/src/CoreVM/ir/IRBuilder.cpp
@@ -1081,6 +1081,14 @@ IndirectCallInstr* IRBuilder::createIndirectCall(Value* callable,
         insert<IndirectCallInstr>(callable, std::move(args), makeName(name.empty() ? "iucall" : name)));
 }
 
+IndirectTailCallInstr* IRBuilder::createIndirectTailCall(Value* callable,
+                                                         std::vector<Value*> args,
+                                                         const std::string& name)
+{
+    return static_cast<IndirectTailCallInstr*>(
+        insert<IndirectTailCallInstr>(callable, std::move(args), makeName(name.empty() ? "iutcall" : name)));
+}
+
 // }}}
 // {{{ Lazy evaluation
 

--- a/src/CoreVM/ir/InstructionVisitor.cpp
+++ b/src/CoreVM/ir/InstructionVisitor.cpp
@@ -137,6 +137,7 @@ IS_SAME_INSTR_IMPL(TailCallInstr)
 
 // Indirect function calls
 IS_SAME_INSTR_IMPL(IndirectCallInstr)
+IS_SAME_INSTR_IMPL(IndirectTailCallInstr)
 
 // Lazy evaluation
 IS_SAME_INSTR_IMPL(FunctionRefInstr)

--- a/src/CoreVM/ir/Instructions.cpp
+++ b/src/CoreVM/ir/Instructions.cpp
@@ -720,6 +720,40 @@ void IndirectCallInstr::accept(InstructionVisitor& v)
 }
 
 // }}}
+// {{{ IndirectTailCallInstr
+IndirectTailCallInstr::IndirectTailCallInstr(Value* callable,
+                                             std::vector<Value*> args,
+                                             const std::string& name):
+    Instr(
+        LiteralType::Void,
+        [&]() {
+            std::vector<Value*> ops;
+            ops.reserve(1 + args.size());
+            ops.push_back(callable);
+            ops.insert(ops.end(), args.begin(), args.end());
+            return ops;
+        }(),
+        name)
+{
+}
+
+std::string IndirectTailCallInstr::to_string() const
+{
+    return formatOne("iutcall");
+}
+
+std::unique_ptr<Instr> IndirectTailCallInstr::clone()
+{
+    std::vector<Value*> args(operands().begin() + 1, operands().end());
+    return std::make_unique<IndirectTailCallInstr>(callable(), std::move(args), name());
+}
+
+void IndirectTailCallInstr::accept(InstructionVisitor& v)
+{
+    v.visit(*this);
+}
+
+// }}}
 // {{{ FunctionRefInstr
 std::string FunctionRefInstr::to_string() const
 {

--- a/src/CoreVM/vm/Instruction.cpp
+++ b/src/CoreVM/vm/Instruction.cpp
@@ -191,7 +191,8 @@ static InstructionInfo instructionInfos[] = {
     IIDEF(UTCALL, II, 0, Void), // stack change handled dynamically (tail call, reuses frame)
 
     // indirect user call (via Callable object)
-    IIDEF(IUCALL, I, 0, Void), // stack change handled dynamically (pops callable + argc args, pushes 1)
+    IIDEF(IUCALL, I, 0, Void),  // stack change handled dynamically (pops callable + argc args, pushes 1)
+    IIDEF(IUTCALL, I, 0, Void), // stack change handled dynamically (indirect tail call)
 
     // lazy evaluation
     IIDEF(LFORCE, V, 0, Void), // consumes lazy obj, pushes result (net 0)
@@ -221,6 +222,9 @@ int getStackChange(Instruction instr)
         case Opcode::IUCALL:
             // Pops callable + argc explicit args, pushes 1 return value: net = 1 - argc - 1
             return -operandA(instr);
+        case Opcode::IUTCALL:
+            // Indirect tail call: handled dynamically (reuses frame). For static analysis treat as 0.
+            return 0;
         default: return instructionInfos[opc].stackChange;
     }
 }

--- a/src/CoreVM/vm/Program.cpp
+++ b/src/CoreVM/vm/Program.cpp
@@ -50,6 +50,7 @@ void Program::setup()
     for (size_t i = 0; i < functions.size(); ++i)
     {
         Function* fn = createFunction(functions[i].first, functions[i].second);
+        fn->setParameterCount(_cp.getFunctionParameterCount(i));
         auto const& locationTable = _cp.getFunctionLocationTable(i);
         if (!locationTable.empty())
             fn->setLocationTable(locationTable);

--- a/src/CoreVM/vm/Runner.cpp
+++ b/src/CoreVM/vm/Runner.cpp
@@ -261,6 +261,51 @@ TypedObject* Runner::allocObject(uint16_t typeId)
     return obj;
 }
 
+TypedObject* Runner::createPartialCallable(TypedObject* callable, std::vector<Value> const& partialArgs)
+{
+    // Original callable: slot 0 = funcId, slots 1..N = captures
+    auto const oldCaptureCount = static_cast<size_t>(callable->type->slotCount - 1);
+    auto const newSlotCount = static_cast<uint16_t>(1 + oldCaptureCount + partialArgs.size());
+
+    // Register a dynamic PartialCallable type if needed
+    auto& registry = const_cast<Program*>(_program)->mutableTypeRegistry();
+    auto typeName = std::format("PartialCallable_{}", newSlotCount);
+    auto const* existingType = registry.getByName(typeName);
+    uint16_t typeId = 0;
+    if (existingType)
+    {
+        typeId = existingType->id;
+    }
+    else
+    {
+        // Create fields for the partial callable (slot 0 = funcId, rest = captures/args)
+        std::vector<FieldInfo> fields;
+        fields.reserve(newSlotCount);
+        for (uint16_t i = 0; i < newSlotCount; ++i)
+            fields.push_back(
+                FieldInfo { .name = std::format("slot{}", i), .offset = static_cast<uint8_t>(i) });
+        auto* desc = registry.registerProductType(typeName, std::move(fields));
+        // Override slotCount since registerProductType sets it to fields.size()
+        desc->slotCount = newSlotCount;
+        typeId = desc->id;
+    }
+
+    auto* partial = allocObject(typeId);
+
+    // Copy funcId
+    partial->setSlot(0, callable->getSlot(0));
+
+    // Copy existing captures
+    for (size_t i = 0; i < oldCaptureCount; ++i)
+        partial->setSlot(static_cast<uint8_t>(1 + i), callable->getSlot(static_cast<uint8_t>(1 + i)));
+
+    // Append new partial args
+    for (size_t i = 0; i < partialArgs.size(); ++i)
+        partial->setSlot(static_cast<uint8_t>(1 + oldCaptureCount + i), partialArgs[i]);
+
+    return partial;
+}
+
 TypedObject* Runner::makeNilList(LiteralType elemType)
 {
     auto* obj = allocObject(BuiltinTypeId::List);
@@ -560,6 +605,7 @@ Runner::RunResult Runner::loopWithResult()
 
         // indirect user call
         label(IUCALL),
+        label(IUTCALL),
 
         // lazy evaluation
         label(LFORCE),
@@ -1646,6 +1692,23 @@ Runner::RunResult Runner::loopWithResult()
 
             // Determine capture count: slotCount - 1 (slot 0 = funcId, rest = captures)
             auto const captureCount = static_cast<size_t>(callable->type->slotCount - 1);
+            auto const totalSupplied = captureCount + argc;
+            auto const expectedArity = _program->function(funcId)->parameterCount();
+
+            // Under-application: produce a partial Callable instead of calling
+            if (expectedArity > 0 && totalSupplied < expectedArity)
+            {
+                pop(); // callable
+                TypedObject* partial = nullptr;
+                {
+                    std::vector<Value> partialArgs(argc);
+                    for (auto i = argc; i > 0; --i)
+                        partialArgs[i - 1] = pop();
+                    partial = createPartialCallable(callable, partialArgs);
+                } // partialArgs destructed before computed goto
+                push(reinterpret_cast<Value>(partial));
+                next;
+            }
 
             // Pop callable from stack
             pop();
@@ -1698,6 +1761,94 @@ Runner::RunResult Runner::loopWithResult()
             pc = codeBase;
         }
 #endif
+        jump;
+    }
+    instr(IUTCALL)
+    {
+        // Indirect tail call via Callable object. Reuses current frame.
+        // Stack before: [..., arg0, arg1, ..., argM, callable_ptr]
+        // A = explicit argc (M)
+        bool iutcall_underApplied = false;
+        {
+            auto const argc = static_cast<size_t>(A);
+
+            auto* callable = getObject(-1);
+            if (!callable)
+            {
+                _ip = get_pc();
+                return std::unexpected(makeError("null object dereference in IUTCALL"));
+            }
+
+            auto funcId = static_cast<uint16_t>(callable->getSlot(0));
+            auto const captureCount = static_cast<size_t>(callable->type->slotCount - 1);
+            auto const totalSupplied = captureCount + argc;
+            auto const expectedArity = _program->function(funcId)->parameterCount();
+
+            // Under-application: produce partial Callable and return via URET-like path
+            if (expectedArity > 0 && totalSupplied < expectedArity)
+            {
+                pop(); // callable
+                TypedObject* partial = nullptr;
+                {
+                    std::vector<Value> partialArgs(argc);
+                    for (auto i = argc; i > 0; --i)
+                        partialArgs[i - 1] = pop();
+                    partial = createPartialCallable(callable, partialArgs);
+                } // partialArgs destructed before computed goto
+                // Return via URET-like logic (pop frame, push partial as return value)
+                if (!_callStack.empty())
+                {
+                    auto const& frame = _callStack.back();
+                    _ip = frame.ip;
+                    _function = frame.function;
+                    _fp = frame.fp;
+                    auto argsBase = frame.argsBase;
+                    _callStack.pop_back();
+                    _stack.discard(_stack.size() - argsBase);
+                    push(reinterpret_cast<Value>(partial));
+                }
+                else
+                {
+                    push(reinterpret_cast<Value>(partial));
+                }
+                iutcall_underApplied = true;
+            }
+            else
+            {
+                // Full application — tail call
+                pop(); // callable
+                {
+                    std::vector<Value> savedArgs(argc);
+                    for (auto i = argc; i > 0; --i)
+                        savedArgs[i - 1] = pop();
+
+                    for (size_t i = 0; i < captureCount; ++i)
+                        _stack[_fp + i] = callable->getSlot(static_cast<uint8_t>(1 + i));
+                    for (size_t i = 0; i < argc; ++i)
+                        _stack[_fp + captureCount + i] = savedArgs[i];
+                } // savedArgs destructed before computed goto
+
+                _stack.discard(_stack.size() - _fp - totalSupplied);
+                _function = _program->function(funcId);
+            }
+        }
+        // All std::vector instances are now destructed; safe for computed goto.
+        if (iutcall_underApplied)
+        {
+            // Resume in restored caller frame
+            codeBase = _function->code().data();
+            pc = codeBase + _ip;
+        }
+        else
+        {
+            // Tail call: jump to start of target function
+#if defined(COREVM_DIRECT_THREADED_VM)
+            COREVM_ASSERT(false, "IUTCALL not yet supported with direct-threaded VM");
+#else
+            codeBase = _function->code().data();
+            pc = codeBase;
+#endif
+        }
         jump;
     }
     // }}}

--- a/src/endo-language/codegen/HOFCodegen.cpp
+++ b/src/endo-language/codegen/HOFCodegen.cpp
@@ -15,6 +15,54 @@
 namespace endo
 {
 
+void IRGenerator::applyHOFFunction(std::string const& funcParamName,
+                                   FSharpFunction const* func,
+                                   std::string const& funcName,
+                                   std::vector<CoreVM::Value*> const& args,
+                                   std::string const& label,
+                                   std::optional<CoreVM::LiteralType> expectedReturnType)
+{
+    // Check if the function parameter is a Callable object (function-typed parameter
+    // inside a compiled function body). If so, emit an indirect call via IUCALL.
+    if (auto* storage = lookupFSharpVariable(funcParamName))
+    {
+        if (getObjectTypeId(storage).value_or(0) == CoreVM::BuiltinTypeId::Callable)
+        {
+            auto* callableVal = _builder.createLoad(storage, label + ".callable.load");
+            _result = _builder.createIndirectCall(callableVal, args, label + ".iucall");
+
+            // IndirectCallInstr returns Void type. Cast the result to the correct IR type
+            // via store/load so downstream operations (toBool, convertToString) dispatch
+            // correctly. Prefer the compiled function's return type; fall back to the
+            // caller-specified expectedReturnType for Callable parameters where func
+            // metadata is unavailable.
+            auto returnType = (func && func->compiledReturnType != CoreVM::LiteralType::Void)
+                                  ? func->compiledReturnType
+                                  : expectedReturnType.value_or(CoreVM::LiteralType::Void);
+            if (returnType != CoreVM::LiteralType::Void)
+            {
+                auto* castAlloca = createAllocaInEntryBlock(returnType, label + ".ret.cast");
+                _builder.createStore(castAlloca, _result);
+                _result = _builder.createLoad(castAlloca, label + ".ret.load");
+            }
+
+            // Propagate return annotations from the compiled function metadata
+            if (func && func->compiledReturnInnerType)
+                annotateInnerType(_result, *func->compiledReturnInnerType);
+            if (func && func->compiledReturnObjectTypeId)
+                annotateObjectTypeId(_result, *func->compiledReturnObjectTypeId);
+            if (func && func->compiledReturnListElementTypeId)
+                annotateListElementTypeId(_result, *func->compiledReturnListElementTypeId);
+            if (func && func->compiledReturnListElementLiteralType)
+                annotateListElementLiteralType(_result, *func->compiledReturnListElementLiteralType);
+            return;
+        }
+    }
+
+    // Fall back to static dispatch via generateFSharpCall
+    generateFSharpCall(func, funcName, args);
+}
+
 void IRGenerator::generateBuiltinHOFCall(FSharpFunction const* func,
                                          std::string const& /*funcName*/,
                                          std::vector<CoreVM::Value*> const& args)
@@ -173,15 +221,20 @@ void IRGenerator::generateMapIR(std::string const& funcParamName, CoreVM::Value*
     auto* slot0 = _builder.get(CoreVM::CoreNumber(0)); // head
     auto* slot1 = _builder.get(CoreVM::CoreNumber(1)); // tail
 
-    // Resolve the function to call
+    // Resolve the function to call (may be null for Callable parameters)
     auto funcName = funcParamName;
     if (auto ref = lookupFSharpFunctionRef(funcParamName))
         funcName = *ref;
     auto const* func = lookupFSharpFunction(funcName);
     if (!func)
     {
-        reportTypeError("map: function argument '{}' not found", std::string_view(funcParamName));
-        return;
+        // Allow Callable parameters (function-typed) to proceed with indirect dispatch
+        if (auto* storage = lookupFSharpVariable(funcParamName);
+            !storage || getObjectTypeId(storage).value_or(0) != CoreVM::BuiltinTypeId::Callable)
+        {
+            reportTypeError("map: function argument '{}' not found", std::string_view(funcParamName));
+            return;
+        }
     }
 
     // Allocas for phase 1 (forward iteration building reversed accumulator)
@@ -232,7 +285,7 @@ void IRGenerator::generateMapIR(std::string const& funcParamName, CoreVM::Value*
     // Propagate element type annotation through load (for field access in lambda body)
     if (auto elemTypeId = getObjectTypeId(elemAlloca))
         annotateObjectTypeId(elemLoad, *elemTypeId);
-    generateFSharpCall(func, funcName, { elemLoad });
+    applyHOFFunction(funcParamName, func, funcName, { elemLoad }, "map");
     auto* mapped = _result;
     if (!mapped)
     {
@@ -316,15 +369,19 @@ void IRGenerator::generateFilterIR(std::string const& predParamName, CoreVM::Val
     auto* slot0 = _builder.get(CoreVM::CoreNumber(0)); // head
     auto* slot1 = _builder.get(CoreVM::CoreNumber(1)); // tail
 
-    // Resolve the predicate function
+    // Resolve the predicate function (may be null for Callable parameters)
     auto predName = predParamName;
     if (auto ref = lookupFSharpFunctionRef(predParamName))
         predName = *ref;
     auto const* pred = lookupFSharpFunction(predName);
     if (!pred)
     {
-        reportTypeError("filter: predicate argument '{}' not found", std::string_view(predParamName));
-        return;
+        if (auto* storage = lookupFSharpVariable(predParamName);
+            !storage || getObjectTypeId(storage).value_or(0) != CoreVM::BuiltinTypeId::Callable)
+        {
+            reportTypeError("filter: predicate argument '{}' not found", std::string_view(predParamName));
+            return;
+        }
     }
 
     // Allocas
@@ -387,7 +444,7 @@ void IRGenerator::generateFilterIR(std::string const& predParamName, CoreVM::Val
     // Propagate element type annotation through load (for field access in lambda body)
     if (auto elemTypeId = getObjectTypeId(elemAlloca))
         annotateObjectTypeId(elemLoad, *elemTypeId);
-    generateFSharpCall(pred, predName, { elemLoad });
+    applyHOFFunction(predParamName, pred, predName, { elemLoad }, "filter", CoreVM::LiteralType::Boolean);
     auto* predResult = _result;
     if (!predResult)
     {
@@ -469,15 +526,19 @@ void IRGenerator::generateFoldIR(CoreVM::Value* initValue,
     auto* slot0 = _builder.get(CoreVM::CoreNumber(0)); // head
     auto* slot1 = _builder.get(CoreVM::CoreNumber(1)); // tail
 
-    // Resolve the function to call
+    // Resolve the function to call (may be null for Callable parameters)
     auto funcName = funcParamName;
     if (auto ref = lookupFSharpFunctionRef(funcParamName))
         funcName = *ref;
     auto const* func = lookupFSharpFunction(funcName);
     if (!func)
     {
-        reportTypeError("fold: function argument '{}' not found", std::string_view(funcParamName));
-        return;
+        if (auto* storage = lookupFSharpVariable(funcParamName);
+            !storage || getObjectTypeId(storage).value_or(0) != CoreVM::BuiltinTypeId::Callable)
+        {
+            reportTypeError("fold: function argument '{}' not found", std::string_view(funcParamName));
+            return;
+        }
     }
 
     // Allocas
@@ -524,7 +585,7 @@ void IRGenerator::generateFoldIR(CoreVM::Value* initValue,
     auto* elemLoad = _builder.createLoad(elemAlloca, "fold.elem.load");
     if (auto elemTypeId = getObjectTypeId(elemAlloca))
         annotateObjectTypeId(elemLoad, *elemTypeId);
-    generateFSharpCall(func, funcName, { accLoad, elemLoad });
+    applyHOFFunction(funcParamName, func, funcName, { accLoad, elemLoad }, "fold");
     auto* newAcc = _result;
     if (!newAcc)
     {
@@ -545,15 +606,19 @@ void IRGenerator::generateReduceIR(std::string const& funcParamName, CoreVM::Val
     auto* slot0 = _builder.get(CoreVM::CoreNumber(0)); // head
     auto* slot1 = _builder.get(CoreVM::CoreNumber(1)); // tail
 
-    // Resolve the function to call
+    // Resolve the function to call (may be null for Callable parameters)
     auto funcName = funcParamName;
     if (auto ref = lookupFSharpFunctionRef(funcParamName))
         funcName = *ref;
     auto const* func = lookupFSharpFunction(funcName);
     if (!func)
     {
-        reportTypeError("reduce: function argument '{}' not found", std::string_view(funcParamName));
-        return;
+        if (auto* storage = lookupFSharpVariable(funcParamName);
+            !storage || getObjectTypeId(storage).value_or(0) != CoreVM::BuiltinTypeId::Callable)
+        {
+            reportTypeError("reduce: function argument '{}' not found", std::string_view(funcParamName));
+            return;
+        }
     }
 
     // Allocas
@@ -626,7 +691,7 @@ void IRGenerator::generateReduceIR(std::string const& funcParamName, CoreVM::Val
     auto* elemLoad = _builder.createLoad(elemAlloca, "reduce.elem.load");
     if (auto elemTypeId = getObjectTypeId(elemAlloca))
         annotateObjectTypeId(elemLoad, *elemTypeId);
-    generateFSharpCall(func, funcName, { accLoad, elemLoad });
+    applyHOFFunction(funcParamName, func, funcName, { accLoad, elemLoad }, "reduce");
     auto* newAcc = _result;
     if (!newAcc)
     {
@@ -992,8 +1057,12 @@ void IRGenerator::generateEachIR(std::string const& funcParamName, CoreVM::Value
         func = lookupFSharpFunction(funcName);
         if (!func)
         {
-            reportTypeError("each: function argument '{}' not found", std::string_view(funcParamName));
-            return;
+            if (auto* storage = lookupFSharpVariable(funcParamName);
+                !storage || getObjectTypeId(storage).value_or(0) != CoreVM::BuiltinTypeId::Callable)
+            {
+                reportTypeError("each: function argument '{}' not found", std::string_view(funcParamName));
+                return;
+            }
         }
     }
 
@@ -1051,7 +1120,7 @@ void IRGenerator::generateEachIR(std::string const& funcParamName, CoreVM::Value
     }
     else
     {
-        generateFSharpCall(func, funcName, { elemLoad });
+        applyHOFFunction(funcParamName, func, funcName, { elemLoad }, "each");
         if (!_result)
         {
             reportTypeError("each: failed to apply function to element");
@@ -1972,8 +2041,7 @@ void IRGenerator::generateSeqTakeIR(CoreVM::Value* countValue, CoreVM::Value* se
 
     auto* revElemReload = _builder.createLoad(revElemTmp, "seq.take.rev.elem.reload");
     auto* revAccReload = _builder.createLoad(revAccTmp, "seq.take.rev.acc.reload");
-    auto* revCons =
-        emitListCons(revElemReload, revAccReload, CoreVM::LiteralType::Void, "seq.take.rev.cons");
+    auto* revCons = emitListCons(revElemReload, revAccReload, CoreVM::LiteralType::Void, "seq.take.rev.cons");
 
     _builder.createStore(revAccStorage, revCons);
     _builder.createBr(revCondBlock);
@@ -2076,8 +2144,7 @@ void IRGenerator::generateToListIR(CoreVM::Value* seqValue)
 
     auto* revElemReload = _builder.createLoad(revElemTmp, "toList.rev.elem.reload");
     auto* revAccReload = _builder.createLoad(revAccTmp, "toList.rev.acc.reload");
-    auto* revCons =
-        emitListCons(revElemReload, revAccReload, CoreVM::LiteralType::Void, "toList.rev.cons");
+    auto* revCons = emitListCons(revElemReload, revAccReload, CoreVM::LiteralType::Void, "toList.rev.cons");
 
     _builder.createStore(revAccStorage, revCons);
     _builder.createBr(revCondBlock);

--- a/src/endo-language/codegen/IRGenerator.cpp
+++ b/src/endo-language/codegen/IRGenerator.cpp
@@ -7459,7 +7459,20 @@ void IRGenerator::visit(ast::ApplicationExpr const& node)
                         // Load the Callable object from the parameter alloca
                         auto* callableVal =
                             _builder.createLoad(callableStorage, funcIdent->name + ".callable.load");
-                        _result = _builder.createIndirectCall(callableVal, args, funcIdent->name + ".iucall");
+
+                        if (_inTailPosition && _compilingFunction)
+                        {
+                            // Indirect tail call — reuse current frame
+                            _builder.createIndirectTailCall(callableVal, args, funcIdent->name + ".iutcall");
+                            auto* unreachable = _builder.createBlock("iutcall.unreachable");
+                            _builder.setInsertPoint(unreachable);
+                            _result = nullptr;
+                        }
+                        else
+                        {
+                            _result =
+                                _builder.createIndirectCall(callableVal, args, funcIdent->name + ".iucall");
+                        }
                         return;
                     }
                 }

--- a/src/endo-language/codegen/IRGenerator.hpp
+++ b/src/endo-language/codegen/IRGenerator.hpp
@@ -452,6 +452,17 @@ class IRGenerator final: public ast::Visitor
                                 std::string const& funcName,
                                 std::vector<CoreVM::Value*> const& args);
 
+    /// Applies a HOF's function argument to the given args, dispatching via IUCALL for Callable
+    /// parameters or falling back to generateFSharpCall for statically known functions.
+    /// @param expectedReturnType If set, cast the indirect call result to this type (needed
+    ///        because IUCALL returns Void, but toBool/convertToString dispatch on IR type).
+    void applyHOFFunction(std::string const& funcParamName,
+                          FSharpFunction const* func,
+                          std::string const& funcName,
+                          std::vector<CoreVM::Value*> const& args,
+                          std::string const& label,
+                          std::optional<CoreVM::LiteralType> expectedReturnType = std::nullopt);
+
     /// Generates IR for `map f xs` — applies f to each element, returns new list.
     void generateMapIR(std::string const& funcName, CoreVM::Value* listValue);
 

--- a/tests/functions/hof_each_indirect.endo
+++ b/tests/functions/hof_each_indirect.endo
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: HOF indirect dispatch — each with function parameter via IUCALL
+# expect: 1
+# expect: 2
+# expect: 3
+# expect:
+
+let show (x: int) = println x
+
+let myeach (f: int -> unit) (xs: list<int>) = each f xs
+
+myeach show [1; 2; 3]

--- a/tests/functions/hof_filter_indirect.endo
+++ b/tests/functions/hof_filter_indirect.endo
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: HOF indirect dispatch — filter with predicate parameter via IUCALL
+# expect: [2; 4]
+
+let is_even (x: int) = x % 2 == 0
+
+let myfilter (pred: int -> bool) (xs: list<int>) = filter pred xs
+
+print (myfilter is_even [1; 2; 3; 4; 5])

--- a/tests/functions/hof_fold_indirect.endo
+++ b/tests/functions/hof_fold_indirect.endo
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: HOF indirect dispatch — fold with function parameter via IUCALL
+# expect: 10
+
+let add (x: int) (y: int) = x + y
+
+let mysum (f: int -> int -> int) (xs: list<int>) = fold 0 f xs
+
+print (mysum add [1; 2; 3; 4])

--- a/tests/functions/hof_map_indirect.endo
+++ b/tests/functions/hof_map_indirect.endo
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: HOF indirect dispatch — map with function parameter via IUCALL
+# expect: [2; 4; 6]
+
+let double (x: int) = x * 2
+
+let mymap (f: int -> int) (xs: list<int>) = map f xs
+
+print (mymap double [1; 2; 3])

--- a/tests/functions/iutcall_tail_recursive_hof.endo
+++ b/tests/functions/iutcall_tail_recursive_hof.endo
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: IUTCALL — tail-recursive HOF using indirect tail call
+# expect: 120
+
+let double (x: int) = x * 2
+
+let rec apply_n (f: int -> int) (n: int) (x: int) =
+    if n == 0 then x
+    else apply_n f (n - 1) (f x)
+
+print (apply_n double 3 15)

--- a/tests/functions/partial_application_basic.endo
+++ b/tests/functions/partial_application_basic.endo
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Runtime partial application — supply fewer args to get a new Callable
+# expect: 8
+
+let add (x: int) (y: int) = x + y
+
+let add5 = add 5
+
+print (add5 3)

--- a/tests/functions/partial_application_chain.endo
+++ b/tests/functions/partial_application_chain.endo
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Chained partial application — apply one arg at a time
+# expect: 6
+
+let add3 (x: int) (y: int) (z: int) = x + y + z
+
+let f = add3 1
+
+let g = f 2
+
+print (g 3)

--- a/tests/functions/partial_application_in_pipeline.endo
+++ b/tests/functions/partial_application_in_pipeline.endo
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Partial application used in a pipeline
+# expect: 25
+
+let multiply (x: int) (y: int) = x * y
+
+let times5 = multiply 5
+
+print (5 |> times5)


### PR DESCRIPTION
- Add `IUTCALL` opcode and `IndirectTailCallInstr` IR instruction for O(1) stack indirect tail calls in recursive HOF patterns
- Implement runtime partial application: IUCALL/IUTCALL detect under-application via `Function::parameterCount()` and produce a new Callable with merged captures instead of crashing
- Add `applyHOFFunction()` helper for HOF indirect dispatch — map, filter, fold, reduce, and each now emit IUCALL for Callable parameters, with return type casting for correct boolean predicate dispatch