### PR TITLE
Normalize all Windows paths to use forward slashes

### DIFF
--- a/src/endo-language/ide/CompletionContext.cpp
+++ b/src/endo-language/ide/CompletionContext.cpp
@@ -3,6 +3,7 @@
 #include <endo-language/lexer/Lexer.hpp>
 
 #include <algorithm>
+#include <cctype>
 
 namespace endo
 {
@@ -311,6 +312,16 @@ bool CompletionContextAnalyzer::looksLikeFilePath(std::string_view prefix)
     // Contains a path separator
     if (prefix.find('/') != std::string_view::npos)
         return true;
+
+#if defined(_WIN32)
+    // Backslash is a path separator on Windows
+    if (prefix.find('\\') != std::string_view::npos)
+        return true;
+
+    // Drive letter prefix (e.g., "C:" or "D:\")
+    if (prefix.size() >= 2 && std::isalpha(static_cast<unsigned char>(prefix[0])) && prefix[1] == ':')
+        return true;
+#endif
 
     return false;
 }

--- a/src/platform/posix/PosixEnvironmentProvider.cpp
+++ b/src/platform/posix/PosixEnvironmentProvider.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "PosixEnvironmentProvider.hpp"
 
+#include <platform/PathUtils.hpp>
+
 #include <algorithm>
 #include <filesystem>
 
@@ -79,7 +81,7 @@ std::expected<void, PlatformError> PosixEnvironmentProvider::changeDirectory(
 
 std::string PosixEnvironmentProvider::currentDirectory() const
 {
-    return std::filesystem::current_path().string();
+    return normalizePath(std::filesystem::current_path());
 }
 
 } // namespace endo::platform

--- a/src/platform/windows/WindowsEnvironmentProvider.cpp
+++ b/src/platform/windows/WindowsEnvironmentProvider.cpp
@@ -3,6 +3,8 @@
 
 #if defined(_WIN32)
 
+    #include <platform/PathUtils.hpp>
+
     #include <algorithm>
     #include <cctype>
     #include <filesystem>
@@ -115,7 +117,7 @@ std::expected<void, PlatformError> WindowsEnvironmentProvider::changeDirectory(
 
 std::string WindowsEnvironmentProvider::currentDirectory() const
 {
-    return std::filesystem::current_path().string();
+    return normalizePath(std::filesystem::current_path());
 }
 
 } // namespace endo::platform

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -959,14 +959,14 @@ void Shell::loadInitScript()
         {
             if (auto content = _fs.readFile(initPath))
             {
-                if (auto const initResult = executeConfigScript(*content, initPath.string()); initResult != 0)
+                if (auto const initResult = executeConfigScript(*content, platform::normalizePath(initPath)); initResult != 0)
                     _tty.writeToStderr(
                         std::format("endo: warning: init.endo exited with code {}\n", initResult));
             }
             else
             {
                 _tty.writeToStderr(
-                    std::format("endo: warning: error loading {}: {}\n", initPath.string(), content.error()));
+                    std::format("endo: warning: error loading {}: {}\n", platform::normalizePath(initPath), content.error()));
             }
         }
     }
@@ -1031,19 +1031,19 @@ void Shell::loadCompleters()
 
         for (auto const& path: files)
         {
-            auto const basename = path.filename().string();
+            auto const basename = path.filename().string(); // no separators in filename
             if (seenBasenames.contains(basename))
                 continue;
             seenBasenames.insert(basename);
 
             if (auto content = _fs.readFile(path))
             {
-                (void) executeConfigScript(*content, path.string());
+                (void) executeConfigScript(*content, platform::normalizePath(path));
             }
             else
             {
                 _tty.writeToStderr(std::format(
-                    "endo: warning: error loading completer {}: {}\n", path.string(), content.error()));
+                    "endo: warning: error loading completer {}: {}\n", platform::normalizePath(path), content.error()));
             }
         }
     };
