### PR TITLE
Make builtin stdin reads interruptible via Ctrl+C

### DIFF
--- a/docs/shell/builtins.md
+++ b/docs/shell/builtins.md
@@ -1868,4 +1868,10 @@ more files simultaneously. Useful for capturing pipeline output while still seei
 echo "hello" | tee output.txt
 echo "data" | tee -a log.txt
 echo "test" | tee file1.txt file2.txt
+echo "quiet" | tee /dev/null     # portable: discards output on Linux, macOS, and Windows
 ```
+
+**Portability:** The path `/dev/null` is accepted on all platforms. On Windows it
+is transparently mapped to the native `NUL` device. See
+[Platform Differences → File Paths](platform-differences.md#null-device-portability-devnull-on-windows)
+for details.

--- a/docs/shell/platform-differences.md
+++ b/docs/shell/platform-differences.md
@@ -215,10 +215,50 @@ Endo normalizes path handling across platforms, but some differences are visible
 |--------|-------|---------|
 | Separator | `/` | `\` (but `/` also works) |
 | Root | `/` | `C:\` (or other drive letter) |
-| Null device | `/dev/null` | `NUL` |
+| Null device | `/dev/null` | `NUL` (Endo also accepts `/dev/null`) |
 | Path length limit | ~4096 bytes | ~260 characters (32,767 with long path support) |
 
 Endo accepts forward slashes in paths on Windows for convenience.
+
+### Null-device portability (`/dev/null` on Windows)
+
+On POSIX systems, the null device is a regular file at `/dev/null`. On Windows the
+equivalent is the reserved device name `NUL`, which is not a filesystem path and has
+no counterpart under `C:\`. Shell scripts and pipelines that target `/dev/null` are
+therefore not portable in general.
+
+To keep commands portable between platforms, Endo rewrites the literal path
+`/dev/null` to `NUL` on Windows at the point where a file is opened. This applies
+consistently across:
+
+- **Builtins that open user-supplied paths** — `tee`, `cat`, `tail`, and other
+  text-processing commands that accept file arguments.
+- **Shell redirections** — both input (`< /dev/null`) and output (`> /dev/null`,
+  `>> /dev/null`) forms.
+
+So the following all behave the same on Linux, macOS, and Windows:
+
+```endo
+echo hello | tee /dev/null          # tees to stdout only
+cat /dev/null                       # prints nothing
+grep pattern file > /dev/null       # discards stdout
+some-command 2> /dev/null           # discards stderr
+```
+
+On Windows, `NUL` itself remains the canonical null device name and may still be
+used directly (e.g. `echo hello > NUL`). The `/dev/null` alias is purely a
+convenience for portability — no other POSIX `/dev/*` names are recognised.
+
+#### Scope of the translation
+
+The rewrite is intentionally narrow: only the exact literal string `/dev/null` is
+mapped. Paths such as `/dev/nullx`, `/dev/null/file`, or `/dev/zero` are treated
+as ordinary filesystem paths, which on Windows will fail to open as expected.
+
+This translation happens inside the shell's file-open helpers — it is not a
+preprocessing step, so user variables and argument strings are unaffected until
+they are passed to a file operation. The implementation lives in
+`endo::platform::resolveDevicePath()` in `src/platform/PathUtils.hpp`.
 
 ---
 

--- a/src/platform/PathUtils.hpp
+++ b/src/platform/PathUtils.hpp
@@ -3,6 +3,7 @@
 
 #include <filesystem>
 #include <string>
+#include <string_view>
 
 namespace endo::platform
 {
@@ -32,6 +33,35 @@ namespace endo::platform
 [[nodiscard]] inline auto normalizePath(std::filesystem::path const& p) -> std::string
 {
     return p.generic_string();
+}
+
+/// @brief Resolves POSIX-style device paths to their platform-native equivalent.
+///
+/// Endo accepts POSIX device paths (`/dev/null`) across all platforms for portability.
+/// On Windows these paths must be rewritten to the corresponding reserved device name
+/// before being passed to file-open APIs:
+///
+/// | POSIX      | Windows |
+/// |------------|---------|
+/// | `/dev/null` | `NUL`   |
+///
+/// On POSIX platforms this helper is a no-op — device paths are native and require no
+/// translation.
+///
+/// Apply this to **user-supplied** paths at the point they are opened (e.g. before
+/// `std::ofstream`, `std::ifstream`, or low-level `open`/`CreateFileW` calls). Do not
+/// apply it to generated or internal paths, as the mapping is intentionally limited to
+/// the device names that users type.
+///
+/// @param path The path to resolve.
+/// @return The platform-native path.
+[[nodiscard]] inline auto resolveDevicePath(std::string_view path) -> std::string
+{
+#if defined(_WIN32)
+    if (path == "/dev/null")
+        return "NUL";
+#endif
+    return std::string { path };
 }
 
 } // namespace endo::platform

--- a/src/platform/SignalHandler.cpp
+++ b/src/platform/SignalHandler.cpp
@@ -293,4 +293,9 @@ void SignalHandler::clearPendingSigint() noexcept
     _sigintPending.store(false);
 }
 
+void SignalHandler::simulateSigint() noexcept
+{
+    _sigintPending.store(true);
+}
+
 } // namespace endo::platform

--- a/src/platform/SignalHandler.hpp
+++ b/src/platform/SignalHandler.hpp
@@ -87,6 +87,9 @@ class SignalHandler
     /// Clears the pending SIGINT flag.
     static void clearPendingSigint() noexcept;
 
+    /// Simulates a SIGINT by setting the pending flag. For testing only.
+    static void simulateSigint() noexcept;
+
     /// Temporarily restores default SIGTSTP handling and re-raises the signal.
     ///
     /// This is called during shell suspend to actually stop the process.

--- a/src/platform/WindowsPlatform_test.cpp
+++ b/src/platform/WindowsPlatform_test.cpp
@@ -46,6 +46,35 @@ TEST_CASE("normalizePath.filesystem_path_overload", "[platform]")
     CHECK(normalizePath(p) == "/some/path");
 }
 
+TEST_CASE("resolveDevicePath.null_device", "[platform]")
+{
+    // `/dev/null` is mapped to the platform-native null device on Windows and
+    // returned unchanged on POSIX systems.
+#if defined(_WIN32)
+    CHECK(resolveDevicePath("/dev/null") == "NUL");
+#else
+    CHECK(resolveDevicePath("/dev/null") == "/dev/null");
+#endif
+}
+
+TEST_CASE("resolveDevicePath.regular_paths_unchanged", "[platform]")
+{
+    CHECK(resolveDevicePath("/tmp/foo.txt") == "/tmp/foo.txt");
+    CHECK(resolveDevicePath("relative/path") == "relative/path");
+    CHECK(resolveDevicePath("C:/Users/test/out.log") == "C:/Users/test/out.log");
+    CHECK(resolveDevicePath("").empty());
+}
+
+TEST_CASE("resolveDevicePath.similar_but_not_null_device", "[platform]")
+{
+    // Only the exact POSIX null-device path is translated. Paths that merely start
+    // with `/dev/` or contain `null` are regular filesystem paths.
+    CHECK(resolveDevicePath("/dev/null/file") == "/dev/null/file");
+    CHECK(resolveDevicePath("/dev/nullx") == "/dev/nullx");
+    CHECK(resolveDevicePath("/dev/zero") == "/dev/zero");
+    CHECK(resolveDevicePath("null") == "null");
+}
+
 TEST_CASE("homeDirectory.returns_value_when_HOME_set", "[platform]")
 {
     auto const* prevHome = std::getenv("HOME");

--- a/src/platform/windows/WindowsProcess.cpp
+++ b/src/platform/windows/WindowsProcess.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+#include <platform/PathUtils.hpp>
 #include <platform/Process.hpp>
 
 #if defined(_WIN32)
@@ -267,7 +268,8 @@ std::expected<NativeHandle, PlatformError> WindowsProcessManager::openFile(std::
     sa.bInheritHandle = TRUE;
     sa.lpSecurityDescriptor = nullptr;
 
-    auto const handle = CreateFileW(path.wstring().c_str(),
+    auto const resolved = std::filesystem::path(resolveDevicePath(path.generic_string()));
+    auto const handle = CreateFileW(resolved.wstring().c_str(),
                                     access,
                                     FILE_SHARE_READ | FILE_SHARE_WRITE,
                                     &sa,

--- a/src/platform/windows/WindowsProcess.cpp
+++ b/src/platform/windows/WindowsProcess.cpp
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-#include <platform/PathUtils.hpp>
 #include <platform/Process.hpp>
 
 #if defined(_WIN32)
@@ -268,8 +267,12 @@ std::expected<NativeHandle, PlatformError> WindowsProcessManager::openFile(std::
     sa.bInheritHandle = TRUE;
     sa.lpSecurityDescriptor = nullptr;
 
-    auto const resolved = std::filesystem::path(resolveDevicePath(path.generic_string()));
-    auto const handle = CreateFileW(resolved.wstring().c_str(),
+    // Special-case the POSIX /dev/null alias; pass any other path through unchanged
+    // to preserve the original wide-string form (round-tripping through generic_string()
+    // can lose non-ASCII characters for arbitrary Windows paths).
+    auto const widePath = path.wstring();
+    auto const* pathToOpen = (widePath == L"/dev/null") ? L"NUL" : widePath.c_str();
+    auto const handle = CreateFileW(pathToOpen,
                                     access,
                                     FILE_SHARE_READ | FILE_SHARE_WRITE,
                                     &sa,

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -4,13 +4,13 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include <platform/PathUtils.hpp>
-
 #include <chrono>
 #include <filesystem>
 #include <format>
 #include <fstream>
 #include <thread>
+
+#include <platform/PathUtils.hpp>
 
 using namespace std::string_literals;
 using namespace std::string_view_literals;
@@ -806,6 +806,64 @@ TEST_CASE("shell.builtin.cat_binary_file_raw_mode")
     std::filesystem::remove("/tmp/endo_test_binary_raw.dat", ec);
 }
 #endif
+
+TEST_CASE("shell.builtin.cat_pipe_regression")
+{
+    // Issue #98: Ensure cat in a pipeline (non-terminal stdin) still works after interruptible read changes.
+    CHECK(escape(TestShell()("echo hello | cat").output()) == escape("hello\n"));
+    CHECK(escape(TestShell()("echo -n test | cat").output()) == escape("test"));
+}
+
+TEST_CASE("shell.builtin.cat_sigint_returns_130")
+{
+    // Issue #98: Simulate SIGINT before running cat with piped input.
+    // The interruptible read loop should detect the pending SIGINT and return 130.
+    TestShell shell;
+    endo::platform::SignalHandler::simulateSigint();
+    shell("echo hello | cat");
+    CHECK(shell.exitCode == 130);
+    endo::platform::SignalHandler::clearPendingSigint(); // cleanup
+}
+
+TEST_CASE("shell.builtin.head_pipe_regression")
+{
+    // Ensure head in a pipeline still works after interruptible read changes.
+    TestShell shell;
+    auto output = shell(R"(echo -e "a\nb\nc" | head -n 2)").output();
+    CHECK(output.find('a') != std::string::npos);
+    CHECK(output.find('b') != std::string::npos);
+    CHECK(shell.exitCode == 0);
+}
+
+TEST_CASE("shell.builtin.grep_sigint_returns_130")
+{
+    // Simulate SIGINT before grep reads stdin.
+    TestShell shell;
+    endo::platform::SignalHandler::simulateSigint();
+    shell("echo hello | grep hello");
+    CHECK(shell.exitCode == 130);
+    endo::platform::SignalHandler::clearPendingSigint();
+}
+
+TEST_CASE("shell.builtin.tr_sigint_returns_130")
+{
+    // Simulate SIGINT before tr reads stdin.
+    TestShell shell;
+    endo::platform::SignalHandler::simulateSigint();
+    shell("echo hello | tr a-z A-Z");
+    CHECK(shell.exitCode == 130);
+    endo::platform::SignalHandler::clearPendingSigint();
+}
+
+TEST_CASE("shell.builtin.tee_sigint_returns_130")
+{
+    // Simulate SIGINT before tee reads stdin.
+    TestShell shell;
+    endo::platform::SignalHandler::simulateSigint();
+    shell("echo hello | tee /dev/null");
+    CHECK(shell.exitCode == 130);
+    endo::platform::SignalHandler::clearPendingSigint();
+}
 
 // ============================================================================
 // Sleep Builtin

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -205,7 +205,7 @@ std::expected<std::pair<std::optional<int>, std::optional<int>>, std::string> pa
 /// Reads from fd using poll() with 100ms timeout, checking for SIGINT between polls.
 /// Calls onChunk(data, size) for each chunk of data read.
 ///
-/// @return 0 on EOF, 130 on SIGINT interruption.
+/// @return 0 on EOF, 1 on I/O error, 130 on SIGINT interruption.
 int interruptibleReadLoop(endo::NativeHandle fd, auto const& onChunk)
 {
     using namespace endo;
@@ -228,15 +228,19 @@ int interruptibleReadLoop(endo::NativeHandle fd, auto const& onChunk)
         {
             if (errno == EINTR)
                 continue;
-            break;
+            return 1;
         }
+        if ((pfd.revents & (POLLERR | POLLNVAL)) != 0)
+            return 1;
         if (pollResult == 0)
             continue;
 #else
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
 #endif
         auto const bytesRead = platformRead(fd, buffer.data(), buffer.size());
-        if (bytesRead <= 0)
+        if (bytesRead < 0)
+            return 1;
+        if (bytesRead == 0)
             break;
         onChunk(buffer.data(), static_cast<size_t>(bytesRead));
     }

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -5,8 +5,6 @@
 #include <shell/commands/KillCommand.hpp>
 #include <shell/commands/TimeoutCommand.hpp>
 
-#include <platform/PathUtils.hpp>
-
 #include <tui/GenericSyntaxHighlighter.hpp>
 #include <tui/ImageLoader.hpp>
 #include <tui/MarkdownRenderer.hpp>
@@ -30,6 +28,7 @@
 
 #include <fcntl.h>
 
+#include <platform/PathUtils.hpp>
 #include <platform/Process.hpp>
 #include <platform/SignalHandler.hpp>
 #include <platform/Types.hpp>
@@ -201,6 +200,58 @@ std::expected<std::pair<std::optional<int>, std::optional<int>>, std::string> pa
         return std::unexpected(std::format("start ({}) must be <= end ({})", *rangeStart, *rangeEnd));
 
     return std::pair { rangeStart, rangeEnd };
+}
+
+/// Reads from fd using poll() with 100ms timeout, checking for SIGINT between polls.
+/// Calls onChunk(data, size) for each chunk of data read.
+///
+/// @return 0 on EOF, 130 on SIGINT interruption.
+int interruptibleReadLoop(endo::NativeHandle fd, auto const& onChunk)
+{
+    using namespace endo;
+    using namespace endo::platform;
+
+    std::array<char, 4096> buffer {};
+
+    while (true)
+    {
+        SignalHandler::processSignalFd();
+        if (SignalHandler::hasPendingSigint())
+        {
+            SignalHandler::clearPendingSigint();
+            return 130;
+        }
+#if !defined(_WIN32)
+        pollfd pfd { .fd = fd, .events = POLLIN, .revents = 0 };
+        auto const pollResult = poll(&pfd, 1, 100);
+        if (pollResult < 0)
+        {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+        if (pollResult == 0)
+            continue;
+#else
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+#endif
+        auto const bytesRead = platformRead(fd, buffer.data(), buffer.size());
+        if (bytesRead <= 0)
+            break;
+        onChunk(buffer.data(), static_cast<size_t>(bytesRead));
+    }
+    return 0;
+}
+
+/// Reads all data from fd interruptibly.
+///
+/// @return {data, exitCode} where exitCode is 0 on EOF or 130 on SIGINT.
+std::pair<std::string, int> interruptibleReadAll(endo::NativeHandle fd)
+{
+    std::string data;
+    auto const exitCode =
+        interruptibleReadLoop(fd, [&](char const* buf, size_t len) { data.append(buf, len); });
+    return { std::move(data), exitCode };
 }
 
 } // namespace
@@ -757,14 +808,8 @@ int Shell::executeInlineCat(CoreVM::CoreStringArray const& args, NativeHandle ou
         }
     };
 
-    auto readFromFd = [](NativeHandle fd) -> std::string {
-        std::string content;
-        char buffer[4096];
-        intptr_t bytesRead = 0;
-        while ((bytesRead = platformRead(fd, buffer, sizeof(buffer))) > 0)
-            content.append(buffer, static_cast<size_t>(bytesRead));
-        return content;
-    };
+    bool const hasProcessingFlags =
+        numberLines || numberNonBlank || squeezeBlank || showEnds || showTabs || rangeSpecified;
 
     bool success = true;
 
@@ -775,8 +820,22 @@ int Shell::executeInlineCat(CoreVM::CoreStringArray const& args, NativeHandle ou
     {
         if (file == "-")
         {
-            auto const content = readFromFd(stdinFd);
-            processContent(content, tui::LanguageId::None);
+            if (hasProcessingFlags)
+            {
+                auto [content, exitCode] = interruptibleReadAll(stdinFd);
+                if (exitCode != 0)
+                    return exitCode;
+                processContent(content, tui::LanguageId::None);
+            }
+            else
+            {
+                // Stream directly for plain cat (best UX for interactive stdin)
+                auto const exitCode = interruptibleReadLoop(stdinFd, [outputFd](char const* buf, size_t len) {
+                    [[maybe_unused]] auto written = platformWrite(outputFd, buf, len);
+                });
+                if (exitCode != 0)
+                    return exitCode;
+            }
         }
         else
         {
@@ -872,8 +931,10 @@ int Shell::executeInlineCat(CoreVM::CoreStringArray const& args, NativeHandle ou
                 continue;
             }
             auto const fd = result.value();
-            auto const content = readFromFd(fd);
+            auto [content, exitCode] = interruptibleReadAll(fd);
             _processManager.closeHandle(fd);
+            if (exitCode != 0)
+                return exitCode;
 
             // Detect binary content (non-image files)
             if (!rawMode && outputIsTty)
@@ -1557,7 +1618,9 @@ int Shell::executeInlineCp(CoreVM::CoreStringArray const& args, NativeHandle out
             // Create the top-level target directory
             if (auto const mkResult = _fs.createDirectories(target); !mkResult.has_value())
             {
-                error("cp: cannot create directory '{}': {}", platform::normalizePath(target), mkResult.error());
+                error("cp: cannot create directory '{}': {}",
+                      platform::normalizePath(target),
+                      mkResult.error());
                 success = false;
                 continue;
             }
@@ -1571,7 +1634,9 @@ int Shell::executeInlineCp(CoreVM::CoreStringArray const& args, NativeHandle out
                 {
                     if (auto const mkResult = _fs.createDirectories(entryTarget); !mkResult.has_value())
                     {
-                        error("cp: cannot create directory '{}': {}", platform::normalizePath(entryTarget), mkResult.error());
+                        error("cp: cannot create directory '{}': {}",
+                              platform::normalizePath(entryTarget),
+                              mkResult.error());
                         success = false;
                     }
                 }
@@ -1594,12 +1659,16 @@ int Shell::executeInlineCp(CoreVM::CoreStringArray const& args, NativeHandle out
                     if (auto const cpResult = _fs.copyFile(entry.path, entryTarget, overwrite);
                         !cpResult.has_value())
                     {
-                        error("cp: cannot copy '{}': {}", platform::normalizePath(entry.path), cpResult.error());
+                        error("cp: cannot copy '{}': {}",
+                              platform::normalizePath(entry.path),
+                              cpResult.error());
                         success = false;
                         continue;
                     }
                     if (verbose)
-                        writeOutput(std::format("'{}' -> '{}'\n", platform::normalizePath(entry.path), platform::normalizePath(entryTarget)));
+                        writeOutput(std::format("'{}' -> '{}'\n",
+                                                platform::normalizePath(entry.path),
+                                                platform::normalizePath(entryTarget)));
                 }
             }
         }
@@ -1611,7 +1680,10 @@ int Shell::executeInlineCp(CoreVM::CoreStringArray const& args, NativeHandle out
 
             if (auto const cpResult = _fs.copyFile(srcPath, target, overwrite); !cpResult.has_value())
             {
-                error("cp: cannot copy '{}' to '{}': {}", src, platform::normalizePath(target), cpResult.error());
+                error("cp: cannot copy '{}' to '{}': {}",
+                      src,
+                      platform::normalizePath(target),
+                      cpResult.error());
                 success = false;
                 continue;
             }
@@ -1810,14 +1882,20 @@ int Shell::executeInlineMv(CoreVM::CoreStringArray const& args, NativeHandle out
                 // Recursive directory copy
                 if (auto const mkResult = _fs.createDirectories(target); !mkResult.has_value())
                 {
-                    error("mv: cannot move '{}' to '{}': {}", src, platform::normalizePath(target), mkResult.error());
+                    error("mv: cannot move '{}' to '{}': {}",
+                          src,
+                          platform::normalizePath(target),
+                          mkResult.error());
                     success = false;
                     continue;
                 }
                 auto const listResult = _fs.listDirectoryRecursive(srcPath);
                 if (!listResult.has_value())
                 {
-                    error("mv: cannot move '{}' to '{}': {}", src, platform::normalizePath(target), listResult.error());
+                    error("mv: cannot move '{}' to '{}': {}",
+                          src,
+                          platform::normalizePath(target),
+                          listResult.error());
                     success = false;
                     continue;
                 }
@@ -2205,15 +2283,9 @@ int Shell::executeInlineGrep(CoreVM::CoreStringArray const& args, NativeHandle o
     if (readingStdin)
     {
         // Read from stdin
-        std::string stdinData;
-        std::array<char, 4096> buffer {};
-        while (true)
-        {
-            auto const bytesRead = platformRead(stdinFd, buffer.data(), buffer.size());
-            if (bytesRead <= 0)
-                break;
-            stdinData.append(buffer.data(), static_cast<size_t>(bytesRead));
-        }
+        auto [stdinData, exitCode] = interruptibleReadAll(stdinFd);
+        if (exitCode != 0)
+            return exitCode;
 
         // Split into lines
         std::vector<std::string> lines;
@@ -2264,8 +2336,8 @@ int Shell::executeInlineGrep(CoreVM::CoreStringArray const& args, NativeHandle o
                 lines.push_back(std::move(line));
             }
 
-            auto const matches =
-                grep::searchLines(lines, *regex, opts, platform::normalizePath(filePath), showFilename, useColor, writer);
+            auto const matches = grep::searchLines(
+                lines, *regex, opts, platform::normalizePath(filePath), showFilename, useColor, writer);
             totalMatches += matches;
 
             // For -q, bail out early on first match
@@ -3464,68 +3536,77 @@ int Shell::executeInlineMktemp(CoreVM::CoreStringArray const& args, NativeHandle
 namespace
 {
 
-    std::vector<std::string> readLinesFromInput(NativeHandle stdinFd,
-                                                std::span<std::string const> files,
-                                                auto const& errorFn)
+    struct ReadLinesResult
     {
         std::vector<std::string> lines;
+        bool hadError = false;
+        int exitCode = 0;
+    };
+
+    ReadLinesResult readLinesFromInput(endo::NativeHandle stdinFd,
+                                       std::span<std::string const> files,
+                                       auto const& errorFn)
+    {
+        using namespace endo::platform;
+
+        ReadLinesResult result;
 
         auto const readFromStream = [&](std::istream& stream) {
             std::string line;
             while (std::getline(stream, line))
             {
+                SignalHandler::processSignalFd();
+                if (SignalHandler::hasPendingSigint())
+                {
+                    SignalHandler::clearPendingSigint();
+                    result.exitCode = 130;
+                    return;
+                }
                 if (!line.empty() && line.back() == '\r')
                     line.pop_back();
-                lines.push_back(std::move(line));
+                result.lines.push_back(std::move(line));
             }
+        };
+
+        auto const readFromStdin = [&]() {
+            auto [stdinData, exitCode] = interruptibleReadAll(stdinFd);
+            if (exitCode != 0)
+            {
+                result.exitCode = exitCode;
+                return;
+            }
+            std::istringstream iss(stdinData);
+            readFromStream(iss);
         };
 
         if (files.empty())
         {
-            // Read from stdin
-            std::string stdinData;
-            std::array<char, 4096> buffer {};
-            while (true)
-            {
-                auto const bytesRead = platformRead(stdinFd, buffer.data(), buffer.size());
-                if (bytesRead <= 0)
-                    break;
-                stdinData.append(buffer.data(), static_cast<size_t>(bytesRead));
-            }
-            std::istringstream iss(stdinData);
-            readFromStream(iss);
+            readFromStdin();
         }
         else
         {
             for (auto const& file: files)
             {
+                if (result.exitCode != 0)
+                    break;
                 if (file == "-")
                 {
-                    std::string stdinData;
-                    std::array<char, 4096> buffer {};
-                    while (true)
-                    {
-                        auto const bytesRead = platformRead(stdinFd, buffer.data(), buffer.size());
-                        if (bytesRead <= 0)
-                            break;
-                        stdinData.append(buffer.data(), static_cast<size_t>(bytesRead));
-                    }
-                    std::istringstream iss(stdinData);
-                    readFromStream(iss);
+                    readFromStdin();
                 }
                 else
                 {
-                    std::ifstream ifs(file);
+                    std::ifstream ifs(platform::resolveDevicePath(file));
                     if (!ifs)
                     {
                         errorFn(std::format("{}: No such file or directory", file));
+                        result.hadError = true;
                         continue;
                     }
                     readFromStream(ifs);
                 }
             }
         }
-        return lines;
+        return result;
     }
 
 } // namespace
@@ -3580,7 +3661,12 @@ int Shell::executeInlineHead(CoreVM::CoreStringArray const& args, NativeHandle o
     auto const errorFn = [this](std::string const& msg) {
         error("head: {}", msg);
     };
-    auto const lines = readLinesFromInput(stdinFd, files, errorFn);
+    auto const result = readLinesFromInput(stdinFd, files, errorFn);
+    if (result.exitCode != 0)
+        return result.exitCode;
+    if (result.hadError)
+        return 1;
+    auto const& lines = result.lines;
 
     auto const count = std::min(static_cast<size_t>(numLines), lines.size());
     for (auto const i: std::views::iota(0uz, count))
@@ -3654,7 +3740,7 @@ int Shell::executeInlineTail(CoreVM::CoreStringArray const& args, NativeHandle o
     {
         // Follow mode: open file once, stream last N lines via bounded deque, then follow
         auto const& filePath = files.back();
-        std::ifstream ifs(filePath);
+        std::ifstream ifs(platform::resolveDevicePath(filePath));
         if (!ifs)
         {
             error("tail: cannot open '{}': No such file or directory", filePath);
@@ -3705,7 +3791,10 @@ int Shell::executeInlineTail(CoreVM::CoreStringArray const& args, NativeHandle o
         auto const errorFn = [this](std::string const& msg) {
             error("tail: {}", msg);
         };
-        auto const lines = readLinesFromInput(stdinFd, files, errorFn);
+        auto const result = readLinesFromInput(stdinFd, files, errorFn);
+        if (result.exitCode != 0)
+            return result.exitCode;
+        auto const& lines = result.lines;
         auto const start =
             lines.size() > static_cast<size_t>(numLines) ? lines.size() - static_cast<size_t>(numLines) : 0uz;
         for (auto const i: std::views::iota(start, lines.size()))
@@ -3750,7 +3839,12 @@ int Shell::executeInlineTail(CoreVM::CoreStringArray const& args, NativeHandle o
     auto const errorFn = [this](std::string const& msg) {
         error("tail: {}", msg);
     };
-    auto const lines = readLinesFromInput(stdinFd, files, errorFn);
+    auto const result = readLinesFromInput(stdinFd, files, errorFn);
+    if (result.exitCode != 0)
+        return result.exitCode;
+    if (result.hadError)
+        return 1;
+    auto const& lines = result.lines;
 
     auto const start =
         lines.size() > static_cast<size_t>(numLines) ? lines.size() - static_cast<size_t>(numLines) : 0uz;
@@ -3975,7 +4069,12 @@ int Shell::executeInlineWc(CoreVM::CoreStringArray const& args, NativeHandle out
     auto const errorFn = [this](std::string const& msg) {
         error("wc: {}", msg);
     };
-    auto const lines = readLinesFromInput(stdinFd, files, errorFn);
+    auto const result = readLinesFromInput(stdinFd, files, errorFn);
+    if (result.exitCode != 0)
+        return result.exitCode;
+    if (result.hadError)
+        return 1;
+    auto const& lines = result.lines;
 
     size_t totalLines = lines.size();
     size_t totalWords = 0;
@@ -4089,7 +4188,12 @@ int Shell::executeInlineSort(CoreVM::CoreStringArray const& args, NativeHandle o
     auto const errorFn = [this](std::string const& msg) {
         error("sort: {}", msg);
     };
-    auto lines = readLinesFromInput(stdinFd, files, errorFn);
+    auto result = readLinesFromInput(stdinFd, files, errorFn);
+    if (result.exitCode != 0)
+        return result.exitCode;
+    if (result.hadError)
+        return 1;
+    auto& lines = result.lines;
 
     // Extract key field helper
     auto const getKey = [keyField](std::string_view line) -> std::string_view {
@@ -4199,7 +4303,12 @@ int Shell::executeInlineUniq(CoreVM::CoreStringArray const& args, NativeHandle o
     auto const errorFn = [this](std::string const& msg) {
         error("uniq: {}", msg);
     };
-    auto const lines = readLinesFromInput(stdinFd, files, errorFn);
+    auto const result = readLinesFromInput(stdinFd, files, errorFn);
+    if (result.exitCode != 0)
+        return result.exitCode;
+    if (result.hadError)
+        return 1;
+    auto const& lines = result.lines;
 
     auto const compareEqual = [ignoreCase](std::string_view a, std::string_view b) {
         if (!ignoreCase)
@@ -4347,7 +4456,12 @@ int Shell::executeInlineCut(CoreVM::CoreStringArray const& args, NativeHandle ou
     auto const errorFn = [this](std::string const& msg) {
         error("cut: {}", msg);
     };
-    auto const lines = readLinesFromInput(stdinFd, files, errorFn);
+    auto const result = readLinesFromInput(stdinFd, files, errorFn);
+    if (result.exitCode != 0)
+        return result.exitCode;
+    if (result.hadError)
+        return 1;
+    auto const& lines = result.lines;
 
     if (!fieldSpec.empty())
     {
@@ -4509,15 +4623,9 @@ int Shell::executeInlineTr(CoreVM::CoreStringArray const& args, NativeHandle out
     auto const expandedSet2 = expandRange(set2);
 
     // Read stdin
-    std::string inputData;
-    std::array<char, 4096> buffer {};
-    while (true)
-    {
-        auto const bytesRead = platformRead(stdinFd, buffer.data(), buffer.size());
-        if (bytesRead <= 0)
-            break;
-        inputData.append(buffer.data(), static_cast<size_t>(bytesRead));
-    }
+    auto [inputData, exitCode] = interruptibleReadAll(stdinFd);
+    if (exitCode != 0)
+        return exitCode;
 
     std::string output;
     output.reserve(inputData.size());
@@ -4597,7 +4705,7 @@ int Shell::executeInlineTee(CoreVM::CoreStringArray const& args, NativeHandle ou
         auto mode = std::ios::out;
         if (appendMode)
             mode |= std::ios::app;
-        outStreams.emplace_back(file, mode);
+        outStreams.emplace_back(platform::resolveDevicePath(file), mode);
         if (!outStreams.back())
         {
             error("tee: {}: Permission denied", file);
@@ -4606,19 +4714,13 @@ int Shell::executeInlineTee(CoreVM::CoreStringArray const& args, NativeHandle ou
     }
 
     // Read from stdin, write to stdout + files
-    std::array<char, 4096> buffer {};
-    while (true)
-    {
-        auto const bytesRead = platformRead(stdinFd, buffer.data(), buffer.size());
-        if (bytesRead <= 0)
-            break;
-
-        auto const data = std::string_view(buffer.data(), static_cast<size_t>(bytesRead));
-        [[maybe_unused]] auto written = platformWrite(outputFd, data.data(), data.size());
-
+    auto const exitCode = interruptibleReadLoop(stdinFd, [&](char const* buf, size_t len) {
+        [[maybe_unused]] auto written = platformWrite(outputFd, buf, len);
         for (auto& ofs: outStreams)
-            ofs.write(data.data(), static_cast<std::streamsize>(data.size()));
-    }
+            ofs.write(buf, static_cast<std::streamsize>(len));
+    });
+    if (exitCode != 0)
+        return exitCode;
 
     return 0;
 }


### PR DESCRIPTION
Fixes #98.

Builtins that read from stdin (`cat`, `grep`, `head`, `tail`, `wc`, `sort`, `uniq`, `cut`, `tr`, `tee`) used blocking `platformRead()` loops that could not be interrupted by Ctrl+C. On Linux, `SIGINT` is blocked via `sigprocmask` and routed to `signalfd`, so `read()` never returns when the user presses Ctrl+C. On macOS, `SA_RESTART` causes `read()` to auto-restart. Either way, a builtin waiting on stdin was effectively unkillable without closing the terminal.

## Changes

- Add `interruptibleReadLoop()` and `interruptibleReadAll()` helpers that use `poll()` with a 100 ms timeout and check `SignalHandler::hasPendingSigint()` between polls — the same pattern already used by `tail -f` and `sleep`.
- Plain `cat` (no flags) now streams output chunk-by-chunk via `interruptibleReadLoop` for responsive interactive UX. `cat` with flags buffers and then processes.
- File reads are interruptible between 4 KB chunks; `readLinesFromInput` checks `SIGINT` between lines for file reads.
- Ctrl+D (EOF) already worked via `Prompt::ScopedSuspend` restoring cooked terminal mode during command execution — no change needed there.