### PR TITLE
Add `pkill` inline builtin

### DIFF
--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(endo-platform STATIC
     UserPaths.hpp
     PathUtils.hpp
     ProcessProvider.hpp
+    ProcessProvider.cpp
     FileSystem.hpp
     NativeFileSystem.hpp
     NativeFileSystem.cpp

--- a/src/platform/ProcessProvider.cpp
+++ b/src/platform/ProcessProvider.cpp
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <platform/ProcessProvider.hpp>
+
+#if defined(_WIN32)
+    #include <platform/windows/WindowsProcessProvider.hpp>
+#elif defined(__APPLE__)
+    #include <platform/darwin/DarwinProcessProvider.hpp>
+#else
+    #include <platform/linux/LinuxProcessProvider.hpp>
+#endif
+
+namespace endo::platform
+{
+
+std::unique_ptr<ProcessProvider> createNativeProcessProvider()
+{
+#if defined(_WIN32)
+    return std::make_unique<WindowsProcessProvider>();
+#elif defined(__APPLE__)
+    return std::make_unique<DarwinProcessProvider>();
+#else
+    return std::make_unique<LinuxProcessProvider>();
+#endif
+}
+
+} // namespace endo::platform

--- a/src/platform/ProcessProvider.hpp
+++ b/src/platform/ProcessProvider.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -33,11 +34,16 @@ class ProcessProvider
     [[nodiscard]] virtual std::vector<ProcessEntry> listProcesses() const = 0;
 };
 
+/// Constructs the platform-native ProcessProvider implementation.
+/// Returns a Linux/Darwin/Windows provider depending on the build target.
+[[nodiscard]] std::unique_ptr<ProcessProvider> createNativeProcessProvider();
+
 } // namespace endo::platform
 
 // Backward-compatible aliases in the endo namespace
 namespace endo
 {
+using endo::platform::createNativeProcessProvider;
 using endo::platform::ProcessEntry;
 using endo::platform::ProcessProvider;
 } // namespace endo

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -184,6 +184,10 @@ add_library(endo-shell STATIC
     commands/BindCommand.cpp
     commands/KillCommand.hpp
     commands/KillCommand.cpp
+    commands/PkillCommand.hpp
+    commands/PkillCommand.cpp
+    completion/ProcessNameQueryProvider.hpp
+    completion/ProcessNameQueryProvider.cpp
 )
 
 # Platform-specific implementations
@@ -258,6 +262,7 @@ add_executable(test-endo-shell
     commands/FindExpression_test.cpp
     commands/GrepCommand_test.cpp
     commands/TimeoutCommand_test.cpp
+    commands/PkillCommand_test.cpp
     CrashHandler_test.cpp
     ui/PromptComponent_test.cpp
     ui/modules/GitModule_test.cpp

--- a/src/shell/Shell.hpp
+++ b/src/shell/Shell.hpp
@@ -287,6 +287,9 @@ class Shell final: public SignalCallback
     [[nodiscard]] int executeInlineTimeout(CoreVM::CoreStringArray const& args, NativeHandle outputFd);
     /// Executes the kill builtin, sending signals to processes or jobs. Returns exit code.
     [[nodiscard]] int executeInlineKill(CoreVM::CoreStringArray const& args, NativeHandle outputFd);
+    /// Executes the pkill builtin, sending signals to processes matched by name or command line. Returns exit
+    /// code.
+    [[nodiscard]] int executeInlinePkill(CoreVM::CoreStringArray const& args, NativeHandle outputFd);
     /// Executes the whoami builtin. Returns exit code.
     [[nodiscard]] int executeInlineWhoami(CoreVM::CoreStringArray const& args, NativeHandle outputFd);
     /// Executes the hostname builtin. Returns exit code.

--- a/src/shell/builtins/InlineCommandDescriptors.cpp
+++ b/src/shell/builtins/InlineCommandDescriptors.cpp
@@ -133,6 +133,18 @@ static constexpr InlineOptionDef kTeeOptions[] = {
     { .shortFlag = "-a", .longFlag = "--append", .description = "Append to files instead of overwriting" },
 };
 
+static constexpr InlineOptionDef kPkillOptions[] = {
+    { .shortFlag = "-s", .longFlag = {}, .description = "Signal to send (name or number)", .takesValue = true },
+    { .shortFlag = "-f", .longFlag = {}, .description = "Match against the full command line" },
+    { .shortFlag = "-x", .longFlag = {}, .description = "Require exact (anchored) match" },
+    { .shortFlag = "-i", .longFlag = {}, .description = "Case-insensitive match" },
+    { .shortFlag = "-c", .longFlag = {}, .description = "Print count of matched processes" },
+    { .shortFlag = "-l", .longFlag = {}, .description = "List matched processes without signalling" },
+    { .shortFlag = "-n", .longFlag = {}, .description = "Match only the newest process" },
+    { .shortFlag = "-o", .longFlag = {}, .description = "Match only the oldest process" },
+    { .shortFlag = "-u", .longFlag = {}, .description = "Restrict to processes owned by USER[,USER]", .takesValue = true },
+};
+
 // clang-format on
 
 // ---------------------------------------------------------------------------
@@ -227,6 +239,10 @@ std::span<InlineCommandDescriptor const> Shell::inlineCommandDescriptors()
           .usageLine = "nproc [OPTIONS]",
           .options = kNprocOptions,
           .noStdinFn = &Shell::executeInlineNproc },
