### PR TITLE
fix: Support shell pipe in variadic F# function calls, add --no-profile

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -133,6 +133,12 @@ let ll ...args = & exa -l ...args
 let gs ...args = & git status ...args
 ```
 
+To start Endo without loading this file, use `--no-profile`:
+
+```bash
+endo --no-profile
+```
+
 ## Next Steps
 
 - [Shell Features](shell/index.md) -- Learn about interactive features, builtins, and

--- a/docs/shell/configuration.md
+++ b/docs/shell/configuration.md
@@ -33,6 +33,16 @@ export PAGER=less
 !!! tip
     Changes to `init.endo` take effect the next time you start a new Endo session.
 
+To skip loading the startup file entirely, pass `--no-profile` on the command line:
+
+```bash
+endo --no-profile
+endo --no-profile -c 'echo "no init.endo loaded"'
+```
+
+This is useful for debugging, benchmarking, or when a broken `init.endo` prevents the
+shell from starting.
+
 ## Environment Variables
 
 ### Setting Variables

--- a/src/endo-language/parser/Parser.cpp
+++ b/src/endo-language/parser/Parser.cpp
@@ -612,19 +612,53 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
             else if (_knownVariadicFunctions.contains(_lexer.currentLiteral()))
             {
                 // Variadic function at statement level: parse args as shell tokens
-                auto funcName = _lexer.currentLiteral();
+                auto const funcName = _lexer.currentLiteral();
+                auto const funcLoc = _lexer.currentRange();
                 _lexer.nextToken(); // consume function name
 
-                std::unique_ptr<ast::Expr> result = std::make_unique<ast::IdentifierExpr>(funcName);
-
-                // Collect arguments in shell tokenization mode (identifiers, flags, paths, etc.)
+                // Collect arguments into a vector first (defer ApplicationExpr construction)
+                std::vector<std::unique_ptr<ast::Expr>> argList;
                 while (isParameterToken())
                 {
                     auto arg = parseParameter();
                     if (!arg)
                         break;
-                    result = std::make_unique<ast::ApplicationExpr>(std::move(result), std::move(arg));
+                    argList.emplace_back(std::move(arg));
                 }
+
+                // Handle shell pipe: fall back to raw command execution in a CallPipeline
+                if (_lexer.currentToken() == Token::Pipe)
+                {
+                    auto* builtinCallProcess = _runtime.find("callproc(Bs)I");
+                    assert(builtinCallProcess != nullptr);
+                    auto call = std::make_unique<ast::ProgramCall>(
+                        *builtinCallProcess,
+                        std::string(funcName),
+                        std::move(argList),
+                        std::vector<std::unique_ptr<ast::InputRedirect>> {},
+                        std::vector<std::unique_ptr<ast::OutputRedirect>> {},
+                        std::vector<std::unique_ptr<ast::HereDocument>> {},
+                        std::vector<std::unique_ptr<ast::HereString>> {});
+                    call->programLocation = funcLoc;
+
+                    std::vector<std::unique_ptr<ast::ProgramCall>> calls;
+                    calls.emplace_back(std::move(call));
+                    while (_lexer.currentToken() == Token::Pipe)
+                    {
+                        _lexer.nextToken();
+                        if (auto nextCall = parseCall(true))
+                            calls.emplace_back(std::move(nextCall));
+                    }
+                    bool const background = _lexer.currentToken() == Token::Ampersand;
+                    if (background)
+                        _lexer.nextToken();
+                    return std::make_unique<ast::CallPipeline>(std::move(calls), background);
+                }
+
+                // No pipe — build ApplicationExpr chain for F# function call (existing behavior)
+                std::unique_ptr<ast::Expr> result = std::make_unique<ast::IdentifierExpr>(funcName);
+                for (auto& arg: argList)
+                    result = std::make_unique<ast::ApplicationExpr>(std::move(result), std::move(arg));
 
                 // Handle trailing |> pipeline
                 if (_lexer.currentToken() == Token::ForwardPipe)

--- a/src/endo-language/parser/Parser_test.cpp
+++ b/src/endo-language/parser/Parser_test.cpp
@@ -2,6 +2,8 @@
 
 #include <endo-language/TestHelper.hpp>
 #include <endo-language/ast/AST.hpp>
+#include <endo-language/lexer/Lexer.hpp>
+#include <endo-language/parser/Parser.hpp>
 #include <endo-language/types/Type.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -2577,4 +2579,77 @@ TEST_CASE("Parser.FSharp.generic_record_ir_generation", "[parser][generic]")
 {
     CHECK(generatesIRSuccessfully("type Pair<'a, 'b> = { first: 'a; second: 'b }\n"
                                   "let p = { first = 1; second = \"hello\" }"));
+}
+
+// =============================================================================
+// Variadic Function + Shell Pipe Tests
+// =============================================================================
+
+namespace
+{
+
+/// Parses source with the given variadic function names registered.
+std::unique_ptr<endo::ast::Statement> parseWithVariadics(std::string const& source,
+                                                         std::unordered_set<std::string> variadics)
+{
+    auto& rt = TestRuntime::instance();
+    rt.clearErrors();
+
+    endo::Parser parser(rt.runtime, rt.report, std::make_unique<endo::StringSource>(source));
+    parser.setKnownVariadicFunctions(std::move(variadics));
+    auto result = parser.parse();
+
+    if (rt.hasErrors())
+        return nullptr;
+
+    return result;
+}
+
+} // namespace
+
+TEST_CASE("Parser.Shell.variadic_function_with_pipe", "[parser][variadic]")
+{
+    auto ast = parseWithVariadics("ip addr show | grep -w inet", { "ip" });
+    REQUIRE(ast != nullptr);
+
+    auto* stmt = getFirstStatement(ast.get());
+    REQUIRE(stmt != nullptr);
+
+    auto* pipeline = dynamic_cast<endo::ast::CallPipeline*>(stmt);
+    REQUIRE(pipeline != nullptr);
+    CHECK(pipeline->calls.size() == 2);
+    CHECK(pipeline->calls[0]->program == "ip");
+    CHECK(pipeline->calls[1]->program == "grep");
+}
+
+TEST_CASE("Parser.Shell.variadic_function_without_pipe", "[parser][variadic]")
+{
+    auto ast = parseWithVariadics("ip addr show", { "ip" });
+    REQUIRE(ast != nullptr);
+
+    auto* stmt = getFirstStatement(ast.get());
+    REQUIRE(stmt != nullptr);
+
+    // Without pipe, should be an ExprStmt containing an ApplicationExpr chain
+    auto* exprStmt = dynamic_cast<endo::ast::ExprStmt*>(stmt);
+    REQUIRE(exprStmt != nullptr);
+
+    auto* app = dynamic_cast<endo::ast::ApplicationExpr*>(exprStmt->expr.get());
+    REQUIRE(app != nullptr);
+}
+
+TEST_CASE("Parser.Shell.variadic_function_with_multi_pipe", "[parser][variadic]")
+{
+    auto ast = parseWithVariadics("ip addr show | grep -w inet | head -5", { "ip" });
+    REQUIRE(ast != nullptr);
+
+    auto* stmt = getFirstStatement(ast.get());
+    REQUIRE(stmt != nullptr);
+
+    auto* pipeline = dynamic_cast<endo::ast::CallPipeline*>(stmt);
+    REQUIRE(pipeline != nullptr);
+    CHECK(pipeline->calls.size() == 3);
+    CHECK(pipeline->calls[0]->program == "ip");
+    CHECK(pipeline->calls[1]->program == "grep");
+    CHECK(pipeline->calls[2]->program == "head");
 }

--- a/src/shell/HelpPrinter.cpp
+++ b/src/shell/HelpPrinter.cpp
@@ -307,6 +307,7 @@ void printHelp()
     h.option("--lsp", "Launch Language Server Protocol server");
     h.option("--dap", "Launch Debug Adapter Protocol server");
     h.option("--log-file=FILE", "Log protocol messages to FILE");
+    h.option("--no-profile", "Skip loading ~/.config/endo/init.endo on startup");
     h.option("--module-path DIR", "Add DIR to module search path");
     h.option("--log=PATTERNS", "Enable logging for matching categories (comma-separated)");
     h.option("--log-list", "List all available log categories and exit");

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -615,8 +615,7 @@ Shell::Shell(TTY& tty, EnvironmentProvider& env, FileSystem& fs):
         // Add search paths: user modules, then system stdlib
         if (auto const home = _env.get("HOME"); home && !home->empty())
         {
-            auto const userModulesDir =
-                std::filesystem::path(*home) / ".config" / "endo" / "modules";
+            auto const userModulesDir = std::filesystem::path(*home) / ".config" / "endo" / "modules";
             if (std::filesystem::exists(userModulesDir))
                 _fsharpState.moduleLoader->addSearchPath(userModulesDir);
         }
@@ -1106,7 +1105,8 @@ int Shell::run()
         return EXIT_FAILURE;
     }
 
-    loadInitScript();
+    if (!_noProfile)
+        loadInitScript();
     loadCompleters();
     onDirectoryChanged();
 

--- a/src/shell/Shell.hpp
+++ b/src/shell/Shell.hpp
@@ -101,6 +101,9 @@ class Shell final: public SignalCallback
     /// Adds an additional module search path (for --module-path CLI option).
     void addModuleSearchPath(std::filesystem::path path);
 
+    /// Disables loading of init.endo profile on startup.
+    void setNoProfile(bool noProfile) noexcept { _noProfile = noProfile; }
+
     /// Set interactive mode (controls prompts, job notifications, etc.)
     void setInteractive(bool interactive);
 
@@ -458,6 +461,7 @@ class Shell final: public SignalCallback
 
     bool _optimize = false;
     bool _checkOnly = false;
+    bool _noProfile = false;
 
     struct PipelineBuilder
     {
@@ -491,10 +495,10 @@ class Shell final: public SignalCallback
     int _exitCode = -1;
     std::chrono::milliseconds _lastCommandDuration { 0 }; ///< Duration of the last command
     bool _interactive = true;                             ///< Whether running in interactive mode
-    unsigned _configScriptDepth = 0;                      ///< Nesting depth of config script / command substitution execution
-    bool _unusedValueDetection = false;                   ///< Detect unused F# bindings (script mode only)
-    bool _lsIcons = true;                                 ///< Show Nerd Font icons in ls output
-    bool _lsDirectorySlash = true;                        ///< Append trailing '/' to directory names
+    unsigned _configScriptDepth = 0;    ///< Nesting depth of config script / command substitution execution
+    bool _unusedValueDetection = false; ///< Detect unused F# bindings (script mode only)
+    bool _lsIcons = true;               ///< Show Nerd Font icons in ls output
+    bool _lsDirectorySlash = true;      ///< Append trailing '/' to directory names
     ProcessId _shellPid = 0;
     ProcessId _shellPgid = 0; ///< Shell's process group ID
     int _signalFd = -1;       ///< signalfd for Linux, -1 otherwise

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -4574,3 +4574,25 @@ TEST_CASE("shell.builtin.grep_pipe_chain")
                      .output())
           == escape("2\n"));
 }
+
+// =============================================================================
+// Variadic function + shell pipe tests
+// =============================================================================
+
+TEST_CASE("shell.variadic_function_pipe", "[variadic]")
+{
+    TestShell shell;
+    // Define a variadic function that wraps echo (the wrapper adds --color=auto
+    // but for piping, the parser falls back to raw command execution).
+    // Use 'echo' directly as the variadic name so it resolves as a real program.
+    shell("let echo ...xs = & echo ...xs");
+    shell("echo hello world | grep --color=never hello");
+    CHECK(escape(shell.output()) == escape("hello world\n"));
+}
+
+TEST_CASE("shell.pipe_with_flags", "[pipe]")
+{
+    // Verify that basic pipes with flags work as expected (regression guard)
+    CHECK(escape(TestShell()("echo -e \"foo\\nbar\" | grep --color=never -w foo").output())
+          == escape("foo\n"));
+}

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -71,6 +71,7 @@ struct ParsedArgs
     std::optional<std::string> agentTracePath; ///< Agent trace file path (nullopt = disabled).
     std::optional<std::string> logFile;        ///< Log file path for protocol messages (DAP, etc.).
     std::vector<std::string_view> modulePaths; ///< Additional module search paths (--module-path).
+    bool noProfile = false;                    ///< Skip loading init.endo profile.
 };
 
 ParsedArgs parseArguments(std::span<char const* const> args)
@@ -124,6 +125,10 @@ ParsedArgs parseArguments(std::span<char const* const> args)
         else if (arg.starts_with("--log="))
         {
             result.logPatterns = arg.substr(6);
+        }
+        else if (arg == "--no-profile")
+        {
+            result.noProfile = true;
         }
         else if (arg == "--module-path" && i + 1 < args.size())
         {
@@ -339,6 +344,9 @@ int main(int argc, char const* argv[])
 
     if (parsed.unusedDetection)
         shell.setUnusedValueDetection(true);
+
+    if (parsed.noProfile)
+        shell.setNoProfile(true);
 
     // Handle -c command with optional arguments
     if (!parsed.command.empty())


### PR DESCRIPTION
- Fix variadic function handler in `parseStmt()` to detect `Token::Pipe` after argument collection and fall back to a `ProgramCall` in a `CallPipeline`, so commands like `ip addr show | grep inet` work when `ip` is a variadic wrapper
- Add `--no-profile` CLI flag to skip loading `~/.config/endo/init.endo`, useful for debugging broken profiles or benchmarking
- Add 5 new tests (3 parser, 2 shell integration) and documentation in `docs/shell/configuration.md` and `docs/getting-started.md`