### PR TITLE
Async git status in the prompt + Windows pipe EOF fix

### DIFF
--- a/src/platform/Types.hpp
+++ b/src/platform/Types.hpp
@@ -122,15 +122,27 @@ inline auto platformWrite(NativeHandle h, void const* data, size_t size) -> intp
 
 /// Cross-platform read using Windows ReadFile.
 ///
+/// Semantics match POSIX `read(2)`: returns the number of bytes read, 0 on
+/// end-of-file (including the case where a pipe's write end has been closed
+/// and the buffer is drained), or -1 on a genuine I/O error.
+///
 /// @param h The native handle to read from.
 /// @param data Pointer to buffer to read into.
 /// @param size Maximum number of bytes to read.
-/// @return Number of bytes read, or -1 on error.
+/// @return Bytes read, 0 on EOF / broken pipe, or -1 on error.
 inline auto platformRead(NativeHandle h, void* data, size_t size) -> intptr_t
 {
     DWORD bytesRead = 0;
     if (!ReadFile(h, data, static_cast<DWORD>(size), &bytesRead, nullptr))
+    {
+        // ERROR_BROKEN_PIPE / ERROR_HANDLE_EOF are stream terminators, not
+        // errors — normalize them to POSIX-style EOF so the cross-platform
+        // abstraction is uniform for callers that distinguish EOF from error.
+        auto const err = GetLastError();
+        if (err == ERROR_BROKEN_PIPE || err == ERROR_HANDLE_EOF)
+            return 0;
         return -1;
+    }
     return static_cast<intptr_t>(bytesRead);
 }
 
@@ -169,7 +181,7 @@ inline auto platformWrite(NativeHandle fd, void const* data, size_t size) -> int
 /// @param fd The file descriptor to read from.
 /// @param data Pointer to buffer to read into.
 /// @param size Maximum number of bytes to read.
-/// @return Number of bytes read, or -1 on error.
+/// @return Bytes read, 0 on EOF / broken pipe, or -1 on error.
 inline auto platformRead(NativeHandle fd, void* data, size_t size) -> intptr_t
 {
     return static_cast<intptr_t>(::read(fd, data, size));

--- a/src/platform/WindowsPlatform_test.cpp
+++ b/src/platform/WindowsPlatform_test.cpp
@@ -1,11 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
 #include <cstdlib>
+#include <string_view>
 
 #include <platform/PathUtils.hpp>
+#include <platform/Types.hpp>
 #include <platform/UserPaths.hpp>
 #include <testing/EnvHelper.hpp>
+
+#if defined(_WIN32)
+    #include <windows.h>
+#else
+    #include <unistd.h>
+#endif
 
 using namespace endo::platform;
 
@@ -168,4 +177,50 @@ TEST_CASE("configHome.falls_back_to_home_dot_config", "[platform]")
         endo::testing::setTestEnv("HOME", savedHome.c_str());
     else
         endo::testing::unsetTestEnv("HOME");
+}
+
+TEST_CASE("platformRead.returns_zero_on_closed_pipe_eof", "[platform]")
+{
+    // Regression guard: on Windows, ReadFile on a drained pipe whose writer has
+    // closed fails with ERROR_BROKEN_PIPE. platformRead must normalize that to
+    // a POSIX-style EOF (return 0), not an I/O error (return -1).
+
+#if defined(_WIN32)
+    HANDLE readEnd = nullptr;
+    HANDLE writeEnd = nullptr;
+    REQUIRE(CreatePipe(&readEnd, &writeEnd, nullptr, 0) != 0);
+    auto const readH = static_cast<NativeHandle>(readEnd);
+
+    auto const payload = std::string_view { "hi" };
+    DWORD written = 0;
+    REQUIRE(WriteFile(writeEnd, payload.data(), static_cast<DWORD>(payload.size()), &written, nullptr) != 0);
+    CHECK(written == payload.size());
+    CloseHandle(writeEnd);
+#else
+    int fds[2] = { -1, -1 };
+    REQUIRE(::pipe(fds) == 0);
+    auto const readH = fds[0];
+    auto const writeH = fds[1];
+
+    auto const payload = std::string_view { "hi" };
+    auto const expected = static_cast<intptr_t>(payload.size());
+    auto const w = static_cast<intptr_t>(::write(writeH, payload.data(), payload.size()));
+    REQUIRE(w == expected);
+    ::close(writeH);
+#endif
+
+    std::array<char, 16> buf {};
+    auto const first = platformRead(readH, buf.data(), buf.size());
+    CHECK(first == 2);
+    CHECK(std::string_view(buf.data(), static_cast<size_t>(first)) == "hi");
+
+    // Second call: buffer empty, writer closed. Must be EOF, not error.
+    auto const second = platformRead(readH, buf.data(), buf.size());
+    CHECK(second == 0);
+
+#if defined(_WIN32)
+    CloseHandle(readEnd);
+#else
+    ::close(readH);
+#endif
 }

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -258,6 +258,7 @@ add_executable(test-endo-shell
     commands/TimeoutCommand_test.cpp
     CrashHandler_test.cpp
     ui/PromptComponent_test.cpp
+    ui/modules/GitModule_test.cpp
     ui/Gradient_test.cpp
     completion/Completer_test.cpp
     completion/FSharpCompleter_test.cpp

--- a/src/shell/ui/modules/GitModule.cpp
+++ b/src/shell/ui/modules/GitModule.cpp
@@ -6,7 +6,10 @@
 
 #include <array>
 #include <cstdio>
+#include <memory>
 #include <string>
+#include <thread>
+#include <utility>
 
 #if defined(_WIN32)
     #define popen  _popen
@@ -38,11 +41,11 @@ namespace
         return result;
     }
 