+        { .name = "pkill",     .briefDescription = "Send signals to processes matched by name or command-line pattern.",
+          .usageLine = "pkill [OPTIONS] [-SIGNAL] PATTERN",
+          .options = kPkillOptions,
+          .noStdinFn = &Shell::executeInlinePkill },
         { .name = "pwd",      .briefDescription = "Print the current working directory.",
           .usageLine = "pwd",
           .options = {},

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -3,6 +3,7 @@
 #include <shell/commands/FindExpression.hpp>
 #include <shell/commands/GrepCommand.hpp>
 #include <shell/commands/KillCommand.hpp>
+#include <shell/commands/PkillCommand.hpp>
 #include <shell/commands/TimeoutCommand.hpp>
 #include <shell/history/RequiredPaths.hpp>
 
@@ -22,6 +23,7 @@
 #include <iostream>
 #include <random>
 #include <ranges>
+#include <regex>
 #include <span>
 #include <sstream>
 #include <thread>
@@ -31,6 +33,7 @@
 
 #include <platform/PathUtils.hpp>
 #include <platform/Process.hpp>
+#include <platform/ProcessProvider.hpp>
 #include <platform/SignalHandler.hpp>
 #include <platform/Types.hpp>
 
@@ -2670,6 +2673,167 @@ int Shell::executeInlineKill(CoreVM::CoreStringArray const& args, NativeHandle o
         }
     }
 