@@ -1236,7 +1236,7 @@ int Shell::run()
         // Populate prompt context for module evaluation
         {
             auto ctx = PromptContext {};
-            ctx.cwd = _fs.currentPath().string();
+            ctx.cwd = platform::normalizePath(_fs.currentPath());
             emitWindowTitle(ctx.cwd);
             if (auto const* home = std::getenv("HOME"))
                 ctx.homePath = home;
@@ -1376,7 +1376,7 @@ int Shell::run()
         // Populate prompt context for module evaluation
         {
             auto ctx = PromptContext {};
-            ctx.cwd = _fs.currentPath().string();
+            ctx.cwd = platform::normalizePath(_fs.currentPath());
             emitWindowTitle(ctx.cwd);
             if (auto const* home = std::getenv("HOME"))
                 ctx.homePath = home;
@@ -2120,7 +2120,7 @@ namespace
             cachedContext ? std::move(*cachedContext) : agent::ProjectContextLoader::load(cwd);
 
         auto promptBuilder = agent::SystemPromptBuilder {};
-        promptBuilder.setWorkingDirectory(cwd.string());
+        promptBuilder.setWorkingDirectory(platform::normalizePath(cwd));
         promptBuilder.setShellInfo("endo");
         promptBuilder.setProjectRules(projectContext.rulesFiles);
         promptBuilder.setGlobalRules(projectContext.globalRules);
@@ -2140,7 +2140,7 @@ namespace
         else
         {
             // Fallback: query git directly (e.g., first agent entry before prompt displayed)
-            auto const cwdStr = cwd.string();
+            auto const cwdStr = platform::normalizePath(cwd);
     #if defined(_WIN32)
             gitBranch = runCommandCapture("git -C " + cwdStr + " rev-parse --abbrev-ref HEAD 2>NUL");
     #else
@@ -2161,14 +2161,14 @@ namespace
         }
 
         // Tilde-contract the project path for display
-        auto projectPath = cwd.string();
+        auto projectPath = platform::normalizePath(cwd);
         if (auto const home = platform::homeDirectory())
         {
-            auto const homeStr = home->string();
+            auto const homeStr = platform::normalizePath(*home);
             if (projectPath.starts_with(homeStr))
             {
                 auto contracted = "~" + projectPath.substr(homeStr.size());
-                if (contracted.size() == 1 || contracted[1] == '/' || contracted[1] == '\\')
+                if (contracted.size() == 1 || contracted[1] == '/')
                     projectPath = std::move(contracted);
             }
         }
@@ -2182,7 +2182,7 @@ namespace
             "Be thorough but concise. Reference file paths with line numbers. "
             "Do not ask follow-up questions — produce a complete answer. "
             "Do not suggest code changes — only report findings.");
-        explorePromptBuilder.setWorkingDirectory(cwd.string());
+        explorePromptBuilder.setWorkingDirectory(platform::normalizePath(cwd));
         explorePromptBuilder.setShellInfo("endo");
         explorePromptBuilder.setProjectRules(projectContext.rulesFiles);
         explorePromptBuilder.setGlobalRules(projectContext.globalRules);
@@ -2966,7 +2966,7 @@ void Shell::runAgentMode(std::optional<std::string> initialMessage)
             auto const now = std::chrono::system_clock::now();
             auto const timestamp =
                 std::format("{:%Y%m%d-%H%M%S}", std::chrono::floor<std::chrono::seconds>(now));
-            tracePath = (traceDir / ("agent-trace-" + timestamp + ".jsonl")).string();
+            tracePath = platform::normalizePath(traceDir / ("agent-trace-" + timestamp + ".jsonl"));
         }
 
         auto tracerResult = agent::AgentTracer::create(tracePath);

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -4,6 +4,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <platform/PathUtils.hpp>
+
 #include <chrono>
 #include <filesystem>
 #include <format>
@@ -4009,7 +4011,7 @@ TEST_CASE("shell.builtin.find_basic")
     shell(std::format("find {}", testDir.string()));
     CHECK(shell.exitCode == 0);
     auto const out = std::string(shell.output());
-    CHECK(out.find(testDir.string()) != std::string::npos);
+    CHECK(out.find(endo::platform::normalizePath(testDir)) != std::string::npos);
     CHECK(out.find("a.txt") != std::string::npos);
     CHECK(out.find("b.txt") != std::string::npos);
     CHECK(out.find("sub") != std::string::npos);

--- a/src/shell/builtins/Environment.cpp
+++ b/src/shell/builtins/Environment.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <shell/Shell.hpp>
 