-    /// @brief Queries git status using a single command.
+    /// @brief Default query implementation: invokes `git status` via popen.
     ///
     /// Extracts branch name from `# branch.head` header and dirty/staged counts
-    /// from porcelain v2 change entries. Avoids the separate `git rev-parse` call.
-    [[nodiscard]] auto queryGitInfo(std::string const& cwd) -> GitInfo
+    /// from porcelain v2 change entries.
+    [[nodiscard]] auto defaultQueryGitInfo(std::string const& cwd) -> GitInfo
     {
         auto info = GitInfo {};
 
@@ -92,17 +95,69 @@ namespace
 
 } // namespace
 
+GitModule::GitModule(QueryFn queryFn):
+    _queryFn(queryFn ? std::move(queryFn) : QueryFn { &defaultQueryGitInfo })
+{
+}
+
+void GitModule::consumePendingIfReady(std::string const& cwd) const
+{
+    if (!_pending)
+        return;
+    if (!_pending->ready.load(std::memory_order_acquire))
+        return;
+
+    // Acquire above pairs with the worker's release-store after writing result;
+    // the read below sees the fully-constructed GitInfo.
+    if (_pending->cwd == cwd)
+    {
+        _cache = std::move(_pending->result);
+        _cachedCwd = _pending->cwd;
+        _cacheTime = std::chrono::steady_clock::now();
+        _cachePopulated = true;
+    }
+    _pending.reset();
+}
+
+void GitModule::launchFetch(std::string const& cwd) const
+{
+    auto slot = std::make_shared<PendingFetch>();
+    slot->cwd = cwd;
+    _pending = slot;
+
+    // The worker owns its own shared_ptr to `slot`, so the slot outlives the
+    // GitModule if the main thread clears `_pending` (e.g., cwd changed) or
+    // the module is destroyed while the worker is still running.
+    std::thread([slot, cwd, query = _queryFn]() mutable {
+        slot->result = query(cwd);
+        slot->ready.store(true, std::memory_order_release);
+    }).detach();
+}
+
 void GitModule::refreshIfNeeded(std::string const& cwd) const
 {
-    auto const now = std::chrono::steady_clock::now();
+    consumePendingIfReady(cwd);
 
+    auto const now = std::chrono::steady_clock::now();
     if (_cachePopulated && _cachedCwd == cwd && (now - _cacheTime) < _cacheTtl)
         return;
 
-    _cache = queryGitInfo(cwd);
-    _cachedCwd = cwd;
-    _cacheTime = now;
-    _cachePopulated = true;
+    // An in-flight fetch for a different cwd is stale: drop our handle. The
+    // worker still holds a shared_ptr to the slot and runs to completion, but
+    // its result is never consumed because the shared slot is no longer
+    // referenced by us.
+    if (_pending && _pending->cwd != cwd)
+        _pending.reset();
+
+    if (!_pending)
+        launchFetch(cwd);
+}
+
+std::optional<std::chrono::milliseconds> GitModule::refreshInterval() const
+{
+    if (_pending)
+        return _pendingInterval;
+    return _idleInterval;
 }
 
 bool GitModule::shouldShow(PromptContext const& ctx) const