+    return exitCode;
+}
+
+// ---------------------------------------------------------------------------
+// pkill
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+    /// Returns true if @p entry's owner is listed in @p users. An empty @p users
+    /// list disables the filter (match-all).
+    [[nodiscard]] bool matchesUserFilter(ProcessEntry const& entry, std::vector<std::string> const& users)
+    {
+        if (users.empty())
+            return true;
+        return std::ranges::find(users, entry.user) != users.end();
+    }
+
+} // namespace
+
+int Shell::executeInlinePkill(CoreVM::CoreStringArray const& args, NativeHandle outputFd)
+{
+    auto pkillArgs = std::vector<std::string> {};
+    for (auto const i: std::views::iota(1uz, args.size()))
+        pkillArgs.push_back(args.at(i));
+
+    auto parsed = pkill_cmd::parsePkillArgs(pkillArgs);
+    if (!parsed.has_value())
+    {
+        error("{}", parsed.error());
+        return 2;
+    }
+
+    auto const& opts = parsed.value();
+
+    if (opts.showHelp)
+        return renderMarkdownHelp(outputFd,
+                                  "# pkill\n"
+                                  "\n"
+                                  "Send signals to processes matched by name or command-line pattern.\n"
+                                  "\n"
+                                  "## Usage\n"
+                                  "\n"
+                                  "`pkill [OPTIONS] [-SIGNAL] PATTERN`\n"
+                                  "\n"
+                                  "## Options\n"
+                                  "\n"
+                                  "| Option | Description |\n"
+                                  "|---|---|\n"
+                                  "| `-SIGNAL` | Signal to send by name or number (default: `TERM`) |\n"
+                                  "| `-s SIGNAL` | Signal to send (POSIX style) |\n"
+                                  "| `-f` | Match PATTERN against the full command line |\n"
+                                  "| `-x` | Require an exact (anchored) match |\n"
+                                  "| `-i` | Case-insensitive pattern match |\n"
+                                  "| `-c` | Print the count of matched processes |\n"
+                                  "| `-l` | List matches (`pid name`) without signalling |\n"
+                                  "| `-n` | Match only the newest (highest PID) process |\n"
+                                  "| `-o` | Match only the oldest (lowest PID) process |\n"
+                                  "| `-u USER[,USER]` | Only match processes owned by listed users |\n"
+                                  "| `-h`, `--help` | Show this help message |\n"
+                                  "\n"
+                                  "## Notes\n"
+                                  "\n"
+                                  "- PATTERN is an ECMAScript regular expression.\n"
+                                  "- The shell's own process is always excluded from matches.\n"
+                                  "- Matching runs against the platform's most reliable command field "
+                                  "(argv[0] on Linux, the command string on Darwin/Windows); `-f` is "
+                                  "accepted for CLI compatibility but targets the same field.\n"
+                                  "\n"
+                                  "## Examples\n"
+                                  "\n"
+                                  "| Example | Description |\n"
+                                  "|---|---|\n"
+                                  "| `pkill sleep` | Send `SIGTERM` to every process named `sleep` |\n"
+                                  "| `pkill -9 firefox` | Send `SIGKILL` to every firefox process |\n"
+                                  "| `pkill -f \"python myscript\"` | Match against the full command line |\n"
+                                  "| `pkill -l nginx` | List matching processes without signalling |\n"
+                                  "| `pkill -u alice bash` | Only signal alice's bash processes |\n");
+
+    auto flags = std::regex::ECMAScript;
+    if (opts.caseInsensitive)
+        flags |= std::regex::icase;
+
+    auto const patternText = opts.exactMatch ? std::string("^(?:") + opts.pattern + ")$" : opts.pattern;
+
+    auto pattern = std::regex {};
+    try
+    {
+        pattern = std::regex(patternText, flags);
+    }
+    catch (std::regex_error const& ex)
+    {
+        error("pkill: invalid pattern '{}': {}", opts.pattern, ex.what());
+        return 2;
+    }
+
+    auto provider = createNativeProcessProvider();
+    auto entries = provider->listProcesses();
+
+    auto const selfPid = static_cast<int64_t>(_shellPid);
+
+    auto matches = std::vector<ProcessEntry> {};
+    for (auto const& entry: entries)
+    {
+        if (entry.pid == selfPid)
+            continue;
+        if (!matchesUserFilter(entry, opts.userFilter))
+            continue;
+
+        // ProcessEntry::command is whatever the platform exposes most reliably
+        // (argv[0] on Linux, the command string on Darwin/Windows). Full-cmdline
+        // matching (-f) is accepted for CLI compatibility but matches the same
+        // field since richer data is not available across all platforms.
+        auto const& haystack = entry.command;
+        auto const matched =
+            opts.exactMatch ? std::regex_match(haystack, pattern) : std::regex_search(haystack, pattern);
+        if (matched)
+            matches.push_back(entry);
+    }
+
+    if (matches.empty())
+        return 1;
+
+    if (opts.newestOnly || opts.oldestOnly)
+    {
+        auto const cmp = [](ProcessEntry const& a, ProcessEntry const& b) {
+            return a.pid < b.pid;
+        };
+        auto const it =
+            opts.newestOnly ? std::ranges::max_element(matches, cmp) : std::ranges::min_element(matches, cmp);
+        auto picked = *it;
+        matches.clear();
+        matches.push_back(std::move(picked));
+    }
+
+    if (opts.listOnly)
+    {
+        auto output = std::string {};
+        for (auto const& m: matches)
+            output += std::format("{} {}\n", m.pid, m.command);
+        [[maybe_unused]] auto const written = platformWrite(outputFd, output.data(), output.size());
+        return 0;
+    }
+
+    if (opts.countOnly)
+    {
+        auto const output = std::format("{}\n", matches.size());
+        [[maybe_unused]] auto const written = platformWrite(outputFd, output.data(), output.size());
+    }
+
+    auto exitCode = 0;
+    for (auto const& m: matches)
+    {
+        auto const result = _processManager.sendSignal(static_cast<ProcessId>(m.pid), opts.signal);
+        if (!result.has_value())
+        {
+            error("pkill: ({}) - {}", m.pid, toString(result.error()));
+            exitCode = 1;
+        }
+    }
     return exitCode;
 }
 

