### PR TITLE
fix: Eliminate ghost text flicker on keystroke

### DIFF
--- a/src/agent/ui/AgentInputComponent.cpp
+++ b/src/agent/ui/AgentInputComponent.cpp
@@ -473,7 +473,6 @@ AgentInputComponent::Action AgentInputComponent::processInput(tui::InputEvent co
             dismissPopup();
             return Action::Abort;
         case tui::InputFieldAction::Changed:
-            _inputField.clearGhostText();
             _ghostTextDirty = true;
             _ghostTextPendingSince = std::chrono::steady_clock::now();
             // If popup was visible and dismissed by typing, re-filter instead of hiding

--- a/src/shell/ui/PromptComponent.cpp
+++ b/src/shell/ui/PromptComponent.cpp
@@ -1163,7 +1163,6 @@ PromptComponent::Action PromptComponent::processInput(tui::InputEvent const& eve
                 _exitHintVisible = false;
                 _inputField.clearGhostText();
             }
-            _inputField.clearGhostText(); // Remove stale suggestion immediately
             _ghostTextDirty = true;
             _ghostTextPendingSince = std::chrono::steady_clock::now();
             // If popup was visible and dismissed by typing, re-filter instead of hiding

--- a/src/tui/InputField.cpp
+++ b/src/tui/InputField.cpp
@@ -949,11 +949,13 @@ auto InputField::handleKey(KeyEvent const& key) -> InputFieldAction
     {
         // Save undo state before any changes
         saveUndoState();
-        clearGhostText(); // User input clears ghost suggestion
 
         // Delete selection first if any (typing replaces selection)
         if (hasSelection())
+        {
+            clearGhostText();
             deleteSelection();
+        }
 
         auto cp = key.codepoint;
         // Handle Shift and CapsLock modifiers for letter capitalization
@@ -963,6 +965,23 @@ auto InputField::handleKey(KeyEvent const& key) -> InputFieldAction
         bool const shouldCapitalize = (shift != capsActive); // XOR logic
         if (shouldCapitalize && cp >= 'a' && cp <= 'z')
             cp = cp - 'a' + 'A';
+
+        // Smart ghost text trimming: if typing at end and character matches ghost prefix, trim it;
+        // otherwise clear the now-stale ghost text. This avoids the visual flicker caused by
+        // clearing ghost text immediately and only recomputing it after the debounce delay.
+        if (!_ghostText.empty() && _cursor == _buffer.size())
+        {
+            auto const typed = encodeUtf8(cp);
+            if (_ghostText.starts_with(typed))
+                _ghostText.erase(0, typed.size());
+            else
+                clearGhostText();
+        }
+        else
+        {
+            clearGhostText();
+        }
+
         insertCodepoint(cp);
         _lastWasKill = false;
         return InputFieldAction::Changed;

--- a/src/tui/InputField_test.cpp
+++ b/src/tui/InputField_test.cpp
@@ -1713,3 +1713,53 @@ TEST_CASE("InputField.history_cycling_strips_newlines_in_single_line_mode")
     (void) field.processEvent(specialKey(KeyCode::Down));
     CHECK(field.text() == "multi line entry");
 }
+
+// ============================================================================
+// Ghost text trimming tests
+// ============================================================================
+
+TEST_CASE("InputField.ghost_text_trimmed_on_matching_char")
+{
+    InputField field;
+    field.setText("foo");
+    field.setCursor(3);
+    field.setGhostText("bar");
+    (void) field.processEvent(charKey('b'));
+    CHECK(field.text() == "foob");
+    CHECK(field.ghostText() == "ar");
+}
+
+TEST_CASE("InputField.ghost_text_cleared_on_non_matching_char")
+{
+    InputField field;
+    field.setText("foo");
+    field.setCursor(3);
+    field.setGhostText("bar");
+    (void) field.processEvent(charKey('x'));
+    CHECK(field.text() == "foox");
+    CHECK(field.ghostText().empty());
+}
+
+TEST_CASE("InputField.ghost_text_cleared_when_cursor_not_at_end")
+{
+    InputField field;
+    field.setText("foo");
+    field.setCursor(3);
+    field.setGhostText("bar");
+    // Move cursor to start
+    (void) field.processEvent(specialKey(KeyCode::Home));
+    (void) field.processEvent(charKey('x'));
+    CHECK(field.ghostText().empty());
+}
+
+TEST_CASE("InputField.ghost_text_trim_respects_capitalization")
+{
+    InputField field;
+    field.setText("H");
+    field.setCursor(1);
+    field.setGhostText("ello");
+    // Type 'e' with Shift → becomes 'E', does not match ghost text starting with 'e'
+    (void) field.processEvent(charKey('e', Modifier::Shift));
+    CHECK(field.text() == "HE");
+    CHECK(field.ghostText().empty());
+}


### PR DESCRIPTION

- Replace immediate `clearGhostText()` on every keystroke with smart prefix trimming: if the typed character matches the ghost text prefix, trim it in-place; otherwise clear — eliminating the visible "disappear → reappear" flicker caused by the 100ms debounce delay
- Remove redundant `clearGhostText()` calls in `PromptComponent` and `AgentInputComponent` that duplicated what `InputField` already handles
- Add 4 unit tests covering matching/non-matching trim, cursor-not-at-end, and capitalization edge cases