--- a/src/shell/ui/modules/GitModule.hpp
+++ b/src/shell/ui/modules/GitModule.hpp
@@ -3,7 +3,10 @@
 
 #include <shell/ui/PromptModule.hpp>
 
+#include <atomic>
 #include <chrono>
+#include <functional>
+#include <memory>
 #include <string>
 
 namespace endo
@@ -21,11 +24,20 @@ struct GitInfo
 /// @brief Prompt module that displays Git branch and status information.
 ///
 /// Shows the current branch name with color-coded dirty/clean/staged states.
-/// Uses a single `git status --porcelain=v2 --branch` call with TTL-based caching
-/// to minimize subprocess overhead.
+/// The `git status --porcelain=v2 --branch` subprocess runs on a background
+/// thread so the prompt never blocks the main event loop; the prompt is
+/// redrawn once the result arrives.
 class GitModule final: public PromptModule
 {
   public:
+    /// @brief Function that fetches git info for a given cwd.
+    using QueryFn = std::function<GitInfo(std::string const&)>;
+
+    /// @brief Constructs the module.
+    /// @param queryFn Query implementation. Defaults to the `popen`-based
+    ///                `git status` call. Tests inject a mock to control timing.
+    explicit GitModule(QueryFn queryFn = {});
+
     [[nodiscard]] std::string_view id() const noexcept override { return "git"; }
 
     [[nodiscard]] ModuleSensitivity sensitivity() const override { return ModuleSensitivity::CwdChange; }
@@ -33,28 +45,59 @@ class GitModule final: public PromptModule
     [[nodiscard]] PromptSegments evaluate(PromptContext const& ctx) const override;
     [[nodiscard]] bool shouldShow(PromptContext const& ctx) const override;
 
-    [[nodiscard]] std::optional<std::chrono::milliseconds> refreshInterval() const override
-    {
-        return std::chrono::seconds(5);
-    }
+    /// @brief Returns a short refresh interval while a background fetch is in
+    ///        flight (so the prompt ticks until the result arrives) and a long
+    ///        idle interval otherwise.
+    [[nodiscard]] std::optional<std::chrono::milliseconds> refreshInterval() const override;
 
     void invalidateCache() override { _cachePopulated = false; }
 
-    /// @brief Returns the cached git info from the most recent query.
+    /// @brief Returns the cached git info from the most recent completed query.
     [[nodiscard]] GitInfo const& cachedInfo() const noexcept { return _cache; }
 
   private:
+    /// @brief Shared slot for communication with a detached worker thread.
+    ///
+    /// The worker writes `result` and then stores `ready = true` with release
+    /// ordering; the main thread observes `ready` with acquire ordering and
+    /// then reads `result`. `cwd` is written only on launch (main thread,
+    /// before the worker starts) and is never mutated afterwards.
+    struct PendingFetch
+    {
+        std::string cwd;
+        std::atomic<bool> ready { false };
+        GitInfo result;
+    };
+
     /// @brief TTL for git info cache.
     static constexpr auto _cacheTtl = std::chrono::seconds(3); // NOLINT(readability-identifier-naming)
 
-    /// @brief Refreshes the cache if the CWD changed or the TTL expired.
-    /// @param cwd The current working directory.
+    /// @brief Refresh interval while no background fetch is in flight.
+    static constexpr auto _idleInterval = // NOLINT(readability-identifier-naming)
+        std::chrono::seconds(5);
+
+    /// @brief Refresh interval while a background fetch is in flight.
+    static constexpr auto _pendingInterval = // NOLINT(readability-identifier-naming)
+        std::chrono::milliseconds(150);
+
+    /// @brief Consumes a completed fetch into `_cache` (if the cwd still
+    ///        matches) and clears `_pending`. No-op if no fetch is pending or
+    ///        the worker has not finished yet.
+    void consumePendingIfReady(std::string const& cwd) const;
+
+    /// @brief Launches a detached worker thread to fetch git info for `cwd`.
+    void launchFetch(std::string const& cwd) const;
+
+    /// @brief Ensures a fresh git info result is either cached or being fetched
+    ///        for `cwd`. Never blocks.
     void refreshIfNeeded(std::string const& cwd) const;
 
+    QueryFn _queryFn;
     mutable GitInfo _cache;
     mutable std::string _cachedCwd;
     mutable std::chrono::steady_clock::time_point _cacheTime;
     mutable bool _cachePopulated = false;
+    mutable std::shared_ptr<PendingFetch> _pending;
 };
 
 } // namespace endo