--- a/src/shell/commands/PkillCommand.cpp
+++ b/src/shell/commands/PkillCommand.cpp
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <shell/commands/PkillCommand.hpp>
+#include <shell/commands/TimeoutCommand.hpp>
+
+#include <format>
+#include <string_view>
+
+namespace endo::pkill_cmd
+{
+
+namespace
+{
+
+    /// Splits a comma-separated user list into individual usernames.
+    /// Empty entries are skipped.
+    std::vector<std::string> splitUsers(std::string_view spec)
+    {
+        auto users = std::vector<std::string> {};
+        size_t start = 0;
+        while (start <= spec.size())
+        {
+            auto const comma = spec.find(',', start);
+            auto const end = (comma == std::string_view::npos) ? spec.size() : comma;
+            if (end > start)
+                users.emplace_back(spec.substr(start, end - start));
+            if (comma == std::string_view::npos)
+                break;
+            start = comma + 1;
+        }
+        return users;
+    }
+
+    /// Consumes the value for an option that requires one, returning the consumed string
+    /// or an error describing the missing operand.
+    std::expected<std::string, std::string> takeValue(std::span<std::string const> args,
+                                                      size_t& i,
+                                                      std::string_view flag)
+    {
+        if (i + 1 >= args.size())
+            return std::unexpected(std::format("pkill: option requires an argument -- '{}'", flag));
+        ++i;
+        return args[i];
+    }
+
+} // namespace
+
+std::expected<PkillOptions, std::string> parsePkillArgs(std::span<std::string const> args)
+{
+    auto opts = PkillOptions {};
+
+    for (size_t i = 0; i < args.size(); ++i)
+    {
+        auto const& arg = args[i];
+
+        if (arg == "-h" || arg == "--help")
+        {
+            opts.showHelp = true;
+            return opts;
+        }
+
+        if (arg == "--")
+        {
+            if (i + 1 < args.size())
+                opts.pattern = args[i + 1];
+            if (i + 2 < args.size())
+                return std::unexpected(std::string("pkill: too many arguments"));
+            if (opts.pattern.empty())
+                return std::unexpected(std::string("pkill: missing pattern"));
+            return opts;
+        }
+
+        if (arg == "-f")
+        {
+            opts.fullMatch = true;
+            continue;
+        }
+        if (arg == "-x")
+        {
+            opts.exactMatch = true;
+            continue;
+        }
+        if (arg == "-i")
+        {
+            opts.caseInsensitive = true;
+            continue;
+        }
+        if (arg == "-c")
+        {
+            opts.countOnly = true;
+            continue;
+        }
+        if (arg == "-l")
+        {
+            opts.listOnly = true;
+            continue;
+        }
+        if (arg == "-n")
+        {
+            opts.newestOnly = true;
+            continue;
+        }
+        if (arg == "-o")
+        {
+            opts.oldestOnly = true;
+            continue;
+        }
+
+        if (arg == "-u")
+        {
+            auto val = takeValue(args, i, "u");
+            if (!val.has_value())
+                return std::unexpected(val.error());
+            opts.userFilter = splitUsers(*val);
+            if (opts.userFilter.empty())
+                return std::unexpected(std::string("pkill: -u requires at least one user"));
+            continue;
+        }
+
+        if (arg == "-s")
+        {
+            auto val = takeValue(args, i, "s");
+            if (!val.has_value())
+                return std::unexpected(val.error());
+            auto const sigResult = timeout::parseSignalSpec(*val);
+            if (!sigResult.has_value())
+                return std::unexpected(std::format("pkill: {}", sigResult.error()));
+            opts.signal = *sigResult;
+            continue;
+        }
+
+        // -SIGNAL (e.g., -9, -TERM, -SIGKILL)
+        if (arg.starts_with("-") && arg.size() > 1 && arg[1] != '-')
+        {
+            auto const spec = std::string_view(arg).substr(1);
+            auto const sigResult = timeout::parseSignalSpec(spec);
+            if (sigResult.has_value())
+            {
+                opts.signal = *sigResult;
+                continue;
+            }
+            return std::unexpected(std::format("pkill: invalid option '{}'", arg));
+        }
+
+        // First non-option positional is the pattern; any further positionals are an error.
+        if (opts.pattern.empty())
+        {
+            opts.pattern = arg;
+            continue;
+        }
+        return std::unexpected(std::string("pkill: too many arguments"));
+    }
+
+    if (opts.newestOnly && opts.oldestOnly)
+        return std::unexpected(std::string("pkill: -n and -o are mutually exclusive"));
+
+    if (opts.pattern.empty())
+        return std::unexpected(std::string("pkill: missing pattern"));
+
+    return opts;
+}
+
+} // namespace endo::pkill_cmd

