### PR TITLE
Add CWD-aware history ranking and required-paths validation

### DIFF
--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -109,6 +109,8 @@ add_library(endo-shell STATIC
     history/History.cpp
     history/PersistentHistory.hpp
     history/PersistentHistory.cpp
+    history/RequiredPaths.hpp
+    history/RequiredPaths.cpp
 
     # Structured Output
     output/OutputDefinition.hpp
@@ -267,6 +269,7 @@ add_executable(test-endo-shell
     completion/ScriptedCompleter_test.cpp
     history/History_test.cpp
     history/PersistentHistory_test.cpp
+    history/RequiredPaths_test.cpp
     output/OutputDefinitionRegistry_test.cpp
     output/OutputParser_test.cpp
     util/CommandResolver_test.cpp

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -1323,7 +1323,7 @@ int Shell::run()
             if (!lineBuffer.empty())
             {
                 prompt.addHistory(lineBuffer);
-                auto const homeEnv = _env.get("HOME").value_or(std::string {});
+                auto const homeEnv = normalizedHomeDirectory(_env);
                 auto const cwdAbs = _env.currentDirectory();
                 history.add(
                     lineBuffer,
@@ -1441,7 +1441,7 @@ int Shell::run()
         if (!lineBuffer.empty())
         {
             prompt.addHistory(lineBuffer);
-            auto const homeEnv = _env.get("HOME").value_or(std::string {});
+            auto const homeEnv = normalizedHomeDirectory(_env);
             auto const cwdAbs = _env.currentDirectory();
             history.add(lineBuffer,
                         HistoryAddContext {

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -2,6 +2,7 @@
 #include "Shell.hpp"
 #include <shell/builtins/InlineCommandDescriptor.hpp>
 #include <shell/completion/ScriptedCompleter.hpp>
+#include <shell/history/RequiredPaths.hpp>
 #include <shell/ui/Prompt.hpp>
 #include <shell/ui/PromptPresets.hpp>
 #include <shell/ui/RichConsoleReport.hpp>
@@ -959,14 +960,16 @@ void Shell::loadInitScript()
         {
             if (auto content = _fs.readFile(initPath))
             {
-                if (auto const initResult = executeConfigScript(*content, platform::normalizePath(initPath)); initResult != 0)
+                if (auto const initResult = executeConfigScript(*content, platform::normalizePath(initPath));
+                    initResult != 0)
                     _tty.writeToStderr(
                         std::format("endo: warning: init.endo exited with code {}\n", initResult));
             }
             else
             {
-                _tty.writeToStderr(
-                    std::format("endo: warning: error loading {}: {}\n", platform::normalizePath(initPath), content.error()));
+                _tty.writeToStderr(std::format("endo: warning: error loading {}: {}\n",
+                                               platform::normalizePath(initPath),
+                                               content.error()));
             }
         }
     }
@@ -1042,8 +1045,9 @@ void Shell::loadCompleters()
             }
             else
             {
-                _tty.writeToStderr(std::format(
-                    "endo: warning: error loading completer {}: {}\n", platform::normalizePath(path), content.error()));
+                _tty.writeToStderr(std::format("endo: warning: error loading completer {}: {}\n",
+                                               platform::normalizePath(path),
+                                               content.error()));
             }
         }
     };
@@ -1150,9 +1154,11 @@ void Shell::ensureInteractiveReady()
     history.autoImportIfEmpty();
 
     // Initialize completion system
-    completer = std::make_unique<Completer>(_env, history, _fsharpState);
+    completer = std::make_unique<Completer>(_env, history, _fsharpState, &_fs);
     prompt.setCompleter(completer.get());
     prompt.setHistory(&history);
+    prompt.setEnvironmentProvider(&_env);
+    prompt.setFileSystem(&_fs);
 }
 
 int Shell::run()
@@ -1317,7 +1323,14 @@ int Shell::run()
             if (!lineBuffer.empty())
             {
                 prompt.addHistory(lineBuffer);
-                history.add(lineBuffer);
+                auto const homeEnv = _env.get("HOME").value_or(std::string {});
+                auto const cwdAbs = _env.currentDirectory();
+                history.add(
+                    lineBuffer,
+                    HistoryAddContext {
+                        .cwd = canonicalizeForHistory(cwdAbs, homeEnv),
+                        .requiredPaths = collectRequiredPathsFromCommandLine(lineBuffer, cwdAbs, homeEnv),
+                    });
             }
 
             {
@@ -1428,7 +1441,13 @@ int Shell::run()
         if (!lineBuffer.empty())
         {
             prompt.addHistory(lineBuffer);
-            history.add(lineBuffer);
+            auto const homeEnv = _env.get("HOME").value_or(std::string {});
+            auto const cwdAbs = _env.currentDirectory();
+            history.add(lineBuffer,
+                        HistoryAddContext {
+                            .cwd = canonicalizeForHistory(cwdAbs, homeEnv),
+                            .requiredPaths = collectRequiredPathsFromCommandLine(lineBuffer, cwdAbs, homeEnv),
+                        });
         }
 
         {

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -3959,7 +3959,7 @@ int Shell::executeInlineHistory(CoreVM::CoreStringArray const& args, NativeHandl
             auto const& pattern = args.at(patternIdx);
             auto options = FuzzySearchOptions {
                 .currentCwd = _env.currentDirectory(),
-                .home = _env.get("HOME").value_or(std::string {}),
+                .home = normalizedHomeDirectory(_env),
                 .validateRequiredPaths = validate,
                 .fs = &_fs,
             };

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -4,6 +4,7 @@
 #include <shell/commands/GrepCommand.hpp>
 #include <shell/commands/KillCommand.hpp>
 #include <shell/commands/TimeoutCommand.hpp>
+#include <shell/history/RequiredPaths.hpp>
 
 #include <tui/GenericSyntaxHighlighter.hpp>
 #include <tui/ImageLoader.hpp>
@@ -3910,7 +3911,9 @@ int Shell::executeInlineHistory(CoreVM::CoreStringArray const& args, NativeHandl
                                       "|------------|-------------|\n"
                                       "| *(none)* | List all history entries, numbered |\n"
                                       "| `N` | List the last N entries |\n"
-                                      "| `search PATTERN` | Search entries by prefix |\n"
+                                      "| `search [--cwd] [--no-validate] PATTERN` | Search entries; `--cwd` "
+                                      "restricts to the current directory or its ancestors, `--no-validate` "
+                                      "skips the required-paths existence filter |\n"
                                       "| `clear` | Clear all history |\n"
                                       "| `-h`, `--help` | Display this help |\n");
 
@@ -3922,16 +3925,74 @@ int Shell::executeInlineHistory(CoreVM::CoreStringArray const& args, NativeHandl
 
         if (subcmd == "search")
         {
-            if (args.size() < 3)
+            // Optional flags may appear before the pattern:
+            //   --cwd           restrict to entries whose stored cwd == or is an
+            //                   ancestor of the current working directory
+            //   --no-validate   skip the required-paths existence filter
+            auto cwdOnly = false;
+            auto validate = true;
+            auto patternIdx = size_t { 2 };
+            while (patternIdx < args.size())
+            {
+                auto const& flag = args.at(patternIdx);
+                if (flag == "--cwd")
+                {
+                    cwdOnly = true;
+                    ++patternIdx;
+                    continue;
+                }
+                if (flag == "--no-validate")
+                {
+                    validate = false;
+                    ++patternIdx;
+                    continue;
+                }
+                break;
+            }
+
+            if (patternIdx >= args.size())
             {
                 error("history: search requires a pattern");
                 return 1;
             }
-            auto const results = history.search(args.at(2), 50);
+
+            auto const& pattern = args.at(patternIdx);
+            auto options = FuzzySearchOptions {
+                .currentCwd = _env.currentDirectory(),
+                .home = _env.get("HOME").value_or(std::string {}),
+                .validateRequiredPaths = validate,
+                .fs = &_fs,
+            };
+
+            // When --cwd is set, filter out entries that aren't exact- or ancestor-CWD matches
+            // by computing canonical forms and rejecting others after the fuzzy search.
+            auto const currentCwdCanonical = canonicalizeForHistory(options.currentCwd, options.home);
+            auto const results = history.searchFuzzy(pattern, 50, options);
+
             auto const& theme = tui::currentTheme();
             std::string buf;
-            for (auto const& entry: results)
+            for (auto const& match: results)
             {
+                if (cwdOnly)
+                {
+                    // Re-check CWD against the original entry to distinguish a boosted-but-not-matching
+                    // result from an actual match. `match.entry` is a view into the history entry's
+                    // command string, so we need to locate the full entry to inspect its `cwd`.
+                    auto const& rich = history.richEntries();
+                    auto it =
+                        std::ranges::find_if(rich, [&](auto const& e) { return e.command == match.entry; });
+                    if (it == rich.end())
+                        continue;
+                    auto const exact = !it->cwd.empty() && it->cwd == currentCwdCanonical;
+                    auto const ancestor = !it->cwd.empty() && it->cwd != currentCwdCanonical
+                                          && currentCwdCanonical.starts_with(it->cwd)
+                                          && currentCwdCanonical.size() > it->cwd.size()
+                                          && currentCwdCanonical[it->cwd.size()] == '/';
+                    if (!exact && !ancestor)
+                        continue;
+                }
+
+                auto const entry = std::string { match.entry };
                 buf.clear();
                 if (useColor)
                 {

--- a/src/shell/completion/Completer.cpp
+++ b/src/shell/completion/Completer.cpp
@@ -17,7 +17,8 @@ namespace endo
 
 Completer::Completer(EnvironmentProvider const& env,
                      History const& history,
-                     FSharpPersistentState const& fsharpState)
+                     FSharpPersistentState const& fsharpState,
+                     FileSystem const* fs)
 {
     // Register default providers in priority order
     _providers.push_back(std::make_unique<BuiltinArgumentCompleter>());
@@ -37,7 +38,7 @@ Completer::Completer(EnvironmentProvider const& env,
     _providers.push_back(std::make_unique<LetBindingCompleter>(fsharpState));
     _providers.push_back(std::make_unique<VariableCompleter>(env));
     _providers.push_back(std::make_unique<FileCompleter>());
-    _providers.push_back(std::make_unique<HistoryCompleter>(history));
+    _providers.push_back(std::make_unique<HistoryCompleter>(history, env, fs));
 
     // Sort by priority (highest first)
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move)

--- a/src/shell/completion/Completer.hpp
+++ b/src/shell/completion/Completer.hpp
@@ -43,9 +43,12 @@ class Completer
     /// @param env The environment for variable and command completion.
     /// @param history The history for history-based suggestions.
     /// @param fsharpState The persistent F# state for let binding completion.
+    /// @param fs Optional filesystem used for required-paths validation in
+    ///           history-based suggestions. Pass nullptr to disable validation.
     Completer(EnvironmentProvider const& env,
               History const& history,
-              FSharpPersistentState const& fsharpState);
+              FSharpPersistentState const& fsharpState,
+              FileSystem const* fs = nullptr);
 
     /// @brief Registers an additional completion provider.
     /// @param provider The provider to add.

--- a/src/shell/completion/HistoryCompleter.cpp
+++ b/src/shell/completion/HistoryCompleter.cpp
@@ -4,7 +4,10 @@
 namespace endo
 {
 
-HistoryCompleter::HistoryCompleter(History const& history): _history(history)
+HistoryCompleter::HistoryCompleter(History const& history,
+                                   EnvironmentProvider const& env,
+                                   FileSystem const* fs):
+    _history(history), _env(env), _fs(fs)
 {
 }
 
@@ -15,7 +18,13 @@ std::vector<CompletionItem> HistoryCompleter::complete(CompletionContext const& 
     // For history completion, we match against the full input, not just the current word
     // This is because history entries are complete command lines
     // Use fuzzy search to find both prefix and fuzzy matches
-    auto matches = _history.searchFuzzy(context.fullInput, 10);
+    auto options = FuzzySearchOptions {
+        .currentCwd = _env.currentDirectory(),
+        .home = _env.get("HOME").value_or(std::string {}),
+        .validateRequiredPaths = _fs != nullptr,
+        .fs = _fs,
+    };
+    auto matches = _history.searchFuzzy(context.fullInput, 10, options);
 
     for (auto const& match: matches)
     {

--- a/src/shell/completion/HistoryCompleter.cpp
+++ b/src/shell/completion/HistoryCompleter.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "HistoryCompleter.hpp"
+#include <shell/history/RequiredPaths.hpp>
 
 namespace endo
 {
@@ -20,7 +21,7 @@ std::vector<CompletionItem> HistoryCompleter::complete(CompletionContext const& 
     // Use fuzzy search to find both prefix and fuzzy matches
     auto options = FuzzySearchOptions {
         .currentCwd = _env.currentDirectory(),
-        .home = _env.get("HOME").value_or(std::string {}),
+        .home = normalizedHomeDirectory(_env),
         .validateRequiredPaths = _fs != nullptr,
         .fs = _fs,
     };

--- a/src/shell/completion/HistoryCompleter.hpp
+++ b/src/shell/completion/HistoryCompleter.hpp
@@ -4,19 +4,29 @@
 #include <shell/completion/CompletionProvider.hpp>
 #include <shell/history/History.hpp>
 
-#include <string>
 #include <vector>
+
+#include <platform/EnvironmentProvider.hpp>
+#include <platform/FileSystem.hpp>
 
 namespace endo
 {
 
 /// @brief Completion provider based on command history.
+///
+/// Uses the supplied environment provider to read the current working directory
+/// on each completion request so `searchFuzzy` can boost entries whose stored
+/// CWD matches or ancestors the current CWD. When a filesystem is supplied,
+/// entries whose `requiredPaths` no longer exist are suppressed.
 class HistoryCompleter: public CompletionProvider
 {
   public:
     /// @brief Constructs a history completer.
     /// @param history The history to search.
-    explicit HistoryCompleter(History const& history);
+    /// @param env     Environment provider (for current CWD and $HOME).
+    /// @param fs      Filesystem used for required-paths validation.
+    ///                Pass nullptr to disable validation (e.g. in unit tests).
+    HistoryCompleter(History const& history, EnvironmentProvider const& env, FileSystem const* fs);
 
     [[nodiscard]] std::vector<CompletionItem> complete(CompletionContext const& context) override;
     [[nodiscard]] bool canHandle(CompletionContextType type) const override;
@@ -25,6 +35,8 @@ class HistoryCompleter: public CompletionProvider
 
   private:
     History const& _history;
+    EnvironmentProvider const& _env;
+    FileSystem const* _fs;
 };
 
 } // namespace endo

--- a/src/shell/history/History.cpp
+++ b/src/shell/history/History.cpp
@@ -14,7 +14,7 @@ InMemoryHistory::InMemoryHistory(size_t maxSize): _maxSize(maxSize)
     _entries.reserve(std::min(maxSize, size_t { 256 }));
 }
 
-void InMemoryHistory::add(std::string entry)
+void InMemoryHistory::add(std::string entry, HistoryAddContext /*context*/)
 {
     trimInPlace(entry);
     if (entry.empty())
@@ -79,8 +79,8 @@ std::vector<std::string_view> InMemoryHistory::search(std::string_view prefix, s
     return results;
 }
 
-std::vector<History::FuzzySearchResult> InMemoryHistory::searchFuzzy(std::string_view prefix,
-                                                                     size_t maxResults) const
+std::vector<History::FuzzySearchResult> InMemoryHistory::searchFuzzy(
+    std::string_view prefix, size_t maxResults, FuzzySearchOptions const& /*options*/) const
 {
     std::vector<FuzzySearchResult> results;
     results.reserve(std::min(maxResults * 2, _entries.size())); // Reserve extra for sorting

--- a/src/shell/history/History.hpp
+++ b/src/shell/history/History.hpp
@@ -6,12 +6,36 @@
 #include <utility>
 #include <vector>
 
+#include <platform/FileSystem.hpp>
 #include <platform/StringUtils.hpp>
 
 namespace endo
 {
 
 using platform::trimInPlace;
+
+/// @brief Context supplied by callers when appending to history.
+///
+/// Optional metadata that enables CWD-aware ranking and required-paths
+/// validation during completion. Empty defaults keep older callers working.
+struct HistoryAddContext
+{
+    std::string cwd; ///< Working directory at execution time (absolute).
+    std::vector<std::string>
+        requiredPaths; ///< Path-like arguments (canonical, home-relative when applicable).
+};
+
+/// @brief Options that influence fuzzy history ranking and filtering.
+///
+/// All fields default to values that disable CWD ranking and required-paths
+/// validation, preserving legacy behavior when not explicitly populated.
+struct FuzzySearchOptions
+{
+    std::string currentCwd;            ///< Absolute current working directory; canonicalized internally.
+    std::string home;                  ///< $HOME; used to canonicalize CWD and expand stored paths.
+    bool validateRequiredPaths = true; ///< Drop entries whose referenced paths no longer exist.
+    FileSystem const* fs = nullptr;    ///< Used for existence checks when validating.
+};
 
 /// @brief Abstract history interface for completion and recall.
 ///
@@ -23,8 +47,10 @@ class History
     virtual ~History() = default;
 
     /// @brief Adds an entry to the history.
-    /// @param entry The command line to add.
-    virtual void add(std::string entry) = 0;
+    /// @param entry   The command line to add.
+    /// @param context Optional metadata (CWD, required paths) used for CWD-aware
+    ///                ranking and required-paths validation in searchFuzzy().
+    virtual void add(std::string entry, HistoryAddContext context = {}) = 0;
 
     /// @brief Returns all history entries (oldest first).
     [[nodiscard]] virtual std::vector<std::string> const& entries() const = 0;
@@ -65,9 +91,10 @@ class History
     /// @brief Searches for entries using both prefix and fuzzy matching.
     /// @param prefix The pattern to search for.
     /// @param maxResults Maximum number of results to return.
+    /// @param options Optional CWD-aware ranking and required-paths validation.
     /// @return Matching entries ordered by score (highest first), then recency.
-    [[nodiscard]] virtual std::vector<FuzzySearchResult> searchFuzzy(std::string_view prefix,
-                                                                     size_t maxResults = 10) const = 0;
+    [[nodiscard]] virtual std::vector<FuzzySearchResult> searchFuzzy(
+        std::string_view prefix, size_t maxResults = 10, FuzzySearchOptions const& options = {}) const = 0;
 };
 
 /// @brief In-memory history implementation (current session only).
@@ -78,15 +105,17 @@ class InMemoryHistory: public History
     /// @param maxSize Maximum number of entries to store (default: 1000).
     explicit InMemoryHistory(size_t maxSize = 1000);
 
-    void add(std::string entry) override;
+    void add(std::string entry, HistoryAddContext context = {}) override;
     [[nodiscard]] std::vector<std::string> const& entries() const override;
     [[nodiscard]] size_t size() const override;
     [[nodiscard]] size_t maxSize() const override;
     void clear() override;
     [[nodiscard]] std::vector<std::string_view> search(std::string_view prefix,
                                                        size_t maxResults = 10) const override;
-    [[nodiscard]] std::vector<FuzzySearchResult> searchFuzzy(std::string_view prefix,
-                                                             size_t maxResults = 10) const override;
+    [[nodiscard]] std::vector<FuzzySearchResult> searchFuzzy(
+        std::string_view prefix,
+        size_t maxResults = 10,
+        FuzzySearchOptions const& options = {}) const override;
 
   private:
     std::vector<std::string> _entries;

--- a/src/shell/history/History.hpp
+++ b/src/shell/history/History.hpp
@@ -20,21 +20,24 @@ using platform::trimInPlace;
 /// validation during completion. Empty defaults keep older callers working.
 struct HistoryAddContext
 {
-    std::string cwd; ///< Working directory at execution time (absolute).
+    std::string cwd; ///< Working directory at execution time (canonical, home-relative when applicable).
     std::vector<std::string>
         requiredPaths; ///< Path-like arguments (canonical, home-relative when applicable).
 };
 
 /// @brief Options that influence fuzzy history ranking and filtering.
 ///
-/// All fields default to values that disable CWD ranking and required-paths
-/// validation, preserving legacy behavior when not explicitly populated.
+/// Leaving @c currentCwd empty disables the CWD ranking bonus. Required-paths
+/// validation is gated by @c fs — when @c fs is @c nullptr no existence checks
+/// run regardless of @c validateRequiredPaths. These two knobs together keep
+/// legacy call sites (no env/fs supplied) on the old behavior.
 struct FuzzySearchOptions
 {
     std::string currentCwd;            ///< Absolute current working directory; canonicalized internally.
     std::string home;                  ///< $HOME; used to canonicalize CWD and expand stored paths.
-    bool validateRequiredPaths = true; ///< Drop entries whose referenced paths no longer exist.
-    FileSystem const* fs = nullptr;    ///< Used for existence checks when validating.
+    bool validateRequiredPaths = true; ///< Drop entries whose referenced paths no longer exist
+                                       ///< (only applies when @c fs is non-null).
+    FileSystem const* fs = nullptr;    ///< Non-null enables required-paths existence checks.
 };
 
 /// @brief Abstract history interface for completion and recall.

--- a/src/shell/history/PersistentHistory.cpp
+++ b/src/shell/history/PersistentHistory.cpp
@@ -12,9 +12,35 @@
 #include <ranges>
 #include <sstream>
 #include <string>
+#include <unordered_map>
+
+#include "RequiredPaths.hpp"
 
 namespace endo
 {
+
+namespace
+{
+
+    /// Component-aware ancestry test: returns true when @p descendant is inside
+    /// @p ancestor (or equal to it). Both inputs must already be in the same
+    /// canonical form (either both absolute or both home-relative `~/...`).
+    [[nodiscard]] bool pathIsAncestor(std::string_view ancestor, std::string_view descendant)
+    {
+        if (ancestor.empty() || descendant.empty())
+            return false;
+        if (ancestor == descendant)
+            return true;
+        if (descendant.size() <= ancestor.size())
+            return false;
+        if (!descendant.starts_with(ancestor))
+            return false;
+        // Require a path boundary after the prefix so `/home/foo` does not match `/home/foobar`.
+        // Treat the bare tilde specially: `~` as ancestor of `~/x` has no intermediate `/`.
+        return descendant[ancestor.size()] == '/' || (ancestor == "~" && descendant.starts_with("~/"));
+    }
+
+} // namespace
 
 PersistentHistory::PersistentHistory(FileSystem const& fs, size_t maxSize):
     _fs(fs), _filePath(defaultHistoryPath()), _maxSize(maxSize)
@@ -82,6 +108,16 @@ void PersistentHistory::load()
 
             if (node["count"])
                 entry.executionCount = node["count"].as<uint32_t>();
+
+            if (node["cwd"])
+                entry.cwd = node["cwd"].as<std::string>();
+
+            if (node["paths"] && node["paths"].IsSequence())
+            {
+                entry.requiredPaths.reserve(node["paths"].size());
+                for (auto const& p: node["paths"])
+                    entry.requiredPaths.push_back(p.as<std::string>());
+            }
 
             entry.persisted = true;
             _richEntries.push_back(std::move(entry));
@@ -159,7 +195,7 @@ void PersistentHistory::autoImportIfEmpty()
 #endif
 }
 
-void PersistentHistory::add(std::string entry)
+void PersistentHistory::add(std::string entry, HistoryAddContext context)
 {
     trimInPlace(entry);
     if (entry.empty())
@@ -171,9 +207,14 @@ void PersistentHistory::add(std::string entry)
 
     if (it != _richEntries.end())
     {
-        // Update existing entry
+        // Update existing entry. Fold in newer context if the caller supplied any —
+        // otherwise keep the stored values so "legacy" callers don't clobber them.
         it->executionCount++;
         it->lastExecuted = std::chrono::system_clock::now();
+        if (!context.cwd.empty())
+            it->cwd = std::move(context.cwd);
+        if (!context.requiredPaths.empty())
+            it->requiredPaths = std::move(context.requiredPaths);
 
         // Move to end (most recent)
         auto updated = std::move(*it);
@@ -191,6 +232,8 @@ void PersistentHistory::add(std::string entry)
             .lastExecuted = std::chrono::system_clock::now(),
             .executionCount = 1,
             .persisted = false,
+            .cwd = std::move(context.cwd),
+            .requiredPaths = std::move(context.requiredPaths),
         });
         _lastAddedIndex = _richEntries.size() - 1;
     }
@@ -261,8 +304,8 @@ std::vector<std::string_view> PersistentHistory::search(std::string_view prefix,
     return results;
 }
 
-std::vector<History::FuzzySearchResult> PersistentHistory::searchFuzzy(std::string_view prefix,
-                                                                       size_t maxResults) const
+std::vector<History::FuzzySearchResult> PersistentHistory::searchFuzzy(
+    std::string_view prefix, size_t maxResults, FuzzySearchOptions const& options) const
 {
     auto results = std::vector<FuzzySearchResult> {};
     results.reserve(std::min(maxResults * 2, _richEntries.size()));
@@ -270,8 +313,28 @@ std::vector<History::FuzzySearchResult> PersistentHistory::searchFuzzy(std::stri
     auto fuzzyConfig = tui::FuzzyConfig {};
     auto const minThreshold = fuzzyConfig.minMatchThreshold;
 
-    // Collect all matches from newest to oldest
+    // CWD ranking bonuses — exact must outrank maxRecencyBonus so same-CWD entries
+    // beat fresh unrelated ones; ancestor is a gentler tiebreaker.
     constexpr auto maxRecencyBonus = 200;
+    constexpr auto exactCwdBonus = 300;
+    constexpr auto ancestorCwdBonus = 150;
+
+    // Canonicalize the current CWD once; comparison against stored cwd stays a cheap string op.
+    auto const currentCwdCanonical = options.currentCwd.empty()
+                                         ? std::string {}
+                                         : canonicalizeForHistory(options.currentCwd, options.home);
+
+    // Existence cache: required-paths validation may revisit the same path across
+    // candidates; a scratch cache keeps cost bounded to one FS probe per unique path.
+    auto existenceCache = std::unordered_map<std::string, bool> {};
+    auto const pathExists = [&](std::string const& stored) {
+        auto const [iter, inserted] = existenceCache.try_emplace(stored, false);
+        if (inserted)
+            iter->second = options.fs->exists(expandForLookup(stored, options.home));
+        return iter->second;
+    };
+
+    // Collect all matches from newest to oldest
     auto const total = static_cast<int>(_richEntries.size());
     auto position = 0;
     for (auto it = _richEntries.rbegin(); it != _richEntries.rend(); ++it, ++position)
@@ -293,6 +356,14 @@ std::vector<History::FuzzySearchResult> PersistentHistory::searchFuzzy(std::stri
         if (!isPrefixMatch && !isFuzzyMatch)
             continue;
 
+        // Required-paths validation: suppress entries whose referenced paths no longer exist.
+        if (options.validateRequiredPaths && options.fs != nullptr && !it->requiredPaths.empty())
+        {
+            auto const allExist = std::ranges::all_of(it->requiredPaths, pathExists);
+            if (!allExist)
+                continue;
+        }
+
         // Recency bonus: scaled to fixed range [0, maxRecencyBonus], newest gets highest
         auto const recencyBonus = total > 0 ? maxRecencyBonus * (total - position) / total : 0;
 
@@ -300,18 +371,28 @@ std::vector<History::FuzzySearchResult> PersistentHistory::searchFuzzy(std::stri
         auto const frequencyBonus =
             static_cast<int>(std::min(static_cast<uint32_t>(it->executionCount * 2), uint32_t { 50 }));
 
+        // CWD bonus: exact match > ancestor match > unrelated/unknown.
+        auto cwdBonus = 0;
+        if (!currentCwdCanonical.empty() && !it->cwd.empty())
+        {
+            if (it->cwd == currentCwdCanonical)
+                cwdBonus = exactCwdBonus;
+            else if (pathIsAncestor(it->cwd, currentCwdCanonical))
+                cwdBonus = ancestorCwdBonus;
+        }
+
         auto score = 0;
         auto matchPositions = std::vector<size_t> {};
 
         if (isPrefixMatch)
         {
             score = tui::SmartCaseMatch::adjustScore(100, it->command, prefix);
-            score += fuzzyConfig.prefixMatchBonus + recencyBonus + frequencyBonus;
+            score += fuzzyConfig.prefixMatchBonus + recencyBonus + frequencyBonus + cwdBonus;
         }
         else
         {
             score = tui::FuzzyMatch::calculateScore(50, it->command, prefix, fuzzyResult, fuzzyConfig);
-            score += recencyBonus + frequencyBonus;
+            score += recencyBonus + frequencyBonus + cwdBonus;
             matchPositions = std::move(fuzzyResult.positions);
         }
 
@@ -345,7 +426,7 @@ void PersistentHistory::flush()
     // Serialize to YAML
     auto emitter = YAML::Emitter {};
     emitter << YAML::BeginMap;
-    emitter << YAML::Key << "version" << YAML::Value << 1;
+    emitter << YAML::Key << "version" << YAML::Value << 2;
     emitter << YAML::Key << "entries" << YAML::Value << YAML::BeginSeq;
 
     for (auto const& entry: _richEntries)
@@ -360,6 +441,15 @@ void PersistentHistory::flush()
         emitter << YAML::Key << "cmd" << YAML::Value << entry.command;
         emitter << YAML::Key << "ts" << YAML::Value << ts;
         emitter << YAML::Key << "count" << YAML::Value << entry.executionCount;
+        if (!entry.cwd.empty())
+            emitter << YAML::Key << "cwd" << YAML::Value << entry.cwd;
+        if (!entry.requiredPaths.empty())
+        {
+            emitter << YAML::Key << "paths" << YAML::Value << YAML::BeginSeq;
+            for (auto const& p: entry.requiredPaths)
+                emitter << p;
+            emitter << YAML::EndSeq;
+        }
         emitter << YAML::EndMap;
     }
 

--- a/src/shell/history/PersistentHistory.hpp
+++ b/src/shell/history/PersistentHistory.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "History.hpp"
-
 #include <platform/FileSystem.hpp>
 
 namespace endo
@@ -22,6 +21,10 @@ struct HistoryEntry
     std::chrono::system_clock::time_point lastExecuted; ///< When the command was last executed.
     uint32_t executionCount = 1;                        ///< Total execution count.
     bool persisted = false;                             ///< Whether this entry should be saved to disk.
+    std::string cwd;                                    ///< Working directory at execution time
+                     ///< (canonical, home-relative when applicable; may be empty for legacy entries).
+    std::vector<std::string> requiredPaths; ///< Path-like arguments referenced by the command
+                                            ///< (canonical, home-relative when applicable).
 };
 
 /// @brief Persistent command history that saves to a YAML file on disk.
@@ -37,7 +40,7 @@ class PersistentHistory final: public History
     /// @param maxSize Maximum number of entries to store (default: 5000).
     explicit PersistentHistory(FileSystem const& fs, size_t maxSize = 5000);
 
-    void add(std::string entry) override;
+    void add(std::string entry, HistoryAddContext context = {}) override;
     [[nodiscard]] std::vector<std::string> const& entries() const override;
     [[nodiscard]] size_t size() const override;
     [[nodiscard]] size_t maxSize() const override;
@@ -45,8 +48,10 @@ class PersistentHistory final: public History
     void markLastResult(int exitCode) override;
     [[nodiscard]] std::vector<std::string_view> search(std::string_view prefix,
                                                        size_t maxResults = 10) const override;
-    [[nodiscard]] std::vector<FuzzySearchResult> searchFuzzy(std::string_view prefix,
-                                                             size_t maxResults = 10) const override;
+    [[nodiscard]] std::vector<FuzzySearchResult> searchFuzzy(
+        std::string_view prefix,
+        size_t maxResults = 10,
+        FuzzySearchOptions const& options = {}) const override;
 
     /// @brief Loads history entries from the file on disk.
     void load();

--- a/src/shell/history/PersistentHistory_test.cpp
+++ b/src/shell/history/PersistentHistory_test.cpp
@@ -5,8 +5,9 @@
 #include <filesystem>
 
 #include "PersistentHistory.hpp"
-
+#include "RequiredPaths.hpp"
 #include <platform/NativeFileSystem.hpp>
+#include <platform/testing/InMemoryFileSystem.hpp>
 
 using namespace std::string_literals;
 using namespace std::string_view_literals;
@@ -450,4 +451,203 @@ TEST_CASE("PersistentHistory.atomic_flush_uses_tmp", "[history]")
     CHECK(!std::filesystem::exists(filePath.string() + ".tmp"));
     // The actual file should exist
     CHECK(std::filesystem::exists(filePath));
+}
+
+// ---------------------------------------------------------------------------
+// CWD-aware ranking and required-paths validation
+// ---------------------------------------------------------------------------
+
+TEST_CASE("PersistentHistory.cwd_and_paths_yaml_roundtrip", "[history][cwd]")
+{
+    auto dir = TempDir {};
+    auto const filePath = dir.path / "history.yml";
+    {
+        auto history = endo::PersistentHistory { testFs() };
+        history.setFilePath(filePath);
+        history.add("vim ~/notes/plan.md",
+                    endo::HistoryAddContext {
+                        .cwd = "~/projects/endo",
+                        .requiredPaths = { "~/notes/plan.md" },
+                    });
+        history.markLastResult(0);
+    }
+
+    auto history = endo::PersistentHistory { testFs() };
+    history.setFilePath(filePath);
+    history.load();
+
+    REQUIRE(history.size() == 1);
+    auto const& entry = history.richEntries().front();
+    CHECK(entry.command == "vim ~/notes/plan.md");
+    CHECK(entry.cwd == "~/projects/endo");
+    REQUIRE(entry.requiredPaths.size() == 1);
+    CHECK(entry.requiredPaths.front() == "~/notes/plan.md");
+}
+
+TEST_CASE("PersistentHistory.legacy_v1_yaml_loads_without_cwd", "[history][cwd]")
+{
+    auto dir = TempDir {};
+    auto const filePath = dir.path / "history.yml";
+    // Hand-craft a legacy v1 file (no cwd, no paths).
+    writeFile(filePath,
+              "version: 1\n"
+              "entries:\n"
+              "  - cmd: legacy command\n"
+              "    ts: 1000\n"
+              "    count: 2\n");
+
+    auto history = endo::PersistentHistory { testFs() };
+    history.setFilePath(filePath);
+    history.load();
+
+    REQUIRE(history.size() == 1);
+    auto const& entry = history.richEntries().front();
+    CHECK(entry.command == "legacy command");
+    CHECK(entry.cwd.empty());
+    CHECK(entry.requiredPaths.empty());
+
+    // Legacy entries are neither boosted nor penalized by CWD ranking.
+    auto options = endo::FuzzySearchOptions {
+        .currentCwd = "/home/u/projects/endo",
+        .home = "/home/u",
+    };
+    auto const results = history.searchFuzzy("legacy", 10, options);
+    REQUIRE(results.size() == 1);
+    CHECK(results.front().entry == "legacy command");
+}
+
+TEST_CASE("PersistentHistory.exact_cwd_match_boosts_rank", "[history][cwd]")
+{
+    auto dir = TempDir {};
+    auto history = endo::PersistentHistory { testFs() };
+    history.setFilePath(dir.path / "history.yml");
+
+    history.add("make build", endo::HistoryAddContext { .cwd = "~/projects/other", .requiredPaths = {} });
+    history.add("make build", endo::HistoryAddContext { .cwd = "~/projects/endo", .requiredPaths = {} });
+    // Duplicate command — add() updates the existing entry. Create a second distinct
+    // command to compare ranking.
+    history.add("make install", endo::HistoryAddContext { .cwd = "~/projects/other", .requiredPaths = {} });
+
+    auto options = endo::FuzzySearchOptions {
+        .currentCwd = "/home/u/projects/endo",
+        .home = "/home/u",
+    };
+    auto const results = history.searchFuzzy("make", 10, options);
+    REQUIRE(!results.empty());
+    // The first result must be "make build" (our CWD-matching entry), outranking the
+    // more-recent but unrelated "make install".
+    CHECK(results.front().entry == "make build");
+}
+
+TEST_CASE("PersistentHistory.ancestor_cwd_match_weaker_than_exact", "[history][cwd]")
+{
+    auto dir = TempDir {};
+    auto history = endo::PersistentHistory { testFs() };
+    history.setFilePath(dir.path / "history.yml");
+
+    // Entry stored with cwd = ~/projects ; current CWD is ~/projects/endo (descendant).
+    history.add("scan project", endo::HistoryAddContext { .cwd = "~/projects", .requiredPaths = {} });
+    history.add("scan project exact",
+                endo::HistoryAddContext { .cwd = "~/projects/endo", .requiredPaths = {} });
+
+    auto options = endo::FuzzySearchOptions {
+        .currentCwd = "/home/u/projects/endo",
+        .home = "/home/u",
+    };
+    auto const results = history.searchFuzzy("scan", 10, options);
+    REQUIRE(results.size() == 2);
+    // Exact (300) > ancestor (150); the exact match comes first.
+    CHECK(results.front().entry == "scan project exact");
+    CHECK(results.back().entry == "scan project");
+}
+
+TEST_CASE("PersistentHistory.required_paths_filtered_when_missing", "[history][required-paths]")
+{
+    auto dir = TempDir {};
+    auto history = endo::PersistentHistory { testFs() };
+    history.setFilePath(dir.path / "history.yml");
+
+    history.add("cat ~/notes/plan.md",
+                endo::HistoryAddContext { .cwd = "~", .requiredPaths = { "~/notes/plan.md" } });
+    history.add("ls", endo::HistoryAddContext { .cwd = "~", .requiredPaths = {} });
+
+    auto fs = endo::platform::testing::InMemoryFileSystem {};
+    // Note: ~/notes/plan.md is NOT added — the file no longer exists.
+
+    auto options = endo::FuzzySearchOptions {
+        .currentCwd = "/home/u",
+        .home = "/home/u",
+        .validateRequiredPaths = true,
+        .fs = &fs,
+    };
+    auto const results = history.searchFuzzy("", 10, options);
+    // Only "ls" (no required paths) should survive validation.
+    REQUIRE(results.size() == 1);
+    CHECK(results.front().entry == "ls");
+}
+
+TEST_CASE("PersistentHistory.required_paths_kept_when_file_exists", "[history][required-paths]")
+{
+    auto dir = TempDir {};
+    auto history = endo::PersistentHistory { testFs() };
+    history.setFilePath(dir.path / "history.yml");
+
+    history.add("cat ~/notes/plan.md",
+                endo::HistoryAddContext { .cwd = "~", .requiredPaths = { "~/notes/plan.md" } });
+
+    auto fs = endo::platform::testing::InMemoryFileSystem {};
+    fs.addFile("/home/u/notes/plan.md", "contents");
+
+    auto options = endo::FuzzySearchOptions {
+        .currentCwd = "/home/u",
+        .home = "/home/u",
+        .validateRequiredPaths = true,
+        .fs = &fs,
+    };
+    auto const results = history.searchFuzzy("cat", 10, options);
+    REQUIRE(results.size() == 1);
+    CHECK(results.front().entry == "cat ~/notes/plan.md");
+}
+
+TEST_CASE("PersistentHistory.required_paths_validation_disabled", "[history][required-paths]")
+{
+    auto dir = TempDir {};
+    auto history = endo::PersistentHistory { testFs() };
+    history.setFilePath(dir.path / "history.yml");
+
+    history.add("cat ~/missing.txt",
+                endo::HistoryAddContext { .cwd = "~", .requiredPaths = { "~/missing.txt" } });
+
+    auto fs = endo::platform::testing::InMemoryFileSystem {};
+
+    auto options = endo::FuzzySearchOptions {
+        .currentCwd = "/home/u",
+        .home = "/home/u",
+        .validateRequiredPaths = false,
+        .fs = &fs,
+    };
+    auto const results = history.searchFuzzy("cat", 10, options);
+    REQUIRE(results.size() == 1);
+    CHECK(results.front().entry == "cat ~/missing.txt");
+}
+
+TEST_CASE("PersistentHistory.readd_updates_cwd_and_paths", "[history][cwd]")
+{
+    auto dir = TempDir {};
+    auto history = endo::PersistentHistory { testFs() };
+    history.setFilePath(dir.path / "history.yml");
+
+    history.add(
+        "make build",
+        endo::HistoryAddContext { .cwd = "~/projects/a", .requiredPaths = { "~/projects/a/Makefile" } });
+    history.add(
+        "make build",
+        endo::HistoryAddContext { .cwd = "~/projects/b", .requiredPaths = { "~/projects/b/Makefile" } });
+
+    REQUIRE(history.size() == 1);
+    auto const& entry = history.richEntries().front();
+    CHECK(entry.cwd == "~/projects/b");
+    REQUIRE(entry.requiredPaths.size() == 1);
+    CHECK(entry.requiredPaths.front() == "~/projects/b/Makefile");
+    CHECK(entry.executionCount == 2);
 }

--- a/src/shell/history/RequiredPaths.cpp
+++ b/src/shell/history/RequiredPaths.cpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "RequiredPaths.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <string>
+
+namespace endo
+{
+
+namespace
+{
+
+    /// Returns true when @p arg looks like a path (absolute, relative, or home-prefixed)
+    /// rather than a flag or bare identifier.
+    [[nodiscard]] bool looksLikePath(std::string_view arg)
+    {
+        if (arg.empty())
+            return false;
+        if (arg.front() == '-')
+            return false; // option flag
+        if (arg.front() == '/')
+            return true;
+        if (arg.starts_with("./") || arg.starts_with("../"))
+            return true;
+        if (arg == "~" || arg.starts_with("~/"))
+            return true;
+        return arg.find('/') != std::string_view::npos;
+    }
+
+    /// Resolves @p arg to an absolute path given @p cwdAbs and @p home.
+    /// Does NOT call std::filesystem::canonical — missing targets stay valid.
+    [[nodiscard]] std::string resolveToAbsolute(std::string_view arg,
+                                                std::string_view cwdAbs,
+                                                std::string_view home)
+    {
+        auto expanded = expandForLookup(arg, home);
+        auto expandedPath = std::filesystem::path { expanded };
+        if (expandedPath.is_absolute())
+            return expandedPath.lexically_normal().string();
+
+        auto combined = std::filesystem::path { cwdAbs } / expandedPath;
+        return combined.lexically_normal().string();
+    }
+
+} // namespace
+
+std::string canonicalizeForHistory(std::string_view absPath, std::string_view home)
+{
+    if (home.empty())
+        return std::string { absPath };
+
+    if (absPath == home)
+        return "~";
+
+    if (absPath.size() > home.size() && absPath.starts_with(home) && absPath[home.size()] == '/')
+        return "~" + std::string { absPath.substr(home.size()) };
+
+    return std::string { absPath };
+}
+
+std::string expandForLookup(std::string_view storedPath, std::string_view home)
+{
+    if (storedPath.empty() || home.empty())
+        return std::string { storedPath };
+
+    if (storedPath == "~")
+        return std::string { home };
+
+    if (storedPath.starts_with("~/"))
+        return std::string { home } + std::string { storedPath.substr(1) };
+
+    return std::string { storedPath };
+}
+
+std::vector<std::string> collectRequiredPaths(std::span<std::string const> argv,
+                                              std::string_view cwdAbs,
+                                              std::string_view home)
+{
+    auto result = std::vector<std::string> {};
+    if (argv.size() <= 1)
+        return result;
+
+    for (auto const& arg: argv.subspan(1))
+    {
+        if (result.size() >= maxRequiredPaths)
+            break;
+        if (!looksLikePath(arg))
+            continue;
+
+        auto abs = resolveToAbsolute(arg, cwdAbs, home);
+        auto canonical = canonicalizeForHistory(abs, home);
+
+        // Deduplicate — identical paths in argv (e.g. `diff a a`) only count once.
+        if (std::ranges::find(result, canonical) == result.end())
+            result.push_back(std::move(canonical));
+    }
+
+    return result;
+}
+
+namespace
+{
+
+    /// Minimal shell-aware tokenizer used only for required-paths heuristics.
+    /// Splits on whitespace; single/double quotes group a token (stripped).
+    /// Does not interpret backslash escapes, variables, or redirections.
+    [[nodiscard]] std::vector<std::string> tokenizeForPathScan(std::string_view line)
+    {
+        auto tokens = std::vector<std::string> {};
+        auto current = std::string {};
+        auto quote = char { 0 };
+
+        auto flush = [&] {
+            if (!current.empty())
+            {
+                tokens.push_back(std::move(current));
+                current = std::string {};
+            }
+        };
+
+        for (auto const c: line)
+        {
+            if (quote != 0)
+            {
+                if (c == quote)
+                    quote = 0;
+                else
+                    current.push_back(c);
+                continue;
+            }
+            if (c == '\'' || c == '"')
+            {
+                quote = c;
+                continue;
+            }
+            if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
+            {
+                flush();
+                continue;
+            }
+            current.push_back(c);
+        }
+        flush();
+        return tokens;
+    }
+
+} // namespace
+
+std::vector<std::string> collectRequiredPathsFromCommandLine(std::string_view commandLine,
+                                                             std::string_view cwdAbs,
+                                                             std::string_view home)
+{
+    auto const tokens = tokenizeForPathScan(commandLine);
+    return collectRequiredPaths(tokens, cwdAbs, home);
+}
+
+} // namespace endo

--- a/src/shell/history/RequiredPaths.cpp
+++ b/src/shell/history/RequiredPaths.cpp
@@ -5,20 +5,58 @@
 #include <filesystem>
 #include <string>
 
+#include <platform/PathUtils.hpp>
+
 namespace endo
 {
 
 namespace
 {
 
+    /// Returns true when @p arg looks like a URL scheme (`http://`, `file://`, `git@host:repo`).
+    /// Such tokens contain a `/` but do not denote a local filesystem path.
+    [[nodiscard]] bool looksLikeUrl(std::string_view arg)
+    {
+        // `scheme://...` — find `://` and ensure everything before it is an identifier.
+        auto const colonSlash = arg.find("://");
+        if (colonSlash != std::string_view::npos && colonSlash > 0)
+        {
+            auto const scheme = arg.substr(0, colonSlash);
+            auto const isSchemeChar = [](char c) {
+                return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '+'
+                       || c == '-' || c == '.';
+            };
+            if (std::ranges::all_of(scheme, isSchemeChar))
+                return true;
+        }
+        // `git@host:path` — no leading scheme, but SCP-style git/ssh remote.
+        if (auto const at = arg.find('@'); at != std::string_view::npos)
+        {
+            auto const after = arg.substr(at + 1);
+            if (auto const colon = after.find(':'); colon != std::string_view::npos && colon > 0)
+            {
+                auto const host = after.substr(0, colon);
+                auto const isHostChar = [](char c) {
+                    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+                           || c == '.' || c == '-' || c == '_';
+                };
+                if (!host.empty() && std::ranges::all_of(host, isHostChar))
+                    return true;
+            }
+        }
+        return false;
+    }
+
     /// Returns true when @p arg looks like a path (absolute, relative, or home-prefixed)
-    /// rather than a flag or bare identifier.
+    /// rather than a flag, URL, or bare identifier.
     [[nodiscard]] bool looksLikePath(std::string_view arg)
     {
         if (arg.empty())
             return false;
         if (arg.front() == '-')
             return false; // option flag
+        if (looksLikeUrl(arg))
+            return false;
         if (arg.front() == '/')
             return true;
         if (arg.starts_with("./") || arg.starts_with("../"))
@@ -30,6 +68,8 @@ namespace
 
     /// Resolves @p arg to an absolute path given @p cwdAbs and @p home.
     /// Does NOT call std::filesystem::canonical — missing targets stay valid.
+    /// Returns the result in generic (forward-slash) form so downstream
+    /// canonicalization works identically on POSIX and Windows.
     [[nodiscard]] std::string resolveToAbsolute(std::string_view arg,
                                                 std::string_view cwdAbs,
                                                 std::string_view home)
@@ -37,16 +77,28 @@ namespace
         auto expanded = expandForLookup(arg, home);
         auto expandedPath = std::filesystem::path { expanded };
         if (expandedPath.is_absolute())
-            return expandedPath.lexically_normal().string();
+            return expandedPath.lexically_normal().generic_string();
 
         auto combined = std::filesystem::path { cwdAbs } / expandedPath;
-        return combined.lexically_normal().string();
+        return combined.lexically_normal().generic_string();
     }
 
 } // namespace
 
+namespace
+{
+    /// Trims a trailing `/` (if any) so `/home/u/` and `/home/u` compare equal.
+    [[nodiscard]] std::string_view trimTrailingSlash(std::string_view path)
+    {
+        while (path.size() > 1 && path.back() == '/')
+            path.remove_suffix(1);
+        return path;
+    }
+} // namespace
+
 std::string canonicalizeForHistory(std::string_view absPath, std::string_view home)
 {
+    home = trimTrailingSlash(home);
     if (home.empty())
         return std::string { absPath };
 
@@ -61,6 +113,7 @@ std::string canonicalizeForHistory(std::string_view absPath, std::string_view ho
 
 std::string expandForLookup(std::string_view storedPath, std::string_view home)
 {
+    home = trimTrailingSlash(home);
     if (storedPath.empty() || home.empty())
         return std::string { storedPath };
 
@@ -153,6 +206,14 @@ std::vector<std::string> collectRequiredPathsFromCommandLine(std::string_view co
 {
     auto const tokens = tokenizeForPathScan(commandLine);
     return collectRequiredPaths(tokens, cwdAbs, home);
+}
+
+std::string normalizedHomeDirectory(EnvironmentProvider const& env)
+{
+    auto const home = env.homeDirectory();
+    if (!home)
+        return {};
+    return platform::normalizePath(*home);
 }
 
 } // namespace endo

--- a/src/shell/history/RequiredPaths.hpp
+++ b/src/shell/history/RequiredPaths.hpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstddef>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace endo
+{
+
+/// Maximum number of required paths to record per history entry.
+///
+/// Caps cost of per-entry existence checks during completion and keeps
+/// storage compact for commands that expand into many path-like args.
+inline constexpr size_t maxRequiredPaths = 8;
+
+/// Canonicalizes an absolute path into a home-relative form for portable storage.
+///
+/// If @p absPath is inside @p home, returns a `~/...` relative form; the bare
+/// home path itself becomes `"~"`. Otherwise returns @p absPath unchanged.
+/// Plain string comparison — no filesystem I/O. Uses component-aware prefix
+/// matching so `/home/userx` is not treated as a child of `/home/user`.
+///
+/// @param absPath An absolute path.
+/// @param home    The user's home directory (absolute path).
+/// @return Canonical, home-relative form when applicable, otherwise @p absPath.
+[[nodiscard]] std::string canonicalizeForHistory(std::string_view absPath, std::string_view home);
+
+/// Expands a canonical (possibly `~`-prefixed) path back to an absolute path.
+///
+/// Inverse of canonicalizeForHistory(). Only handles leading `~/` and bare `~`
+/// — does not expand `~user` forms. Other inputs are returned unchanged.
+///
+/// @param storedPath Path as stored in history.
+/// @param home       The user's home directory (absolute path).
+/// @return Expanded absolute path.
+[[nodiscard]] std::string expandForLookup(std::string_view storedPath, std::string_view home);
+
+/// Collects path-like arguments from a post-expansion argv.
+///
+/// Scans @p argv starting at index 1 (skipping the command name). For each
+/// argument that looks like a path, resolves it to an absolute form (expanding
+/// `~`, joining with @p cwdAbs if relative) and then canonicalizes it for
+/// portable storage via canonicalizeForHistory().
+///
+/// An argument is considered path-like if it starts with `/`, `./`, `../`,
+/// `~/`, or `~`, or if it contains a `/` character. Bare identifiers and
+/// option flags (`-f`, `--flag`, `--foo=bar`) are skipped.
+///
+/// The returned list is capped at maxRequiredPaths entries.
+///
+/// @param argv    Post-expansion argument vector (argv[0] is the command).
+/// @param cwdAbs  Absolute current working directory at command execution time.
+/// @param home    The user's home directory (absolute path).
+/// @return Canonical, portable paths referenced by the command.
+[[nodiscard]] std::vector<std::string> collectRequiredPaths(std::span<std::string const> argv,
+                                                            std::string_view cwdAbs,
+                                                            std::string_view home);
+
+/// Convenience overload that tokenizes a raw command line before collecting paths.
+///
+/// Uses a lightweight shell-aware splitter: whitespace separates tokens, single
+/// and double quotes group a token (quotes are stripped from the result). Does
+/// NOT perform variable expansion, pipelines, redirection, or glob expansion —
+/// the goal is best-effort path detection, not faithful shell parsing. Good
+/// enough for real interactive lines like `vim ~/notes/plan.md` or
+/// `cp "/tmp/a b.txt" /home/u/b`.
+///
+/// @param commandLine The raw command line typed by the user.
+/// @param cwdAbs      Absolute current working directory at command execution time.
+/// @param home        The user's home directory (absolute path).
+/// @return Canonical, portable paths referenced by the command.
+[[nodiscard]] std::vector<std::string> collectRequiredPathsFromCommandLine(std::string_view commandLine,
+                                                                           std::string_view cwdAbs,
+                                                                           std::string_view home);
+
+} // namespace endo

--- a/src/shell/history/RequiredPaths.hpp
+++ b/src/shell/history/RequiredPaths.hpp
@@ -7,8 +7,19 @@
 #include <string_view>
 #include <vector>
 
+#include <platform/EnvironmentProvider.hpp>
+
 namespace endo
 {
+
+/// Returns the user's home directory as a forward-slash–normalized string.
+///
+/// Uses @c EnvironmentProvider::homeDirectory() (HOME → USERPROFILE fallback),
+/// so it works on Windows when HOME is unset. The returned string uses
+/// forward slashes regardless of platform, matching the convention used by
+/// @c EnvironmentProvider::currentDirectory() and the rest of the shell.
+/// Returns an empty string if neither variable is set.
+[[nodiscard]] std::string normalizedHomeDirectory(EnvironmentProvider const& env);
 
 /// Maximum number of required paths to record per history entry.
 ///

--- a/src/shell/history/RequiredPaths_test.cpp
+++ b/src/shell/history/RequiredPaths_test.cpp
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <catch2/catch_test_macros.hpp>
+
+#include "RequiredPaths.hpp"
+
+using namespace endo;
+
+TEST_CASE("canonicalizeForHistory.home_subpath", "[history][required-paths]")
+{
+    CHECK(canonicalizeForHistory("/home/u/projects/endo", "/home/u") == "~/projects/endo");
+}
+
+TEST_CASE("canonicalizeForHistory.exact_home", "[history][required-paths]")
+{
+    CHECK(canonicalizeForHistory("/home/u", "/home/u") == "~");
+}
+
+TEST_CASE("canonicalizeForHistory.outside_home", "[history][required-paths]")
+{
+    CHECK(canonicalizeForHistory("/tmp/x", "/home/u") == "/tmp/x");
+    CHECK(canonicalizeForHistory("/etc/hosts", "/home/u") == "/etc/hosts");
+}
+
+TEST_CASE("canonicalizeForHistory.no_false_prefix_match", "[history][required-paths]")
+{
+    // /home/userx is NOT inside /home/user.
+    CHECK(canonicalizeForHistory("/home/userx/a", "/home/user") == "/home/userx/a");
+}
+
+TEST_CASE("canonicalizeForHistory.empty_home", "[history][required-paths]")
+{
+    CHECK(canonicalizeForHistory("/home/u/x", "") == "/home/u/x");
+}
+
+TEST_CASE("expandForLookup.tilde_slash", "[history][required-paths]")
+{
+    CHECK(expandForLookup("~/projects/endo", "/home/u") == "/home/u/projects/endo");
+}
+
+TEST_CASE("expandForLookup.bare_tilde", "[history][required-paths]")
+{
+    CHECK(expandForLookup("~", "/home/u") == "/home/u");
+}
+
+TEST_CASE("expandForLookup.absolute_unchanged", "[history][required-paths]")
+{
+    CHECK(expandForLookup("/tmp/x", "/home/u") == "/tmp/x");
+}
+
+TEST_CASE("canonicalize_expand_roundtrip", "[history][required-paths]")
+{
+    auto const home = std::string_view { "/home/u" };
+    auto const original = std::string_view { "/home/u/projects/endo/file.txt" };
+    auto const canonical = canonicalizeForHistory(original, home);
+    CHECK(canonical == "~/projects/endo/file.txt");
+    CHECK(expandForLookup(canonical, home) == original);
+}
+
+TEST_CASE("collectRequiredPaths.absolute_path", "[history][required-paths]")
+{
+    auto const argv = std::vector<std::string> { "vim", "/tmp/a.txt" };
+    auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
+    REQUIRE(paths.size() == 1);
+    CHECK(paths[0] == "/tmp/a.txt");
+}
+
+TEST_CASE("collectRequiredPaths.bare_name_is_not_a_path", "[history][required-paths]")
+{
+    // Bare filenames without `/` or path prefix are NOT treated as paths —
+    // they could equally be command names resolved via $PATH.
+    auto const argv = std::vector<std::string> { "vim", "a.txt" };
+    auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
+    CHECK(paths.empty());
+}
+
+TEST_CASE("collectRequiredPaths.dotslash_relative_under_cwd", "[history][required-paths]")
+{
+    auto const argv = std::vector<std::string> { "vim", "./a.txt" };
+    auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
+    REQUIRE(paths.size() == 1);
+    CHECK(paths[0] == "~/a.txt");
+}
+
+TEST_CASE("collectRequiredPaths.subdir_relative_under_cwd", "[history][required-paths]")
+{
+    auto const argv = std::vector<std::string> { "vim", "notes/plan.md" };
+    auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
+    REQUIRE(paths.size() == 1);
+    CHECK(paths[0] == "~/notes/plan.md");
+}
+
+TEST_CASE("collectRequiredPaths.absolute_in_home_canonicalized", "[history][required-paths]")
+{
+    auto const argv = std::vector<std::string> { "vim", "/home/u/notes" };
+    auto const paths = collectRequiredPaths(argv, "/home/u/projects", "/home/u");
+    REQUIRE(paths.size() == 1);
+    CHECK(paths[0] == "~/notes");
+}
+
+TEST_CASE("collectRequiredPaths.tilde_prefix", "[history][required-paths]")
+{
+    auto const argv = std::vector<std::string> { "cat", "~/notes/plan.md" };
+    auto const paths = collectRequiredPaths(argv, "/tmp", "/home/u");
+    REQUIRE(paths.size() == 1);
+    CHECK(paths[0] == "~/notes/plan.md");
+}
+
+TEST_CASE("collectRequiredPaths.skips_bare_command_and_flags", "[history][required-paths]")
+{
+    auto const argv = std::vector<std::string> { "ls", "-la", "--color=auto" };
+    auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
+    CHECK(paths.empty());
+}
+
+TEST_CASE("collectRequiredPaths.mixed_args", "[history][required-paths]")
+{
+    auto const argv = std::vector<std::string> { "cp", "-r", "/tmp/a", "/home/u/b" };
+    auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
+    REQUIRE(paths.size() == 2);
+    CHECK(paths[0] == "/tmp/a");
+    CHECK(paths[1] == "~/b");
+}
+
+TEST_CASE("collectRequiredPaths.caps_at_max", "[history][required-paths]")
+{
+    auto argv = std::vector<std::string> { "rm" };
+    for (auto i = 0; i < 20; ++i)
+        argv.push_back("/tmp/f" + std::to_string(i));
+
+    auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
+    CHECK(paths.size() == maxRequiredPaths);
+}
+
+TEST_CASE("collectRequiredPaths.deduplicates", "[history][required-paths]")
+{
+    auto const argv = std::vector<std::string> { "diff", "/tmp/a", "/tmp/a" };
+    auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
+    REQUIRE(paths.size() == 1);
+    CHECK(paths[0] == "/tmp/a");
+}
+
+TEST_CASE("collectRequiredPaths.empty_argv", "[history][required-paths]")
+{
+    auto const argv = std::vector<std::string> {};
+    auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
+    CHECK(paths.empty());
+}
+
+TEST_CASE("collectRequiredPaths.only_command", "[history][required-paths]")
+{
+    auto const argv = std::vector<std::string> { "git" };
+    auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
+    CHECK(paths.empty());
+}

--- a/src/shell/history/RequiredPaths_test.cpp
+++ b/src/shell/history/RequiredPaths_test.cpp
@@ -27,6 +27,12 @@ TEST_CASE("canonicalizeForHistory.no_false_prefix_match", "[history][required-pa
     CHECK(canonicalizeForHistory("/home/userx/a", "/home/user") == "/home/userx/a");
 }
 
+TEST_CASE("canonicalizeForHistory.home_with_trailing_slash", "[history][required-paths]")
+{
+    CHECK(canonicalizeForHistory("/home/u/projects", "/home/u/") == "~/projects");
+    CHECK(canonicalizeForHistory("/home/u", "/home/u/") == "~");
+}
+
 TEST_CASE("canonicalizeForHistory.empty_home", "[history][required-paths]")
 {
     CHECK(canonicalizeForHistory("/home/u/x", "") == "/home/u/x");
@@ -129,6 +135,19 @@ TEST_CASE("collectRequiredPaths.caps_at_max", "[history][required-paths]")
 
     auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
     CHECK(paths.size() == maxRequiredPaths);
+}
+
+TEST_CASE("collectRequiredPaths.skips_urls", "[history][required-paths]")
+{
+    // Classic fetch/clone URLs must not be recorded as required paths.
+    auto const httpArgv = std::vector<std::string> { "curl", "https://example.com/a/b" };
+    CHECK(collectRequiredPaths(httpArgv, "/home/u", "/home/u").empty());
+
+    auto const gitArgv = std::vector<std::string> { "git", "clone", "git@github.com:org/repo" };
+    CHECK(collectRequiredPaths(gitArgv, "/home/u", "/home/u").empty());
+
+    auto const fileArgv = std::vector<std::string> { "open", "file:///tmp/a" };
+    CHECK(collectRequiredPaths(fileArgv, "/home/u", "/home/u").empty());
 }
 
 TEST_CASE("collectRequiredPaths.deduplicates", "[history][required-paths]")

--- a/src/shell/ui/Prompt.cpp
+++ b/src/shell/ui/Prompt.cpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "Prompt.hpp"
-#include "PromptPresets.hpp"
 
 #include <tui/Screen.hpp>
 
+#include "PromptPresets.hpp"
 #include "modules/GitModule.hpp"
 
 #if defined(__clang__)
@@ -29,8 +29,7 @@
 namespace endo
 {
 
-Prompt::Prompt():
-    _promptConfig { promptPreset("endo-signature") }
+Prompt::Prompt(): _promptConfig { promptPreset("endo-signature") }
 {
     _promptStr = _promptConfig.indicator;
 }
@@ -622,6 +621,20 @@ void Prompt::setHistory(History const* history)
     _history = history;
     if (_promptComponent)
         _promptComponent->setHistory(history);
+}
+
+void Prompt::setEnvironmentProvider(EnvironmentProvider const* env)
+{
+    _envProvider = env;
+    if (_promptComponent)
+        _promptComponent->setEnvironmentProvider(env);
+}
+
+void Prompt::setFileSystem(FileSystem const* fs)
+{
+    _historyFs = fs;
+    if (_promptComponent)
+        _promptComponent->setFileSystem(fs);
 }
 
 void Prompt::setCommandRegistry(tui::CommandRegistry* registry)

--- a/src/shell/ui/Prompt.hpp
+++ b/src/shell/ui/Prompt.hpp
@@ -131,6 +131,14 @@ class Prompt
     /// @param history The history object (ownership not transferred).
     void setHistory(History const* history);
 
+    /// @brief Sets the environment provider used for CWD-aware history ranking.
+    /// @param env Pointer (not owned) — may outlive the prompt.
+    void setEnvironmentProvider(EnvironmentProvider const* env);
+
+    /// @brief Sets the filesystem used for required-paths validation in history search.
+    /// @param fs Pointer (not owned); nullptr disables validation.
+    void setFileSystem(FileSystem const* fs);
+
     /// @brief Sets the command registry used by the command palette.
     /// @param registry Pointer to the registry (caller owns, must outlive this prompt).
     void setCommandRegistry(tui::CommandRegistry* registry);
@@ -184,6 +192,8 @@ class Prompt
     std::unique_ptr<CommandResolver> _commandResolver;
     Completer* _completer = nullptr;
     History const* _history = nullptr;
+    EnvironmentProvider const* _envProvider = nullptr;
+    FileSystem const* _historyFs = nullptr;
     std::string _promptStr = "> ";
     PromptConfig _promptConfig;
     bool _initialized = false;

--- a/src/shell/ui/PromptComponent.cpp
+++ b/src/shell/ui/PromptComponent.cpp
@@ -3,6 +3,7 @@
 #include <shell/completion/Completer.hpp>
 #include <shell/completion/FileCompleter.hpp>
 #include <shell/history/History.hpp>
+#include <shell/history/RequiredPaths.hpp>
 #include <shell/ui/SourceOffsetUtils.hpp>
 #include <shell/ui/SyntaxHighlighter.hpp>
 #include <shell/util/CommandResolver.hpp>
@@ -1335,7 +1336,7 @@ void PromptComponent::triggerHistorySearch()
     if (_envProvider)
     {
         options.currentCwd = _envProvider->currentDirectory();
-        options.home = _envProvider->get("HOME").value_or(std::string {});
+        options.home = normalizedHomeDirectory(*_envProvider);
     }
     options.fs = _historyFs;
     options.validateRequiredPaths = _historyFs != nullptr;
@@ -1375,7 +1376,7 @@ void PromptComponent::updateHistorySearchPopup()
     if (_envProvider)
     {
         options.currentCwd = _envProvider->currentDirectory();
-        options.home = _envProvider->get("HOME").value_or(std::string {});
+        options.home = normalizedHomeDirectory(*_envProvider);
     }
     options.fs = _historyFs;
     options.validateRequiredPaths = _historyFs != nullptr;

--- a/src/shell/ui/PromptComponent.cpp
+++ b/src/shell/ui/PromptComponent.cpp
@@ -1331,7 +1331,15 @@ void PromptComponent::triggerHistorySearch()
     }
 
     auto const inputText = std::string(_inputField.text());
-    auto results = _history->searchFuzzy(inputText, 200);
+    auto options = FuzzySearchOptions {};
+    if (_envProvider)
+    {
+        options.currentCwd = _envProvider->currentDirectory();
+        options.home = _envProvider->get("HOME").value_or(std::string {});
+    }
+    options.fs = _historyFs;
+    options.validateRequiredPaths = _historyFs != nullptr;
+    auto results = _history->searchFuzzy(inputText, 200, options);
 
     if (results.empty())
     {
@@ -1363,7 +1371,15 @@ void PromptComponent::updateHistorySearchPopup()
     }
 
     auto const inputText = std::string(_inputField.text());
-    auto results = _history->searchFuzzy(inputText, 200);
+    auto options = FuzzySearchOptions {};
+    if (_envProvider)
+    {
+        options.currentCwd = _envProvider->currentDirectory();
+        options.home = _envProvider->get("HOME").value_or(std::string {});
+    }
+    options.fs = _historyFs;
+    options.validateRequiredPaths = _historyFs != nullptr;
+    auto results = _history->searchFuzzy(inputText, 200, options);
 
     if (results.empty())
     {

--- a/src/shell/ui/PromptComponent.hpp
+++ b/src/shell/ui/PromptComponent.hpp
@@ -25,6 +25,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include <platform/EnvironmentProvider.hpp>
+#include <platform/FileSystem.hpp>
+
 namespace endo
 {
 
@@ -108,6 +111,14 @@ class PromptComponent: public tui::Component
 
     /// @brief Sets the history source for inline history cycling.
     void setHistory(History const* history) { _history = history; }
+
+    /// @brief Sets the environment provider used to read the current CWD and $HOME
+    /// when querying history with CWD-aware ranking.
+    void setEnvironmentProvider(EnvironmentProvider const* env) { _envProvider = env; }
+
+    /// @brief Sets the filesystem used for required-paths validation in history search.
+    /// Pass nullptr to disable validation.
+    void setFileSystem(FileSystem const* fs) { _historyFs = fs; }
 
     /// @brief Handles input events dispatched by Screen (mouse events).
     ///
@@ -245,6 +256,8 @@ class PromptComponent: public tui::Component
     bool _terminalFocused = true; ///< Terminal focus state for visual dimming.
     CommandResolver* _commandResolver = nullptr;
     History const* _history = nullptr;
+    EnvironmentProvider const* _envProvider = nullptr;
+    FileSystem const* _historyFs = nullptr;
     std::string _promptStr = "> ";
 
     // Prompt theming


### PR DESCRIPTION
Record the working directory and path-like arguments alongside each history entry, stored in canonical home-relative (`~/...`) form so the history file remains portable across users and machines. Ghost text and completion now surface entries from the current directory ahead of unrelated but more-recent ones, and suggestions whose referenced files no longer exist are hidden automatically — closing the gap that fish-shell [#120](https://github.com/fish-shell/fish-shell/issues/120) has had open since 2011, while also adopting fish's `required_paths` validation.

## Changes

- `HistoryEntry` carries `cwd` and `requiredPaths`; YAML schema bumps to v2 and still reads v1 files (no migration required).
- Stored paths use `~/...` when under `\$HOME`, keeping history usable across machines where `\$HOME` differs (`/home/alice` vs `/Users/alice` vs `/root`).
- `searchFuzzy` adds two ranking bonuses: exact-CWD match (+300, outranks max recency) and ancestor-CWD match (+150). Unknown/empty CWD is neither boosted nor penalised.
- Entries whose required paths no longer exist are suppressed from completions; a per-call existence cache keeps the cost bounded on large histories.
- `HistoryCompleter` now takes an `EnvironmentProvider` and optional `FileSystem`; the Ctrl-R-style history popup applies the same ranking.
- `history search` gains `--cwd` (restrict to current directory or an ancestor) and `--no-validate` (skip the existence filter).
- Fish import picks up fish's `paths:` field and routes it through the same canonicalisation.