--- a/src/shell/ui/modules/GitModule_test.cpp
+++ b/src/shell/ui/modules/GitModule_test.cpp
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <catch2/catch_test_macros.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "GitModule.hpp"
+
+using namespace endo;
+using namespace std::chrono_literals;
+
+namespace
+{
+
+/// @brief Copyable query stub: N independent promises, one per expected fetch.
+///
+/// Each invocation consumes the next promise. The test fulfills them in order
+/// via `fulfill(index, GitInfo)`. Shared state is held in a `Shared` struct
+/// via `shared_ptr`, so every copy of the stub (the test's copy and the one
+/// stored inside GitModule's `std::function`) sees the same state.
+struct ControlledQuery
+{
+    struct Shared
+    {
+        std::atomic<int> callCount { 0 };
+        std::vector<std::shared_ptr<std::promise<GitInfo>>> promises;
+        std::atomic<std::thread::id> lastThreadId;
+        std::mutex cwdMutex;
+        std::string lastCwd;
+    };
+
+    std::shared_ptr<Shared> shared = std::make_shared<Shared>();
+
+    explicit ControlledQuery(int expectedCalls = 1)
+    {
+        for (auto i = 0; i < expectedCalls; ++i)
+            shared->promises.push_back(std::make_shared<std::promise<GitInfo>>());
+    }
+
+    GitInfo operator()(std::string const& cwd) const
+    {
+        auto const n = shared->callCount.fetch_add(1, std::memory_order_relaxed);
+        shared->lastThreadId.store(std::this_thread::get_id(), std::memory_order_relaxed);
+        {
+            auto const lock = std::scoped_lock { shared->cwdMutex };
+            shared->lastCwd = cwd;
+        }
+        // at() throws if the test didn't reserve enough promises — turns a
+        // missing expectation into a clear test failure rather than UB.
+        return shared->promises.at(static_cast<size_t>(n))->get_future().get();
+    }
+
+    void fulfill(int index, GitInfo info) const
+    {
+        shared->promises.at(static_cast<size_t>(index))->set_value(std::move(info));
+    }
+
+    [[nodiscard]] int calls() const { return shared->callCount.load(std::memory_order_relaxed); }
+
+    [[nodiscard]] std::thread::id workerThreadId() const
+    {
+        return shared->lastThreadId.load(std::memory_order_relaxed);
+    }
+};
+
+GitInfo makeGit(std::string branch, int dirty = 0, int staged = 0)
+{
+    return GitInfo { .branch = std::move(branch), .dirty = dirty, .staged = staged, .valid = true };
+}
+
+PromptContext ctxAt(std::string cwd)
+{
+    auto ctx = PromptContext {};
+    ctx.cwd = std::move(cwd);
+    return ctx;
+}
+
+/// @brief Polls a predicate every 1 ms up to a deadline — avoids fixed sleeps.
+template <typename Pred>
+bool waitUntil(Pred pred, std::chrono::milliseconds timeout = 2s)
+{
+    auto const deadline = std::chrono::steady_clock::now() + timeout;
+    while (!pred())
+    {
+        if (std::chrono::steady_clock::now() >= deadline)
+            return false;
+        std::this_thread::sleep_for(1ms);
+    }
+    return true;
+}
+
+} // namespace
+
+TEST_CASE("GitModule.issue_99_evaluate_does_not_block_on_slow_query", "[git][prompt]")
+{
+    // Reproducer for issue #99: a slow `git status` must not stall the prompt.
+    // Before the fix, evaluate() blocked on popen; now it must return promptly
+    // and surface the data on a later call once the worker has finished.
+    auto query = ControlledQuery { /*expectedCalls=*/1 };
+    auto mod = GitModule(query);
+
+    auto const start = std::chrono::steady_clock::now();
+    auto const segments = mod.evaluate(ctxAt("/repo"));
+    auto const elapsed = std::chrono::steady_clock::now() - start;
+
+    CHECK(elapsed < 100ms);
+    CHECK(segments.empty()); // No git info yet — fetch still in flight.
+
+    query.fulfill(0, makeGit("main"));
+    CHECK(waitUntil([&] { return !mod.evaluate(ctxAt("/repo")).empty(); }));
+}
+
+TEST_CASE("GitModule.evaluate_returns_empty_segments_while_fetch_is_pending", "[git][prompt]")
+{
+    auto query = ControlledQuery { 1 };
+    auto mod = GitModule(query);
+
+    CHECK(mod.evaluate(ctxAt("/repo")).empty());
+    CHECK(mod.evaluate(ctxAt("/repo")).empty());
+    // One fetch per distinct cwd — repeated evaluate() while pending is a no-op.
+    // The worker may not have run yet; wait until it has observed the call.
+    CHECK(waitUntil([&] { return query.calls() == 1; }));
+
+    query.fulfill(0, makeGit("main"));
+    CHECK(waitUntil([&] { return !mod.evaluate(ctxAt("/repo")).empty(); }));
+}
+
+TEST_CASE("GitModule.evaluate_returns_cached_result_after_fetch_completes", "[git][prompt]")
+{
+    auto query = ControlledQuery { 1 };
+    auto mod = GitModule(query);
+
+    CHECK(mod.evaluate(ctxAt("/repo")).empty());
+    query.fulfill(0, makeGit("feature", /*dirty=*/2, /*staged=*/1));
+
+    REQUIRE(waitUntil([&] { return !mod.evaluate(ctxAt("/repo")).empty(); }));
+
+    auto const segments = mod.evaluate(ctxAt("/repo"));
+    REQUIRE(segments.size() == 2); // branch + indicator
+    CHECK(segments[0].text.find("feature") != std::string::npos);
+    CHECK(segments[1].text == " !2 +1");
+}
+
+TEST_CASE("GitModule.refreshInterval_is_short_while_pending_and_long_when_idle", "[git][prompt]")
+{
+    auto query = ControlledQuery { 1 };
+    auto mod = GitModule(query);
+
+    // Before any evaluate() call, no fetch is in flight.
+    REQUIRE(mod.refreshInterval().has_value());
+    CHECK(mod.refreshInterval().value() == 5s);
+
+    (void) mod.evaluate(ctxAt("/repo"));
+
+    auto const pending = mod.refreshInterval();
+    REQUIRE(pending.has_value());
+    CHECK(pending.value() == 150ms);
+
+    query.fulfill(0, makeGit("main"));
+    // Drain the fetch by calling evaluate() until the cache is populated.
+    REQUIRE(waitUntil([&] { return !mod.evaluate(ctxAt("/repo")).empty(); }));
+
+    auto const idle = mod.refreshInterval();
+    REQUIRE(idle.has_value());
+    CHECK(idle.value() == 5s);
+}
+
+TEST_CASE("GitModule.superseded_fetch_is_discarded_when_cwd_changes_mid_flight", "[git][prompt]")
+{
+    // Two fetches: one for /a (superseded), one for /b (applied).
+    auto query = ControlledQuery { 2 };
+    auto mod = GitModule(query);
+
+    // 1. cd into /a — launches fetch #0 for /a.
+    CHECK(mod.evaluate(ctxAt("/a")).empty());
+
+    // 2. cd into /b BEFORE fetch #0 completes — launches fetch #1 for /b and
+    //    drops the reference to fetch #0's slot.
+    CHECK(mod.evaluate(ctxAt("/b")).empty());
+    CHECK(waitUntil([&] { return query.calls() == 2; }));
+
+    // 3. Fetch #0 resolves with /a's result. It must NOT populate the cache.
+    query.fulfill(0, makeGit("branch-a"));
+
+    // Let the worker finish its store; a short poll window is enough because
+    // we're only racing on the worker storing `ready = true`.
+    std::this_thread::sleep_for(50ms);
+    CHECK(mod.evaluate(ctxAt("/b")).empty());
+    CHECK_FALSE(mod.cachedInfo().valid);
+
+    // 4. Fetch #1 resolves with /b's result. This one IS applied.
+    query.fulfill(1, makeGit("branch-b"));
+    REQUIRE(waitUntil([&] { return !mod.evaluate(ctxAt("/b")).empty(); }));
+    CHECK(mod.cachedInfo().branch == "branch-b");
+}
+
+TEST_CASE("GitModule.invalidateCache_triggers_new_background_fetch", "[git][prompt]")
+{
+    auto query = ControlledQuery { 2 };
+    auto mod = GitModule(query);
+
+    (void) mod.evaluate(ctxAt("/repo"));
+    query.fulfill(0, makeGit("main"));
+    REQUIRE(waitUntil([&] { return !mod.evaluate(ctxAt("/repo")).empty(); }));
+    REQUIRE(query.calls() == 1);
+
+    mod.invalidateCache();
+
+    // First evaluate after invalidate launches a new fetch. The stale cache
+    // (from fetch #0) may still be shown while the refresh runs — that is
+    // intentional (avoids a brief blank flicker after every command).
+    (void) mod.evaluate(ctxAt("/repo"));
+    CHECK(waitUntil([&] { return query.calls() == 2; }));
+
+    query.fulfill(1, makeGit("main", /*dirty=*/3));
+    // Drain the pending fetch on the main thread.
+    REQUIRE(waitUntil([&] {
+        (void) mod.evaluate(ctxAt("/repo"));
+        return mod.cachedInfo().dirty == 3;
+    }));
+}
+
+TEST_CASE("GitModule.repeated_evaluate_within_ttl_does_not_launch_new_fetch", "[git][prompt]")
+{
+    auto query = ControlledQuery { 1 };
+    auto mod = GitModule(query);
+
+    (void) mod.evaluate(ctxAt("/repo"));
+    query.fulfill(0, makeGit("main"));
+    REQUIRE(waitUntil([&] { return !mod.evaluate(ctxAt("/repo")).empty(); }));
+    REQUIRE(query.calls() == 1);
+
+    for (auto i = 0; i < 5; ++i)
+        (void) mod.evaluate(ctxAt("/repo"));
+
+    // TTL (3 s) has not elapsed — still exactly one invocation.
+    CHECK(query.calls() == 1);
+}
+
+TEST_CASE("GitModule.query_runs_off_the_main_thread", "[git][prompt]")
+{
+    auto query = ControlledQuery { 1 };
+    auto mod = GitModule(query);
+    auto const mainId = std::this_thread::get_id();
+
+    (void) mod.evaluate(ctxAt("/repo"));
+    // The worker records its thread id before blocking on the promise — a
+    // short poll is enough to observe it.
+    CHECK(waitUntil([&] { return query.workerThreadId() != std::thread::id {}; }));
+    CHECK(query.workerThreadId() != mainId);
+
+    query.fulfill(0, makeGit("main"));
+    // Drain on the main thread — consumePendingIfReady runs inside evaluate().
+    CHECK(waitUntil([&] {
+        (void) mod.evaluate(ctxAt("/repo"));
+        return mod.cachedInfo().valid;
+    }));
+}