--- a/src/shell/commands/PkillCommand.hpp
+++ b/src/shell/commands/PkillCommand.hpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <expected>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace endo::pkill_cmd
+{
+
+/// Options parsed from pkill command-line arguments.
+struct PkillOptions
+{
+    int signal = 15;                     ///< Signal to send (default SIGTERM)
+    std::string pattern;                 ///< Regex pattern to match against process name / command line
+    std::vector<std::string> userFilter; ///< -u USER[,USER]: only match processes owned by these users
+    bool fullMatch = false;              ///< -f: match against full command line instead of short name
+    bool exactMatch = false;             ///< -x: require full (anchored) match, not substring
+    bool caseInsensitive = false;        ///< -i: case-insensitive pattern match
+    bool countOnly = false;              ///< -c: print count of matched processes
+    bool listOnly = false;               ///< -l: list matches (pid name) and do not signal
+    bool newestOnly = false;             ///< -n: match only the newest (highest PID) process
+    bool oldestOnly = false;             ///< -o: match only the oldest (lowest PID) process
+    bool showHelp = false;               ///< -h / --help: show help text
+};
+
+/// Parses pkill command-line arguments.
+///
+/// Supports:
+/// - `pkill PATTERN` (default SIGTERM)
+/// - `pkill -SIGNAL PATTERN` (e.g., `-9`, `-TERM`, `-SIGKILL`)
+/// - `pkill -s SIGNAL PATTERN` (POSIX style)
+/// - `pkill -f PATTERN` (match full command line)
+/// - `pkill -x PATTERN` (exact anchored match)
+/// - `pkill -i PATTERN` (case-insensitive)
+/// - `pkill -c PATTERN` (print count and still signal)
+/// - `pkill -l PATTERN` (list matches without signalling)
+/// - `pkill -n PATTERN` (newest-only) / `-o PATTERN` (oldest-only)
+/// - `pkill -u USER[,USER] PATTERN` (restrict to owners)
+/// - `pkill -h` / `pkill --help`
+///
+/// @param args The arguments to parse (excluding the "pkill" program name).
+/// @return Parsed options, or an error message.
+[[nodiscard]] std::expected<PkillOptions, std::string> parsePkillArgs(std::span<std::string const> args);
+
+} // namespace endo::pkill_cmd

