### PR TITLE
ci: Add macOS code signing and notarization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,39 @@ jobs:
     - name: Build
       run: cmake --build ${{ matrix.build_dir }}
 
+    # ── macOS code signing ──
+
+    - name: Import Apple signing certificate
+      if: runner.os == 'macOS' && env.BUILD_CERTIFICATE_BASE64 != ''
+      env:
+        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      run: |
+        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+        KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+
+        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+        security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security list-keychain -d user -s $KEYCHAIN_PATH login.keychain-db
+
+    - name: Sign binary
+      if: runner.os == 'macOS' && env.BUILD_CERTIFICATE_BASE64 != ''
+      env:
+        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+      run: |
+        codesign --force --options runtime \
+          --sign "Developer ID Application: Christian Parpart (6T525MU9UR)" \
+          --timestamp \
+          ${{ matrix.build_dir }}/src/shell/endo
+
+    # ── Checks & Tests ──
+
     - name: Check endo formatting
       if: runner.os == 'Linux'
       run: |
@@ -99,6 +132,45 @@ jobs:
       working-directory: ${{ matrix.build_dir }}
       run: cpack -G DragNDrop
 
+    - name: Sign and notarize DMG
+      if: runner.os == 'macOS' && env.BUILD_CERTIFICATE_BASE64 != ''
+      env:
+        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      run: |
+        DMG=$(ls ${{ matrix.build_dir }}/endo-*.dmg)
+
+        codesign --force \
+          --sign "Developer ID Application: Christian Parpart (6T525MU9UR)" \
+          --timestamp "$DMG"
+
+        xcrun notarytool submit "$DMG" \
+          --apple-id "$APPLE_ID" \
+          --password "$APPLE_ID_PASSWORD" \
+          --team-id "$APPLE_TEAM_ID" \
+          --wait
+
+        xcrun stapler staple "$DMG"
+
+    - name: Notarize standalone binary
+      if: runner.os == 'macOS' && env.BUILD_CERTIFICATE_BASE64 != ''
+      env:
+        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      run: |
+        zip -j ${{ matrix.build_dir }}/endo-notarize.zip \
+          ${{ matrix.build_dir }}/src/shell/endo
+
+        xcrun notarytool submit ${{ matrix.build_dir }}/endo-notarize.zip \
+          --apple-id "$APPLE_ID" \
+          --password "$APPLE_ID_PASSWORD" \
+          --team-id "$APPLE_TEAM_ID" \
+          --wait
+
     - name: Upload macOS binary
       if: runner.os == 'macOS'
       uses: actions/upload-artifact@v4
@@ -114,6 +186,12 @@ jobs:
         name: endo-macos-arm64-dmg
         path: ${{ matrix.build_dir }}/endo-*.dmg
         retention-days: 30
+
+    - name: Clean up keychain
+      if: always() && runner.os == 'macOS'
+      run: |
+        security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
+        rm -f $RUNNER_TEMP/build_certificate.p12
 
   static-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,25 @@ jobs:
       - name: Install CMake
         uses: ssrobins/install-cmake@v1
 
+      - name: Import Apple signing certificate
+        if: env.BUILD_CERTIFICATE_BASE64 != ''
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH login.keychain-db
+
       - name: "Fetch vendored libraries (crispy & vtparser)"
         run: python3 scripts/get_contour_dirs.py
 
@@ -130,6 +149,16 @@ jobs:
       - name: Build
         run: cmake --build --preset clang-release
 
+      - name: Sign binary
+        if: env.BUILD_CERTIFICATE_BASE64 != ''
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        run: |
+          codesign --force --options runtime \
+            --sign "Developer ID Application: Christian Parpart (6T525MU9UR)" \
+            --timestamp \
+            build/clang-release/src/shell/endo
+
       - name: Test
         working-directory: build/clang-release
         run: ctest --output-on-failure
@@ -138,6 +167,45 @@ jobs:
       - name: Build DMG installer
         working-directory: build/clang-release
         run: cpack -G DragNDrop
+
+      - name: Sign and notarize DMG
+        if: env.BUILD_CERTIFICATE_BASE64 != ''
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          DMG=$(ls build/clang-release/endo-*.dmg)
+
+          codesign --force \
+            --sign "Developer ID Application: Christian Parpart (6T525MU9UR)" \
+            --timestamp "$DMG"
+
+          xcrun notarytool submit "$DMG" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+          xcrun stapler staple "$DMG"
+
+      - name: Notarize standalone binary
+        if: env.BUILD_CERTIFICATE_BASE64 != ''
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          zip -j build/clang-release/endo-notarize.zip \
+            build/clang-release/src/shell/endo
+
+          xcrun notarytool submit build/clang-release/endo-notarize.zip \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
 
       - name: Upload to release
         env:
@@ -149,6 +217,12 @@ jobs:
             endo-${VERSION}-macos-arm64 \
             build/clang-release/endo-*.dmg \
             --clobber
+
+      - name: Clean up keychain
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
+          rm -f $RUNNER_TEMP/build_certificate.p12
 
   windows:
     needs: create-release


### PR DESCRIPTION
- Sign the endo binary with Developer ID Application certificate and notarize both the standalone binary and DMG with Apple, preventing macOS Gatekeeper from blocking downloaded binaries
- Applied to both `build.yml` (CI artifacts) and `release.yml` (release artifacts)
- All signing/notarization steps are conditional on secrets being configured, so forks and PRs still build without them