+#include <platform/PathUtils.hpp>
+
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
@@ -64,7 +66,7 @@ void Shell::applyDirectoryChange(std::filesystem::path const& path, CoreVM::Para
     auto const result = _env.changeDirectory(path);
     if (!result.has_value())
     {
-        error("Failed to change directory to '{}': {}", path.string(), toString(result.error()));
+        error("Failed to change directory to '{}': {}", platform::normalizePath(path), toString(result.error()));
         _exitCode = 1;
     }
     else
@@ -289,7 +291,7 @@ int Shell::executeInlineSourceEnv(CoreVM::CoreStringArray const& args, NativeHan
     // 1. Validate script exists
     if (!std::filesystem::exists(scriptPath))
     {
-        error("source-env: script not found: {}", scriptPath.string());
+        error("source-env: script not found: {}", platform::normalizePath(scriptPath));
         return EXIT_FAILURE;
     }
 
@@ -379,7 +381,7 @@ int Shell::executeInlineSourceEnv(CoreVM::CoreStringArray const& args, NativeHan
         auto ofs = std::ofstream(wrapperPath, std::ios::binary);
         if (!ofs)
         {
-            error("source-env: failed to create temp wrapper: {}", wrapperPath.string());
+            error("source-env: failed to create temp wrapper: {}", platform::normalizePath(wrapperPath));
             return EXIT_FAILURE;
         }
         ofs << wrapperContent;
@@ -437,7 +439,7 @@ int Shell::executeInlineSourceEnv(CoreVM::CoreStringArray const& args, NativeHan
     }
     else
     {
-        error("source-env: failed to spawn interpreter: {}", interpreter.string());
+        error("source-env: failed to spawn interpreter: {}", platform::normalizePath(interpreter));
         return EXIT_FAILURE;
     }
 

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -5,6 +5,8 @@
 #include <shell/commands/KillCommand.hpp>
 #include <shell/commands/TimeoutCommand.hpp>
 
+#include <platform/PathUtils.hpp>
+
 #include <tui/GenericSyntaxHighlighter.hpp>
 #include <tui/ImageLoader.hpp>
 #include <tui/MarkdownRenderer.hpp>
@@ -1201,12 +1203,12 @@ int Shell::executeInlineRm(CoreVM::CoreStringArray const& args, NativeHandle out
                             if (!removeResult.has_value() || !removeResult.value())
                             {
                                 error("rm: cannot remove '{}': {}",
-                                      entry.string(),
+                                      platform::normalizePath(entry),
                                       removeResult.has_value() ? "Unknown error" : removeResult.error());
                                 allOk = false;
                                 break;
                             }
-                            writeOutput(std::format("removed '{}'\n", entry.string()));
+                            writeOutput(std::format("removed '{}'\n", platform::normalizePath(entry)));
                         }
                         if (!allOk)
                         {
@@ -1516,7 +1518,7 @@ int Shell::executeInlineCp(CoreVM::CoreStringArray const& args, NativeHandle out
 
     if (sources.size() > 1 && !destIsDir)
     {
-        error("cp: target '{}' is not a directory", dest.string());
+        error("cp: target '{}' is not a directory", platform::normalizePath(dest));
         return 1;
     }
 
@@ -1555,7 +1557,7 @@ int Shell::executeInlineCp(CoreVM::CoreStringArray const& args, NativeHandle out
             // Create the top-level target directory
             if (auto const mkResult = _fs.createDirectories(target); !mkResult.has_value())
             {
-                error("cp: cannot create directory '{}': {}", target.string(), mkResult.error());
+                error("cp: cannot create directory '{}': {}", platform::normalizePath(target), mkResult.error());
                 success = false;
                 continue;
             }
@@ -1569,7 +1571,7 @@ int Shell::executeInlineCp(CoreVM::CoreStringArray const& args, NativeHandle out
                 {
                     if (auto const mkResult = _fs.createDirectories(entryTarget); !mkResult.has_value())
                     {
-                        error("cp: cannot create directory '{}': {}", entryTarget.string(), mkResult.error());
+                        error("cp: cannot create directory '{}': {}", platform::normalizePath(entryTarget), mkResult.error());
                         success = false;
                     }
                 }
@@ -1584,7 +1586,7 @@ int Shell::executeInlineCp(CoreVM::CoreStringArray const& args, NativeHandle out
                         !mkResult.has_value())
                     {
                         error("cp: cannot create directory '{}': {}",
-                              entryTarget.parent_path().string(),
+                              platform::normalizePath(entryTarget.parent_path()),
                               mkResult.error());
                         success = false;
                         continue;
@@ -1592,12 +1594,12 @@ int Shell::executeInlineCp(CoreVM::CoreStringArray const& args, NativeHandle out
                     if (auto const cpResult = _fs.copyFile(entry.path, entryTarget, overwrite);
                         !cpResult.has_value())
                     {
-                        error("cp: cannot copy '{}': {}", entry.path.string(), cpResult.error());
+                        error("cp: cannot copy '{}': {}", platform::normalizePath(entry.path), cpResult.error());
                         success = false;
                         continue;
                     }
                     if (verbose)
-                        writeOutput(std::format("'{}' -> '{}'\n", entry.path.string(), entryTarget.string()));
+                        writeOutput(std::format("'{}' -> '{}'\n", platform::normalizePath(entry.path), platform::normalizePath(entryTarget)));
                 }
             }
         }
@@ -1609,13 +1611,13 @@ int Shell::executeInlineCp(CoreVM::CoreStringArray const& args, NativeHandle out
 
             if (auto const cpResult = _fs.copyFile(srcPath, target, overwrite); !cpResult.has_value())
             {
-                error("cp: cannot copy '{}' to '{}': {}", src, target.string(), cpResult.error());
+                error("cp: cannot copy '{}' to '{}': {}", src, platform::normalizePath(target), cpResult.error());
                 success = false;
                 continue;
             }
 
             if (verbose)
-                writeOutput(std::format("'{}' -> '{}'\n", src, target.string()));
+                writeOutput(std::format("'{}' -> '{}'\n", src, platform::normalizePath(target)));
         }
     }
 
@@ -1747,7 +1749,7 @@ int Shell::executeInlineMv(CoreVM::CoreStringArray const& args, NativeHandle out
 
     if (sources.size() > 1 && !destIsDir)
     {
-        error("mv: target '{}' is not a directory", dest.string());
+        error("mv: target '{}' is not a directory", platform::normalizePath(dest));
         return 1;
     }
 
@@ -1773,7 +1775,7 @@ int Shell::executeInlineMv(CoreVM::CoreStringArray const& args, NativeHandle out
 
             if (interactive && !force)
             {
-                auto const prompt = std::format("mv: overwrite '{}'? ", target.string());
+                auto const prompt = std::format("mv: overwrite '{}'? ", platform::normalizePath(target));
                 [[maybe_unused]] auto w = platformWrite(standardError(), prompt.data(), prompt.size());
                 if (!_tty.isTerminal())
                     continue;
@@ -1795,7 +1797,7 @@ int Shell::executeInlineMv(CoreVM::CoreStringArray const& args, NativeHandle out
                                        || renameError.find("EXDEV") != std::string::npos;
             if (!isCrossDevice)
             {
-                error("mv: cannot move '{}' to '{}': {}", src, target.string(), renameError);
+                error("mv: cannot move '{}' to '{}': {}", src, platform::normalizePath(target), renameError);
                 success = false;
                 continue;
             }
@@ -1808,14 +1810,14 @@ int Shell::executeInlineMv(CoreVM::CoreStringArray const& args, NativeHandle out
                 // Recursive directory copy
                 if (auto const mkResult = _fs.createDirectories(target); !mkResult.has_value())
                 {
-                    error("mv: cannot move '{}' to '{}': {}", src, target.string(), mkResult.error());
+                    error("mv: cannot move '{}' to '{}': {}", src, platform::normalizePath(target), mkResult.error());
                     success = false;
                     continue;
                 }
                 auto const listResult = _fs.listDirectoryRecursive(srcPath);
                 if (!listResult.has_value())
                 {
-                    error("mv: cannot move '{}' to '{}': {}", src, target.string(), listResult.error());
+                    error("mv: cannot move '{}' to '{}': {}", src, platform::normalizePath(target), listResult.error());
                     success = false;
                     continue;
                 }
@@ -1862,7 +1864,7 @@ int Shell::executeInlineMv(CoreVM::CoreStringArray const& args, NativeHandle out
 
             if (copyFailed)
             {
-                error("mv: cannot move '{}' to '{}': {}", src, target.string(), copyError);
+                error("mv: cannot move '{}' to '{}': {}", src, platform::normalizePath(target), copyError);
                 success = false;
                 continue;
             }
@@ -1872,7 +1874,7 @@ int Shell::executeInlineMv(CoreVM::CoreStringArray const& args, NativeHandle out
             {
                 error("mv: moved '{}' to '{}' but failed to remove source: {}",
                       src,
-                      target.string(),
+                      platform::normalizePath(target),
                       removeResult.error());
                 success = false;
                 continue;
@@ -1880,7 +1882,7 @@ int Shell::executeInlineMv(CoreVM::CoreStringArray const& args, NativeHandle out
         }
 
         if (verbose)
-            writeOutput(std::format("'{}' -> '{}'\n", src, target.string()));
+            writeOutput(std::format("'{}' -> '{}'\n", src, platform::normalizePath(target)));
     }
 
     return success ? 0 : 1;
@@ -2021,7 +2023,7 @@ int Shell::executeInlineFind(CoreVM::CoreStringArray const& args, NativeHandle o
         {
             if (!_fs.exists(searchPath))
             {
-                error("find: '{}': No such file or directory", searchPath.string());
+                error("find: '{}': No such file or directory", platform::normalizePath(searchPath));
                 continue;
             }
 
@@ -2042,7 +2044,7 @@ int Shell::executeInlineFind(CoreVM::CoreStringArray const& args, NativeHandle o
 
             if (!expression || expression->evaluate(entry))
             {
-                auto const output = searchPath.string() + std::string(separator);
+                auto const output = platform::normalizePath(searchPath) + std::string(separator);
                 platformWrite(outputFd, output.data(), output.size());
             }
         }
@@ -2083,7 +2085,7 @@ int Shell::executeInlineFind(CoreVM::CoreStringArray const& args, NativeHandle o
 
             if (!expression || expression->evaluate(entry))
             {
-                auto const output = dirEntry.path.string() + std::string(separator);
+                auto const output = platform::normalizePath(dirEntry.path) + std::string(separator);
                 platformWrite(outputFd, output.data(), output.size());
             }
         }
@@ -2248,7 +2250,7 @@ int Shell::executeInlineGrep(CoreVM::CoreStringArray const& args, NativeHandle o
             if (!fileStream || !fileStream->good())
             {
                 if (!opts.suppressErrors)
-                    error("grep: {}: Permission denied", filePath.string());
+                    error("grep: {}: Permission denied", platform::normalizePath(filePath));
                 hasError = true;
                 continue;
             }
@@ -2263,7 +2265,7 @@ int Shell::executeInlineGrep(CoreVM::CoreStringArray const& args, NativeHandle o
             }
 
             auto const matches =
-                grep::searchLines(lines, *regex, opts, filePath.string(), showFilename, useColor, writer);
+                grep::searchLines(lines, *regex, opts, platform::normalizePath(filePath), showFilename, useColor, writer);
             totalMatches += matches;
 
             // For -q, bail out early on first match
@@ -3143,7 +3145,7 @@ int Shell::executeInlineDirname(CoreVM::CoreStringArray const& args, NativeHandl
                                       "| `--help` | Display this help |\n");
     }
 
-    auto parent = std::filesystem::path(args.at(1)).parent_path().string();
+    auto parent = platform::normalizePath(std::filesystem::path(args.at(1)).parent_path());
     if (parent.empty())
         parent = ".";
 
@@ -3194,7 +3196,7 @@ int Shell::executeInlineRealpath(CoreVM::CoreStringArray const& args, NativeHand
             exitCode = 1;
             continue;
         }
-        auto output = std::format("{}\n", canonical.string());
+        auto output = std::format("{}\n", platform::normalizePath(canonical));
         [[maybe_unused]] auto written = platformWrite(outputFd, output.data(), output.size());
     }
     return exitCode;
@@ -3436,7 +3438,7 @@ int Shell::executeInlineMktemp(CoreVM::CoreStringArray const& args, NativeHandle
         std::filesystem::create_directories(path, ec);
         if (ec)
         {
-            error("mktemp: failed to create directory '{}': {}", path.string(), ec.message());
+            error("mktemp: failed to create directory '{}': {}", platform::normalizePath(path), ec.message());
             return 1;
         }
     }
@@ -3445,12 +3447,12 @@ int Shell::executeInlineMktemp(CoreVM::CoreStringArray const& args, NativeHandle
         std::ofstream ofs(path);
         if (!ofs)
         {
-            error("mktemp: failed to create file '{}'", path.string());
+            error("mktemp: failed to create file '{}'", platform::normalizePath(path));
             return 1;
         }
     }
 
-    auto output = std::format("{}\n", path.string());
+    auto output = std::format("{}\n", platform::normalizePath(path));
     [[maybe_unused]] auto written = platformWrite(outputFd, output.data(), output.size());
     return 0;
 }

--- a/src/shell/builtins/ProcessExecution.cpp
+++ b/src/shell/builtins/ProcessExecution.cpp
@@ -7,6 +7,8 @@
 
 #include <endo-language/LogCategories.hpp>
 
+#include <platform/PathUtils.hpp>
+
 #include <CoreVM/CoreVM.hpp>
 
 #include <format>
@@ -43,7 +45,7 @@ int Shell::executeEndoScript(std::filesystem::path const& scriptPath)
     auto content = _fs.readFile(scriptPath.string());
     if (!content)
     {
-        error("{}: {}", scriptPath.string(), content.error());
+        error("{}: {}", platform::normalizePath(scriptPath), content.error());
         return EXIT_FAILURE;
     }
 
@@ -59,7 +61,7 @@ int Shell::executeEndoScript(std::filesystem::path const& scriptPath)
 
     auto const savedSourceFile = _fsharpState.sourceFilePath;
     _fsharpState.sourceFilePath = _fs.weaklyCanonical(scriptPath);
-    auto const result = executeConfigScript(*content, scriptPath.string());
+    auto const result = executeConfigScript(*content, platform::normalizePath(scriptPath));
     _fsharpState.sourceFilePath = savedSourceFile;
     return result;
 }
@@ -68,7 +70,7 @@ int Shell::executeEndoScript(std::filesystem::path const& scriptPath, std::span<
 {
     auto savedPositionalParams = _positionalParameters;
     _positionalParameters.clear();
-    _positionalParameters.push_back(scriptPath.string());
+    _positionalParameters.push_back(platform::normalizePath(scriptPath));
     for (auto const& arg: args)
         _positionalParameters.push_back(arg);
 

--- a/src/shell/commands/FindCommand.cpp
+++ b/src/shell/commands/FindCommand.cpp
@@ -6,6 +6,8 @@
 #include <CoreVM/CoreVM.hpp>
 #include <CoreVM/types/TypeDescriptor.hpp>
 
+#include <platform/PathUtils.hpp>
+
 #include <filesystem>
 #include <ranges>
 
@@ -61,7 +63,7 @@ CoreVM::TypedObject* FindCommand::execute(CoreVM::Runner& runner) const
                 {
                     auto const fileStatus = fs::status(canonicalSearch, ec);
                     matches.push_back({
-                        .path = canonicalSearch.string(),
+                        .path = platform::normalizePath(canonicalSearch),
                         .size = entry.size,
                         .mode = static_cast<uint64_t>(fileStatus.permissions()),
                         .mtime = static_cast<int64_t>(
@@ -116,7 +118,7 @@ CoreVM::TypedObject* FindCommand::execute(CoreVM::Runner& runner) const
             {
                 auto const fileStatus = dirEntry.status(ec);
                 matches.push_back({
-                    .path = dirEntry.path().string(),
+                    .path = platform::normalizePath(dirEntry.path()),
                     .size = entry.size,
                     .mode = static_cast<uint64_t>(ec ? fs::perms::none : fileStatus.permissions()),
                     .mtime = static_cast<int64_t>(

--- a/src/shell/commands/FindExpression.cpp
+++ b/src/shell/commands/FindExpression.cpp
@@ -2,6 +2,8 @@
 #include <shell/commands/FindExpression.hpp>
 #include <shell/util/GlobMatcher.hpp>
 
+#include <platform/PathUtils.hpp>
+
 #include <algorithm>
 #include <cctype>
 #include <charconv>
@@ -408,7 +410,7 @@ bool NameExpr::evaluate(FindEntry const& entry) const
 
 bool PathExpr::evaluate(FindEntry const& entry) const
 {
-    auto const pathStr = entry.path.string();
+    auto const pathStr = platform::normalizePath(entry.path);
     if (caseInsensitive)
         return globMatch(toLower(pathStr), toLower(pattern));
     return globMatch(pathStr, pattern);

--- a/src/shell/completion/CommandCompleter.cpp
+++ b/src/shell/completion/CommandCompleter.cpp
@@ -6,6 +6,8 @@
 #include <endo-language/builtins/BuiltinSignatures.hpp>
 #include <endo-language/ide/CompletionCandidates.hpp>
 
+#include <platform/PathUtils.hpp>
+
 #include <crispy/utils.h>
 
 #include <algorithm>
@@ -195,7 +197,7 @@ std::vector<std::pair<std::string, std::string>> CommandCompleter::scanPath() co
 
             // Use stem (without extension) as command name
             auto const cmdName = path.stem().string();
-            commands.try_emplace(cmdName, path.string());
+            commands.try_emplace(cmdName, platform::normalizePath(path));
 #else
             // Check if executable (on POSIX)
             auto status = std::filesystem::status(path, ec);
@@ -209,7 +211,7 @@ std::vector<std::pair<std::string, std::string>> CommandCompleter::scanPath() co
                 || (perms & std::filesystem::perms::others_exec) != std::filesystem::perms::none;
 
             if (isExecutable)
-                commands.try_emplace(path.filename().string(), path.string());
+                commands.try_emplace(path.filename().string(), platform::normalizePath(path));
 #endif
         }
     }

--- a/src/shell/completion/FileCompleter.cpp
+++ b/src/shell/completion/FileCompleter.cpp
@@ -25,7 +25,10 @@ std::vector<CompletionItem> FileCompleter::complete(CompletionContext const& con
     if (context.command.has_value() && isBuiltinWithArgumentCompletion(*context.command))
         return {};
 
-    auto const& prefix = context.prefix;
+    // Normalize backslashes to forward slashes on Windows so that user-typed
+    // backslash paths are handled correctly in all slash-related logic below.
+    auto const normalizedPrefix = platform::normalizePath(std::string(context.prefix));
+    std::string_view const prefix = normalizedPrefix;
 
     if (prefix.empty())
     {

--- a/src/shell/util/GlobMatcher.cpp
+++ b/src/shell/util/GlobMatcher.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "GlobMatcher.hpp"
 
+#include <platform/PathUtils.hpp>
+
 #include <algorithm>
 #include <filesystem>
 #include <ranges>
@@ -53,7 +55,7 @@ std::vector<std::string> expandGlobPattern(std::string_view pattern)
             if (dirPath == ".")
                 results.push_back(filename);
             else
-                results.push_back(entry.path().string());
+                results.push_back(platform::normalizePath(entry.path()));
         }
     }
 
@@ -94,7 +96,7 @@ std::vector<std::string> expandRecursiveGlob(std::string_view pattern)
         if (!entry.is_regular_file())
             continue;
 
-        std::string filePath = entry.path().string();
+        std::string filePath = platform::normalizePath(entry.path());
         std::string filename = entry.path().filename().string();
 
         if (!suffixPattern.empty())


### PR DESCRIPTION
- Apply `platform::normalizePath()` consistently across the codebase so that all user-visible paths use forward slashes on Windows instead of native backslashes
- Fix root sources (`EnvironmentProvider::currentDirectory()`, prompt context CWD), all builtin outputs (`find`, `grep`, `cp`, `mv`, `rm`, `dirname`, `realpath`, `mktemp`), glob expansion, command/file completion, error messages, and diagnostic paths
- Teach `FileCompleter` to normalize backslash input and `CompletionContextAnalyzer` to recognize backslash paths and drive-letter prefixes on Windows; external process execution paths deliberately keep native separators for OS compatibility