--- a/src/shell/commands/PkillCommand_test.cpp
+++ b/src/shell/commands/PkillCommand_test.cpp
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <shell/commands/PkillCommand.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <vector>
+
+using namespace endo::pkill_cmd;
+
+namespace
+{
+std::vector<std::string> makeArgs(std::initializer_list<std::string_view> items)
+{
+    auto out = std::vector<std::string> {};
+    out.reserve(items.size());
+    for (auto const& s: items)
+        out.emplace_back(s);
+    return out;
+}
+} // namespace
+
+TEST_CASE("parsePkillArgs.missing_pattern", "[pkill]")
+{
+    auto const args = std::vector<std::string> {};
+    auto const result = parsePkillArgs(args);
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("parsePkillArgs.defaults", "[pkill]")
+{
+    auto const args = makeArgs({ "foo" });
+    auto const result = parsePkillArgs(args);
+    REQUIRE(result.has_value());
+    CHECK(result->pattern == "foo");
+    CHECK(result->signal == 15);
+    CHECK_FALSE(result->fullMatch);
+    CHECK_FALSE(result->exactMatch);
+    CHECK_FALSE(result->caseInsensitive);
+    CHECK_FALSE(result->countOnly);
+    CHECK_FALSE(result->listOnly);
+    CHECK_FALSE(result->newestOnly);
+    CHECK_FALSE(result->oldestOnly);
+    CHECK(result->userFilter.empty());
+}
+
+TEST_CASE("parsePkillArgs.numeric_signal_dash_prefix", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-9", "foo" }));
+    REQUIRE(result.has_value());
+    CHECK(result->signal == 9);
+    CHECK(result->pattern == "foo");
+}
+
+TEST_CASE("parsePkillArgs.named_signal_dash_prefix", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-TERM", "foo" }));
+    REQUIRE(result.has_value());
+    CHECK(result->signal == 15);
+    CHECK(result->pattern == "foo");
+}
+
+TEST_CASE("parsePkillArgs.sigkill_prefix", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-SIGKILL", "foo" }));
+    REQUIRE(result.has_value());
+    CHECK(result->signal == 9);
+}
+
+TEST_CASE("parsePkillArgs.s_flag_signal", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-s", "HUP", "foo" }));
+    REQUIRE(result.has_value());
+    CHECK(result->signal == 1);
+    CHECK(result->pattern == "foo");
+}
+
+TEST_CASE("parsePkillArgs.s_flag_missing_value", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-s" }));
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("parsePkillArgs.unknown_dash_option", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-ZZZ", "foo" }));
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("parsePkillArgs.flags_combo", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-f", "-x", "-i", "bar" }));
+    REQUIRE(result.has_value());
+    CHECK(result->fullMatch);
+    CHECK(result->exactMatch);
+    CHECK(result->caseInsensitive);
+    CHECK(result->pattern == "bar");
+}
+
+TEST_CASE("parsePkillArgs.list_flag_no_signal_required", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-l", "bar" }));
+    REQUIRE(result.has_value());
+    CHECK(result->listOnly);
+    CHECK(result->signal == 15);
+}
+
+TEST_CASE("parsePkillArgs.count_flag", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-c", "bar" }));
+    REQUIRE(result.has_value());
+    CHECK(result->countOnly);
+}
+
+TEST_CASE("parsePkillArgs.user_filter_single", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-u", "alice", "foo" }));
+    REQUIRE(result.has_value());
+    REQUIRE(result->userFilter.size() == 1);
+    CHECK(result->userFilter[0] == "alice");
+}
+
+TEST_CASE("parsePkillArgs.user_filter_multi", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-u", "alice,bob,carol", "foo" }));
+    REQUIRE(result.has_value());
+    REQUIRE(result->userFilter.size() == 3);
+    CHECK(result->userFilter[0] == "alice");
+    CHECK(result->userFilter[1] == "bob");
+    CHECK(result->userFilter[2] == "carol");
+}
+
+TEST_CASE("parsePkillArgs.user_filter_empty_rejected", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-u", ",,", "foo" }));
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("parsePkillArgs.newest_and_oldest_mutually_exclusive", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-n", "-o", "foo" }));
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("parsePkillArgs.help_short", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-h" }));
+    REQUIRE(result.has_value());
+    CHECK(result->showHelp);
+}
+
+TEST_CASE("parsePkillArgs.help_long", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "--help" }));
+    REQUIRE(result.has_value());
+    CHECK(result->showHelp);
+}
+
+TEST_CASE("parsePkillArgs.double_dash_pattern", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "--", "-weird-pattern" }));
+    REQUIRE(result.has_value());
+    CHECK(result->pattern == "-weird-pattern");
+}
+
+TEST_CASE("parsePkillArgs.too_many_positionals", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "foo", "bar" }));
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("parsePkillArgs.combined_signal_and_flags", "[pkill]")
+{
+    auto const result = parsePkillArgs(makeArgs({ "-9", "-f", "-i", "my.*proc" }));
+    REQUIRE(result.has_value());
+    CHECK(result->signal == 9);
+    CHECK(result->fullMatch);
+    CHECK(result->caseInsensitive);
+    CHECK(result->pattern == "my.*proc");
+}