### PR DESCRIPTION
This PR bundles two fixes that shipped together on the same branch.

## 1. Async git status in the prompt (fixes #99)

The `git` prompt module ran `git status --porcelain=v2 --branch` synchronously via `popen` on the main thread, so every `cd` into a repository blocked the shell for the full query duration — ~7 s in a medium repo, ~30 s in LLVM. Keystrokes were dropped during that window.

The subprocess now runs on a detached worker thread. A shared `PendingFetch` slot carries the cwd and result; the worker signals completion with an atomic release-store, the main thread drains the slot with an acquire-load on the next `evaluate()`. Stale in-flight fetches (cwd changed mid-flight) are dropped: the worker runs to completion, but its result is never consumed.

While a fetch is pending the module advertises a 150 ms `refreshInterval` so the existing `PromptComponent` / `Prompt::read()` deadline machinery re-renders promptly once the result lands — no event-loop changes were needed.

### Changes

- `GitModule` takes an injectable `QueryFn` and replaces the synchronous `popen` call with a detached `std::thread` per fetch, gated by a `shared_ptr<PendingFetch>` slot.
- `refreshInterval()` returns 150 ms while a fetch is in flight and 5 s otherwise, driving the prompt to redraw promptly when data arrives.
- Catch2 tests cover the issue reproducer, cwd-change supersession, cache invalidation, TTL deduplication, and the off-main-thread invariant.

## 2. Normalize `platformRead` to POSIX EOF semantics on Windows

The `Windows clang-cl Release` CI job was failing on this branch with ~15 tests in `Shell_test.cpp` all reporting empty output from builtin-to-builtin pipes (`echo … | grep …`, `echo … | cat -E`, etc.). The regression was inherited from master (first appears at `1102bec6`, merge of #102) and had nothing to do with the git-status change.

Root cause: `platformRead` on Windows wrapped `ReadFile` and returned -1 when the write end of a drained pipe was closed (`ERROR_BROKEN_PIPE`). POSIX `read()` returns 0 for the equivalent EOF case. Every existing caller used `bytesRead <= 0` and so masked the mismatch — until #102's new `interruptibleReadLoop` introduced a strict `< 0` vs `== 0` distinction, which on Windows misclassified EOF as an I/O error and aborted the downstream builtin with exit code 1.

Fix: normalize `ERROR_BROKEN_PIPE` and `ERROR_HANDLE_EOF` to a 0 return in the Windows branch of `platformRead`. Added a platform-neutral regression test in `WindowsPlatform_test.cpp` that pipes, closes the writer, drains, and asserts the terminating read returns 0 (not -1).