--- a/src/shell/completion/Completer.cpp
+++ b/src/shell/completion/Completer.cpp
@@ -4,6 +4,7 @@
 #include <shell/completion/DirconfigSpec.hpp>
 #include <shell/completion/GitSpec.hpp>
 #include <shell/completion/HistorySpec.hpp>
+#include <shell/completion/ProcessNameQueryProvider.hpp>
 #include <shell/completion/ScriptedCompleter.hpp>
 
 #include <tui/completer/Completer.hpp>
@@ -20,6 +21,8 @@ Completer::Completer(EnvironmentProvider const& env,
                      FSharpPersistentState const& fsharpState,
                      FileSystem const* fs)
 {
+    _processProvider = createNativeProcessProvider();
+
     // Register default providers in priority order
     _providers.push_back(std::make_unique<BuiltinArgumentCompleter>());
     _providers.push_back(std::make_unique<CommandCompleter>(env, history));
@@ -30,7 +33,22 @@ Completer::Completer(EnvironmentProvider const& env,
     specCompleter->registerCommand(createGitSpec(), std::make_unique<GitQueryProvider>());
     specCompleter->registerCommand(createDirconfigSpec(), nullptr);
     for (auto& spec: createBuiltinSpecs())
+    {
+        if (spec.command == "pkill")
+        {
+            spec.positionalArgs.clear();
+            spec.positionalArgs.push_back(
+                ArgDef { .kind = ArgKind::DynamicQuery,
+                         .description = "Process name pattern",
+                         .queryTag = "process-names",
+                         .repeatable = false,
+                         .optionQueryOverrides = { { "-f", "process-command-lines" } } });
+            specCompleter->registerCommand(std::move(spec),
+                                           std::make_unique<ProcessNameQueryProvider>(*_processProvider));
+            continue;
+        }
         specCompleter->registerCommand(std::move(spec), nullptr);
+    }
     // Register after createBuiltinSpecs() to overwrite the auto-generated spec with subcommands
     specCompleter->registerCommand(createHistorySpec(), nullptr);
     _providers.push_back(std::move(specCompleter));

--- a/src/shell/completion/Completer.hpp
+++ b/src/shell/completion/Completer.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <platform/EnvironmentProvider.hpp>
+#include <platform/ProcessProvider.hpp>
 
 namespace endo
 {
@@ -82,6 +83,9 @@ class Completer
     [[nodiscard]] std::vector<std::string> takeLastErrors();
 
   private:
+    /// Owned platform process provider used by the pkill process-name query.
+    /// Kept alive for the lifetime of the CommandSpecCompleter that references it.
+    std::unique_ptr<ProcessProvider> _processProvider;
     std::vector<std::unique_ptr<CompletionProvider>> _providers;
     CompletionConfig _config;
 

--- a/src/shell/completion/ProcessNameQueryProvider.cpp
+++ b/src/shell/completion/ProcessNameQueryProvider.cpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "ProcessNameQueryProvider.hpp"
+
+#include <algorithm>
+#include <format>
+#include <unordered_map>
+
+namespace endo
+{
+
+ProcessNameQueryProvider::ProcessNameQueryProvider(ProcessProvider const& provider): _provider(provider)
+{
+}
+
+std::vector<QueryResult> ProcessNameQueryProvider::query(std::string_view queryTag)
+{
+    if (queryTag != "process-names" && queryTag != "process-command-lines")
+        return {};
+
+    // Deduplicate by command text; keep a representative pid for the description
+    // so the menu can show e.g. "pid=1234" to disambiguate.
+    auto seen = std::unordered_map<std::string, int64_t> {};
+    for (auto const& entry: _provider.listProcesses())
+    {
+        if (entry.command.empty())
+            continue;
+        seen.try_emplace(entry.command, entry.pid);
+    }
+
+    auto results = std::vector<QueryResult> {};
+    results.reserve(seen.size());
+    for (auto const& [cmd, pid]: seen)
+        results.push_back(QueryResult { .text = cmd, .description = std::format("pid={}", pid) });
+
+    std::ranges::sort(results, {}, &QueryResult::text);
+    return results;
+}
+
+} // namespace endo

--- a/src/shell/completion/ProcessNameQueryProvider.hpp
+++ b/src/shell/completion/ProcessNameQueryProvider.hpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <shell/completion/CommandQueryProvider.hpp>
+
+#include <string_view>
+#include <vector>
+
+#include <platform/ProcessProvider.hpp>
+
+namespace endo
+{
+
+/// @brief Provides completion candidates derived from the currently running
+/// processes on the host system.
+///
+/// Used by the `pkill` builtin to suggest live process names. The provider
+/// borrows a reference to a ProcessProvider injected by the completion system.
+class ProcessNameQueryProvider: public CommandQueryProvider
+{
+  public:
+    /// @param provider Reference to the process enumerator. Must outlive this object.
+    explicit ProcessNameQueryProvider(ProcessProvider const& provider);
+
+    /// @brief Resolves a query tag into completion candidates.
+    ///
+    /// Supported tags:
+    ///  - `"process-names"` — deduplicated list of process command names.
+    ///  - `"process-command-lines"` — same set today; reserved for future full-cmdline mode.
+    ///
+    /// @return Candidates (empty for unknown tags).
+    [[nodiscard]] std::vector<QueryResult> query(std::string_view queryTag) override;
+
+  private:
+    ProcessProvider const& _provider;
+};
+
+} // namespace endo

--- a/tests/builtins/pkill_help.endo
+++ b/tests/builtins/pkill_help.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: pkill --help shows usage
+# expect-nonempty
+
+pkill --help


### PR DESCRIPTION
Adds a procps-compatible `pkill` builtin that signals processes matched by regex against the platform's command field, with tab completion over live process names. Implemented as an inline builtin so it works without spawning an external `pkill` and participates in the shell's help/completion/LSP metadata pipeline.

## Changes

- **`pkill` builtin** — supports `-SIGNAL`/`-s`, `-f`/`-x`/`-i` match modes, `-l`/`-c` reporting, `-n`/`-o` selection, and `-u USER[,USER]` owner filtering. Always excludes the shell's own pid.
- **Process-name completion** — new `ProcessNameQueryProvider` feeds `pkill <TAB>` with live process names; the existing `QueryCache` wrap in `CommandSpecCompleter` keeps `/proc` reads off the typing hot path.
- **Platform cleanup** — extracts `platform::createNativeProcessProvider()` so the Linux/Darwin/Windows selection lives in one place instead of being duplicated at each call site.
- **Tests** — Catch2 unit tests for `PkillCommand` argument parsing and an E2E test in `tests/builtins/pkill_help.endo`.