### PR TITLE
Support function-valued shell_prompt_* properties

### DIFF
--- a/docs/shell/configuration.md
+++ b/docs/shell/configuration.md
@@ -112,11 +112,44 @@ shell_prompt_layout <- "boxed"
 
 ### Prompt Indicator
 
+The indicator is the character(s) shown just before the input cursor. The string
+form is rendered verbatim -- there is no template expansion (for example,
+`"${pwd}"` prints the literal text `${pwd}`).
+
 ```endo
-# Change the input indicator character
+# Static string form: rendered verbatim, no substitution
 shell_prompt_indicator <- "> "
 shell_prompt_indicator <- "$ "
 ```
+
+To produce an indicator that depends on live shell state, assign a
+zero-argument function that returns a string. It is invoked at each prompt
+render:
+
+```endo
+# Dynamic form: named function
+let myPrompt () = $"{(env "PWD")?} => "
+shell_prompt_indicator <- myPrompt
+
+# Anonymous lambda literal also works
+shell_prompt_indicator <- fun () -> $"{(env "PWD")?} => "
+```
+
+Notes and limitations:
+
+- Invocation runs synchronously on the main thread; results are cached and
+  re-evaluated only when the shell context changes (CWD, exit code, or last-
+  command duration). Within a single context, every keystroke reuses the cached
+  value so typing is never slowed by the callback.
+- For genuinely slow callbacks (network or heavy computation), a background-
+  thread execution path analogous to the git status module is still a
+  potential future enhancement. Until then, prefer callbacks that are fast
+  on the happy path.
+- If the function is unknown, throws, or returns an empty string, the static
+  `shell_prompt_indicator` value is used as a fallback and the shell stays alive.
+- The static and dynamic forms write to separate storage: assigning a string
+  clears any dynamic function; assigning a function leaves the static string
+  untouched as the fallback.
 
 ### Separator Style
 
@@ -260,6 +293,25 @@ shell_prompt_color_indicator <- "#50FA7B"
 # Red separator bar
 shell_prompt_color_separator <- "#FF5555"
 ```
+
+#### Dynamic Colors
+
+Any color property (except background) also accepts a zero-argument function
+that returns a color-spec string. The function is invoked at each context
+change (cached between renders within the same context), so the color can
+depend on live shell state such as exit code or working directory:
+
+```endo
+# Indicator color that changes with the last exit code
+let indicatorColor () = "#FF5555"
+shell_prompt_color_indicator <- indicatorColor
+
+# Inline lambda form
+shell_prompt_color_path <- fun () -> "#5078FF:#00DCC8"
+```
+
+If the function returns an unparseable string or fails, the color falls back
+to the theme default (same behavior as `"theme"`).
 
 #### Gradient Colors
 

--- a/src/CoreVM/NativeProperty.cpp
+++ b/src/CoreVM/NativeProperty.cpp
@@ -22,8 +22,30 @@ NativeProperty& NativeProperty::onGet(Getter cb)
 
 NativeProperty& NativeProperty::onSet(Setter cb)
 {
-    _setter = std::move(cb);
+    return onSet(_type, std::move(cb));
+}
+
+NativeProperty& NativeProperty::onSet(LiteralType argType, Setter cb)
+{
+    for (auto& [t, setter]: _setters)
+    {
+        if (t == argType)
+        {
+            setter = std::move(cb);
+            return *this;
+        }
+    }
+    _setters.emplace_back(argType, std::move(cb));
+    _setterTypes.push_back(argType);
     return *this;
+}
+
+bool NativeProperty::hasSetter(LiteralType argType) const noexcept
+{
+    for (auto const& [t, setter]: _setters)
+        if (t == argType)
+            return setter != nullptr;
+    return false;
 }
 
 void NativeProperty::invokeGet(Params& args) const
@@ -32,10 +54,16 @@ void NativeProperty::invokeGet(Params& args) const
         _getter(args);
 }
 
-void NativeProperty::invokeSet(Params& args) const
+void NativeProperty::invokeSet(LiteralType argType, Params& args) const
 {
-    if (_setter)
-        _setter(args);
+    for (auto const& [t, setter]: _setters)
+    {
+        if (t == argType && setter)
+        {
+            setter(args);
+            return;
+        }
+    }
 }
 
 } // namespace CoreVM

--- a/src/CoreVM/vm/NativeCallback.hpp
+++ b/src/CoreVM/vm/NativeCallback.hpp
@@ -306,7 +306,15 @@ class NativeProperty
 
     [[nodiscard]] std::string const& name() const noexcept { return _name; }
 
+    /// Primary (declared) type of this property. Used for the getter and as the
+    /// default type for setter overload registration.
     [[nodiscard]] LiteralType type() const noexcept { return _type; }
+
+    /// All setter types accepted by this property, in registration order.
+    [[nodiscard]] std::vector<LiteralType> const& acceptedSetterTypes() const noexcept
+    {
+        return _setterTypes;
+    }
 
     [[nodiscard]] std::string const& description() const noexcept { return _description; }
 
@@ -314,10 +322,21 @@ class NativeProperty
 
     [[nodiscard]] bool hasGetter() const noexcept { return _getter != nullptr; }
 
-    [[nodiscard]] bool hasSetter() const noexcept { return _setter != nullptr; }
+    /// Returns true if any setter (primary or overload) is registered.
+    [[nodiscard]] bool hasSetter() const noexcept { return !_setters.empty(); }
+
+    /// Returns true if a setter for the given argument type is registered.
+    [[nodiscard]] bool hasSetter(LiteralType argType) const noexcept;
 
     NativeProperty& onGet(Getter cb);
+
+    /// Registers the primary setter (accepts a value of the property's declared type()).
     NativeProperty& onSet(Setter cb);
+
+    /// Registers an additional setter overload for the given argument type. This
+    /// enables a single property to accept multiple RHS types (e.g. String or Function),
+    /// dispatched by the argument's literal type at the assignment site.
+    NativeProperty& onSet(LiteralType argType, Setter cb);
 
     template <typename Class>
     NativeProperty& onGet(void (Class::*method)(Params&), Class* obj)
@@ -332,14 +351,18 @@ class NativeProperty
     }
 
     void invokeGet(Params& args) const;
-    void invokeSet(Params& args) const;
+
+    /// Invokes the setter for the given argument type. No-op if no setter is
+    /// registered for that type.
+    void invokeSet(LiteralType argType, Params& args) const;
 
   private:
     std::string _name;
     LiteralType _type;
     std::string _description;
     Getter _getter;
-    Setter _setter;
+    std::vector<std::pair<LiteralType, Setter>> _setters; ///< Ordered list of setter overloads.
+    std::vector<LiteralType> _setterTypes;                ///< Accepted types (parallel to _setters).
 };
 
 // =============================================================================
@@ -504,6 +527,16 @@ inline NativeCallback& NativeCallback::param<CoreVM::TypedObject*>(const std::st
 {
     assert(_defaults.size() == _names.size());
     _signature.args().push_back(LiteralType::Object);
+    _names.push_back(name);
+    _defaults.emplace_back(std::monostate {});
+    return *this;
+}
+
+template <>
+inline NativeCallback& NativeCallback::param<const CoreVM::Function*>(const std::string& name)
+{
+    assert(_defaults.size() == _names.size());
+    _signature.args().push_back(LiteralType::Function);
     _names.push_back(name);
     _defaults.emplace_back(std::monostate {});
     return *this;

--- a/src/CoreVM/vm/Runtime.cpp
+++ b/src/CoreVM/vm/Runtime.cpp
@@ -28,6 +28,22 @@ NativeCallback& Runtime::registerFunction(const std::string& name, LiteralType r
     return *_builtins[_builtins.size() - 1];
 }
 
+namespace
+{
+    void setterAddParam(NativeCallback& setter, LiteralType type)
+    {
+        switch (type)
+        {
+            case LiteralType::String: setter.param<CoreString>("value"); break;
+            case LiteralType::Number: setter.param<CoreNumber>("value"); break;
+            case LiteralType::Boolean: setter.param<bool>("value"); break;
+            case LiteralType::Object: setter.param<TypedObject*>("value"); break;
+            case LiteralType::Function: setter.param<const Function*>("value"); break;
+            default: setter.param<CoreNumber>("value"); break;
+        }
+    }
+} // namespace
+
 NativeProperty& Runtime::registerProperty(std::string const& name, LiteralType type)
 {
     _properties.push_back(std::make_unique<NativeProperty>(name, type));
@@ -37,20 +53,38 @@ NativeProperty& Runtime::registerProperty(std::string const& name, LiteralType t
     auto& getter = registerFunction(name, type);
     getter.bind([&prop](Params& args) { prop.invokeGet(args); });
 
-    // Register setter callback: name(T)V — 1 arg (the new value), returns void
+    // Register primary setter callback: name(T)V — 1 arg (the new value), returns void
     auto& setter = registerFunction(name);
-    switch (type)
-    {
-        case LiteralType::String: setter.param<CoreString>("value"); break;
-        case LiteralType::Number: setter.param<CoreNumber>("value"); break;
-        case LiteralType::Boolean: setter.param<bool>("value"); break;
-        case LiteralType::Object: setter.param<TypedObject*>("value"); break;
-        default: setter.param<CoreNumber>("value"); break;
-    }
+    setterAddParam(setter, type);
     setter.returnType(LiteralType::Void);
-    setter.bind([&prop](Params& args) { prop.invokeSet(args); });
+    setter.bind([&prop, type](Params& args) { prop.invokeSet(type, args); });
 
     return prop;
+}
+
+NativeProperty& Runtime::registerPropertySetterOverload(std::string const& name, LiteralType argType)
+{
+    auto* prop = findProperty(name);
+    assert(prop != nullptr
+           && "registerPropertySetterOverload: property not found — call registerProperty first");
+
+    // Register an additional setter callback with a distinct argument type.
+    // Overload resolution at the assignment site (in IRGenerator) selects by arg type.
+    auto& setter = registerFunction(name);
+    setterAddParam(setter, argType);
+    setter.returnType(LiteralType::Void);
+    setter.bind([prop, argType](Params& args) { prop->invokeSet(argType, args); });
+
+    // Ensure `NativeProperty::acceptedSetterTypes()` reflects the overload. Without
+    // this, consumers that discover overload support only by inspecting the property
+    // (semantic analyzer, hover provider, diagnostic hints) would see just the
+    // primary setter type even when a real callback is registered via the Runtime.
+    // If a user-provided callback for this type is later bound via
+    // `NativeProperty::onSet(argType, cb)`, it replaces this no-op in the slot.
+    if (!prop->hasSetter(argType))
+        prop->onSet(argType, [](Params&) {});
+
+    return *prop;
 }
 
 NativeProperty* Runtime::findProperty(std::string const& name) const noexcept

--- a/src/CoreVM/vm/Runtime.hpp
+++ b/src/CoreVM/vm/Runtime.hpp
@@ -45,6 +45,13 @@ class Runtime
 
     NativeProperty& registerProperty(std::string const& name, LiteralType type);
 
+    /// Registers an additional setter overload for an already-registered property.
+    /// This lets a single property (e.g. `shell_prompt_indicator`) accept multiple
+    /// RHS types (e.g. String or Function). The callback on the NativeProperty for
+    /// `argType` must be registered separately via `NativeProperty::onSet(argType, ...)`.
+    /// Returns a reference to the existing NativeProperty (for chaining).
+    NativeProperty& registerPropertySetterOverload(std::string const& name, LiteralType argType);
+
     [[nodiscard]] NativeProperty* findProperty(std::string const& name) const noexcept;
 
     [[nodiscard]] auto const& properties() const noexcept { return _properties; }

--- a/src/endo-language/builtins/BuiltinSignatures.cpp
+++ b/src/endo-language/builtins/BuiltinSignatures.cpp
@@ -534,11 +534,17 @@ namespace
 {
     /// Registers a property and binds getter/setter via the CallbackResolver.
     /// The property name is passed once to avoid duplication.
+    /// When `extraSetterTypes` is non-empty, an additional setter callback is
+    /// registered per extra type via `Runtime::registerPropertySetterOverload` so
+    /// sema sees the full accepted-type set. Extra-overload callbacks are no-ops
+    /// in this shared path — runtimes that need concrete behavior (notably the
+    /// shell) bind real callbacks separately via `NativeProperty::onSet(type, cb)`.
     void registerPropertyResolved(CoreVM::Runtime& rt,
                                   CallbackResolver const& resolve,
                                   std::string_view name,
                                   CoreVM::LiteralType type,
-                                  std::string_view desc = {})
+                                  std::string_view desc = {},
+                                  std::span<CoreVM::LiteralType const> extraSetterTypes = {})
     {
         auto& prop = rt.registerProperty(std::string(name), type);
         if (!desc.empty())
@@ -553,6 +559,13 @@ namespace
             prop.onSet(*setterCb);
         else
             prop.onSet([](CoreVM::Params&) {});
+
+        // Additional setter overloads (e.g. Function for shell_prompt_indicator).
+        // Registered purely to make `NativeProperty::acceptedSetterTypes()` and the
+        // underlying `Runtime` callback table complete — sema can then type-check
+        // RHS values against the full accepted set.
+        for (auto const extraType: extraSetterTypes)
+            rt.registerPropertySetterOverload(std::string(name), extraType);
     }
 
     /// Registers a read-only property (getter only, no setter).
@@ -582,7 +595,8 @@ void registerPromptPropertyBuiltins(CoreVM::Runtime& rt, CallbackResolver const&
         if (desc.readOnly)
             registerReadOnlyPropertyResolved(rt, resolve, desc.name, desc.type, desc.description);
         else
-            registerPropertyResolved(rt, resolve, desc.name, desc.type, desc.description);
+            registerPropertyResolved(
+                rt, resolve, desc.name, desc.type, desc.description, desc.extraSetterTypes);
     }
 }
 
@@ -597,7 +611,8 @@ void registerAgentConfigPropertyBuiltins(CoreVM::Runtime& rt, CallbackResolver c
         if (desc.readOnly)
             registerReadOnlyPropertyResolved(rt, resolve, desc.name, desc.type, desc.description);
         else
-            registerPropertyResolved(rt, resolve, desc.name, desc.type, desc.description);
+            registerPropertyResolved(
+                rt, resolve, desc.name, desc.type, desc.description, desc.extraSetterTypes);
     }
 }
 

--- a/src/endo-language/builtins/PropertyDescriptors.cpp
+++ b/src/endo-language/builtins/PropertyDescriptors.cpp
@@ -64,6 +64,13 @@ static constexpr std::array colorValues = {
     EnumValueEntry { .value="transparent", .description="Use terminal default background" },
     EnumValueEntry { .value="theme", .description="Use theme default color" },
 };
+
+/// Setter-argument types for properties that additionally accept a zero-argument
+/// function returning a string (`shell_prompt_indicator`, `shell_prompt_color_*`).
+/// Referenced from PropertyDescriptor::extraSetterTypes.
+static constexpr std::array stringOrFunctionExtraTypes = {
+    CoreVM::LiteralType::Function,
+};
 // clang-format on
 
 static constexpr std::array webSearchEngineValues = {
@@ -148,7 +155,10 @@ static constexpr std::array promptProperties = {
         .name = "shell_prompt_indicator",
         .type = CoreVM::LiteralType::String,
         .description = "Prompt indicator character(s)",
-        .detail = "**shell_prompt_indicator** -- property\n\nSets the prompt indicator character(s).",
+        .detail = "**shell_prompt_indicator** -- property\n\nSets the prompt indicator character(s). "
+                  "Accepts either a string or a zero-argument function returning a string "
+                  "(invoked at each prompt render).",
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_layout",
@@ -242,6 +252,7 @@ static constexpr std::array promptProperties = {
             "\"#5078FF:#00DCC8\"\nshell_prompt_color_path theme\n```",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_git_clean",
@@ -251,6 +262,7 @@ static constexpr std::array promptProperties = {
                   "repository is clean.",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_git_dirty",
@@ -260,6 +272,7 @@ static constexpr std::array promptProperties = {
                   "are unstaged changes.",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_git_staged",
@@ -269,6 +282,7 @@ static constexpr std::array promptProperties = {
                   "changes exist.",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_indicator",
@@ -278,6 +292,7 @@ static constexpr std::array promptProperties = {
                   "(e.g., `|> `).",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_indicator_error",
@@ -287,6 +302,7 @@ static constexpr std::array promptProperties = {
                   "last command failed (non-zero exit).",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_exit_code",
@@ -295,6 +311,7 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_exit_code** -- property\n\nSets the exit code badge color.",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_duration",
@@ -303,6 +320,7 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_duration** -- property\n\nSets the command duration badge color.",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_hostname",
@@ -312,6 +330,7 @@ static constexpr std::array promptProperties = {
                   "in SSH sessions).",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_separator",
@@ -320,6 +339,7 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_separator** -- property\n\nSets the left bar / separator color.",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_badge",
@@ -329,6 +349,7 @@ static constexpr std::array promptProperties = {
                   "mode, structured output).",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_badge_text",
@@ -337,6 +358,7 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_badge_text** -- property\n\nSets the badge text color.",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_clock",
@@ -345,6 +367,7 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_clock** -- property\n\nSets the clock module text color.",
         .readOnly = false,
         .enumValues = colorValues,
+        .extraSetterTypes = stringOrFunctionExtraTypes,
     },
 };
 

--- a/src/endo-language/builtins/PropertyDescriptors.hpp
+++ b/src/endo-language/builtins/PropertyDescriptors.hpp
@@ -28,11 +28,19 @@ struct EnumValueEntry
 struct PropertyDescriptor
 {
     std::string_view name;        ///< Property name (e.g., "shell_prompt_preset")
-    CoreVM::LiteralType type;     ///< Property value type
+    CoreVM::LiteralType type;     ///< Property getter/primary setter value type
     std::string_view description; ///< Short description for registration and completion display
     std::string_view detail;      ///< Detailed markdown documentation for completion detail panel
     bool readOnly = false;        ///< True for read-only properties (no setter)
     std::span<EnumValueEntry const> enumValues; ///< Enumerated values for argument completion
+
+    /// @brief Extra setter-argument types accepted by the property, in addition to `type`.
+    ///
+    /// When non-empty, a Function-typed setter overload (or similar) is registered
+    /// alongside the primary one. The semantic analyzer consults this list to accept
+    /// RHS values whose literal type is either `type` or one of these. Empty means
+    /// the property accepts exactly `type`.
+    std::span<CoreVM::LiteralType const> extraSetterTypes;
 };
 
 /// Returns prompt/shell property descriptors.

--- a/src/endo-language/codegen/IRGenerator.cpp
+++ b/src/endo-language/codegen/IRGenerator.cpp
@@ -432,12 +432,19 @@ std::unique_ptr<CoreVM::IRProgram> IRGenerator::generate(ast::Statement const& r
     }
 
     // Run Hindley-Milner type inference pre-pass.
-    // Inference errors are non-fatal: unresolved types simply remain unannotated
-    // and fall back to AST inlining during codegen.
+    //
+    // Most inference errors are non-fatal: unresolved types simply remain
+    // unannotated and fall back to AST inlining during codegen. However,
+    // property-type mismatches (e.g. `shell_prompt_indicator <- 42`) are emitted
+    // as TypeError messages onto the shared `report`. When that happens, we
+    // skip IR generation so the code generator only sees type-checked ASTs.
     {
         auto inferencer = TypeInferencer(createStandardTypeEnv());
+        inferencer.setRuntimeContext(&runtime, &report);
         generator._inferenceResult = inferencer.inferProgram(rootNode);
     }
+    if (report.containsFailures())
+        return nullptr;
 
     generator.codegen(&rootNode);
 
@@ -1091,6 +1098,13 @@ CoreVM::Value* IRGenerator::wrapInResultOrOption(CoreVM::Value* value, ReturnKin
 std::string IRGenerator::generateLambdaName()
 {
     return std::format("__lambda_{}", _lambdaCounter++);
+}
+
+std::string IRGenerator::generatePromptCallbackName()
+{
+    // Does not start with `__lambda_`, so the persistence pass in IRGenerator::generate()
+    // keeps it — required for the function to be resolvable at subsequent prompt renders.
+    return std::format("__promptcb_{}", _lambdaCounter++);
 }
 
 // --- Annotation wrappers (delegated to AnnotationTracker) ---
@@ -4781,18 +4795,39 @@ void IRGenerator::visit(ast::MutAssignStmt const& node)
             reportTypeError("Cannot assign to read-only property '{}'", std::string_view(node.name));
             return;
         }
-        auto* newValue = codegen(node.value.get());
-        if (!newValue)
+
+        // If the property has a Function-typed setter overload and the RHS is a
+        // function reference (identifier or lambda literal), emit a proper IR
+        // function ref and dispatch to the Function setter directly. The IR-level
+        // type of FunctionRefInstr is Number (it carries the runtime function index);
+        // at the setter-callback ABI level that same uint64_t is interpreted as a
+        // Function via Params::getFunction, so the signature used here is (H)V.
+        CoreVM::Value* newValue = nullptr;
+        CoreVM::NativeCallback* cb = nullptr;
+        auto const functionSetterSig =
+            node.name + "(" + CoreVM::signatureType(CoreVM::LiteralType::Function) + ")V";
+        if (findCallback(functionSetterSig))
+            newValue = tryEmitFunctionRef(*node.value);
+        if (newValue)
         {
-            reportTypeError("Failed to generate code for assignment value");
-            return;
+            cb = findCallback(functionSetterSig);
         }
-        // Emit call to setter callback: name(T)V
-        auto const setterSig = node.name + "(" + CoreVM::signatureType(prop->type()) + ")V";
-        if (auto* cb = findCallback(setterSig))
+        else
         {
-            _builder.createCallFunction(_builder.getBuiltinFunction(*cb), { newValue }, node.name + ".set");
+            newValue = codegen(node.value.get());
+            if (!newValue)
+            {
+                reportTypeError("Failed to generate code for assignment value");
+                return;
+            }
+            // Dispatch strictly on the value's IR type. Sema has already verified
+            // the RHS against the property's accepted setter types, so a missing
+            // callback here is an internal invariant violation, not a user error.
+            auto const valueSig = node.name + "(" + CoreVM::signatureType(newValue->type()) + ")V";
+            cb = findCallback(valueSig);
         }
+        assert(cb && "property setter dispatch: sema should have rejected type-mismatched assignments");
+        _builder.createCallFunction(_builder.getBuiltinFunction(*cb), { newValue }, node.name + ".set");
         _result = nullptr;
         return;
     }
@@ -4890,18 +4925,30 @@ void IRGenerator::visit(ast::MutAssignExpr const& node)
             reportTypeError("Cannot assign to read-only property '{}'", std::string_view(node.name));
             return;
         }
-        auto* newValue = codegen(node.value.get());
+
+        // If the property has a Function-typed setter overload and the RHS is a
+        // function reference (identifier or lambda literal), emit a proper IR
+        // function ref so the Function setter is selected over the String setter.
+        CoreVM::Value* newValue = nullptr;
+        auto const functionSetterSig =
+            node.name + "(" + CoreVM::signatureType(CoreVM::LiteralType::Function) + ")V";
+        if (findCallback(functionSetterSig))
+            newValue = tryEmitFunctionRef(*node.value);
+
+        if (!newValue)
+            newValue = codegen(node.value.get());
         if (!newValue)
         {
             reportTypeError("Failed to generate code for assignment value");
             return;
         }
-        // Emit call to setter callback: name(T)V
-        auto const setterSig = node.name + "(" + CoreVM::signatureType(prop->type()) + ")V";
-        if (auto* cb = findCallback(setterSig))
-        {
-            _builder.createCallFunction(_builder.getBuiltinFunction(*cb), { newValue }, node.name + ".set");
-        }
+        // Dispatch strictly on the value's IR type. Sema has already verified the
+        // RHS type against the property's accepted setter types; a missing callback
+        // here is an internal invariant violation.
+        auto const valueSig = node.name + "(" + CoreVM::signatureType(newValue->type()) + ")V";
+        auto* cb = findCallback(valueSig);
+        assert(cb && "property setter dispatch: sema should have rejected type-mismatched assignments");
+        _builder.createCallFunction(_builder.getBuiltinFunction(*cb), { newValue }, node.name + ".set");
         _result = _builder.get(CoreVM::CoreNumber(0)); // returns unit
         return;
     }
@@ -8255,6 +8302,57 @@ void IRGenerator::visit(ast::ParenExpr const& node)
     // Parentheses just evaluate the inner expression
     if (node.inner)
         codegen(node.inner.get());
+}
+
+CoreVM::Value* IRGenerator::tryEmitFunctionRef(ast::Expr const& value)
+{
+    std::string funcName;
+
+    // Case A: lambda literal — register the lambda, then fall through with its synthesized name.
+    // Use a prompt-callback-specific prefix so the lambda is persisted across REPL prompts
+    // (regular lambda names starting with `__lambda_` are stripped by the persistence pass).
+    if (auto const* lambda = dynamic_cast<ast::LambdaExpr const*>(&value))
+    {
+        funcName = generatePromptCallbackName();
+
+        FSharpFunction func;
+        extractTypedParameters(lambda->parameters, func);
+        func.returnType = lambda->returnType;
+        func.body = lambda->body.get();
+        func.returnKind = determineReturnKind(func.body);
+        func.capturedBindings = collectFreeVariables(func.body, func.parameters);
+        collectCapturedMutables(func);
+        for (auto const& [capName, _]: func.capturedBindings)
+            if (auto ref = lookupFSharpFunctionRef(capName))
+                func.capturedFunctionRefs[capName] = *ref;
+
+        registerFSharpFunction(funcName, std::move(func));
+    }
+    // Case B: named F# function referenced by identifier.
+    else if (auto const* ident = dynamic_cast<ast::IdentifierExpr const*>(&value))
+    {
+        if (lookupFSharpFunction(ident->name))
+            funcName = ident->name;
+        else
+            return nullptr;
+    }
+    else
+    {
+        return nullptr;
+    }
+
+    auto* func = const_cast<FSharpFunction*>(lookupFSharpFunction(funcName));
+    if (!func)
+        return nullptr;
+
+    // Trigger compilation if not already compiled; property callbacks require a
+    // resolvable IRFunction so a runtime function reference can be formed.
+    if (!func->compiledFunction)
+        compileFunctionBody(funcName, *func);
+    if (!func->compiledFunction)
+        return nullptr;
+
+    return _builder.createFunctionRef(func->compiledFunction, funcName + ".funcRef");
 }
 
 void IRGenerator::visit(ast::LambdaExpr const& node)

--- a/src/endo-language/codegen/IRGenerator.hpp
+++ b/src/endo-language/codegen/IRGenerator.hpp
@@ -657,6 +657,19 @@ class IRGenerator final: public ast::Visitor
     /// Sets func->compiledFunction to the new function on success.
     void compileFunctionBody(std::string const& name, FSharpFunction& func);
 
+    /// Attempts to produce a LiteralType::Function-typed IR value for an expression
+    /// that references a user-defined F# function. Used at property-assignment sites
+    /// where the property has a setter overload accepting Function (e.g. `shell_prompt_indicator`).
+    ///
+    /// Handles two RHS shapes:
+    ///   - Lambda literal: `fun () -> <body>` (registers the lambda, then emits a function ref).
+    ///   - Identifier:     `myFn` (already-named F# function; emits a function ref).
+    ///
+    /// Returns nullptr if the expression is not a function reference, or if the referenced
+    /// function cannot be compiled (e.g. free parameters without type annotations). Callers
+    /// should fall back to the normal codegen path in that case.
+    CoreVM::Value* tryEmitFunctionRef(ast::Expr const& value);
+
     /// Maps a high-level TypePtr to the corresponding CoreVM::LiteralType for validation.
     [[nodiscard]] static std::optional<CoreVM::LiteralType> mapTypeToLiteralType(TypePtr const& type);
 
@@ -821,6 +834,13 @@ class IRGenerator final: public ast::Visitor
     // Lambda counter for generating unique anonymous function names
     size_t _lambdaCounter = 0;
     [[nodiscard]] std::string generateLambdaName();
+
+    /// Generates a stable name for a lambda literal that must survive across REPL prompts
+    /// (for example, one assigned to a builtin property's Function-typed setter). Unlike
+    /// `generateLambdaName()`, the result does NOT start with the `__lambda_` prefix, so
+    /// it passes the persistence filter in `IRGenerator::generate()` and ends up in
+    /// `FSharpPersistentState::functions`.
+    [[nodiscard]] std::string generatePromptCallbackName();
 
     /// Creates an FSharpFunction from a PlaceholderLambdaExpr (desugars `_` to single-parameter function).
     [[nodiscard]] FSharpFunction createFunctionFromPlaceholder(ast::PlaceholderLambdaExpr const& node);

--- a/src/endo-language/ide/DiagnosticsCollector_test.cpp
+++ b/src/endo-language/ide/DiagnosticsCollector_test.cpp
@@ -323,3 +323,71 @@ TEST_CASE("DiagnosticsCollector.heterogeneous_list_type_error", "[diagnostics][t
     }
     CHECK(found);
 }
+
+// =============================================================================
+// Property type check diagnostics (drives the shell's live prompt feedback)
+// =============================================================================
+
+TEST_CASE("DiagnosticsCollector.property_type_mismatch_int_to_indicator", "[diagnostics][property-type]")
+{
+    // The shell prompt's live diagnostics layer uses collectDiagnostics() with the
+    // stub runtime. It must surface the same type error the shell itself raises —
+    // including the full accepted-type set in the hint, not only the primary type.
+    auto const diagnostics = collectDiagnostics("shell_prompt_indicator <- 42");
+    REQUIRE(!diagnostics.empty());
+
+    auto found = false;
+    for (auto const& d: diagnostics)
+    {
+        if (d.message.find("shell_prompt_indicator") == std::string::npos)
+            continue;
+        if (d.message.find("int") == std::string::npos)
+            continue;
+        found = true;
+        CHECK(d.severity == DiagnosticSeverity::Error);
+        REQUIRE(!d.suggestions.empty());
+        auto const& hint = d.suggestions[0];
+        CHECK(hint.find("string") != std::string::npos);
+        CHECK(hint.find("FunctionRef") != std::string::npos);
+    }
+    CHECK(found);
+}
+
+TEST_CASE("DiagnosticsCollector.property_type_mismatch_bool_to_color", "[diagnostics][property-type]")
+{
+    auto const diagnostics = collectDiagnostics("shell_prompt_color_indicator <- true");
+    REQUIRE(!diagnostics.empty());
+
+    auto found = false;
+    for (auto const& d: diagnostics)
+    {
+        if (d.message.find("shell_prompt_color_indicator") == std::string::npos)
+            continue;
+        if (d.message.find("bool") == std::string::npos)
+            continue;
+        found = true;
+        REQUIRE(!d.suggestions.empty());
+        auto const& hint = d.suggestions[0];
+        CHECK(hint.find("string") != std::string::npos);
+        CHECK(hint.find("FunctionRef") != std::string::npos);
+    }
+    CHECK(found);
+}
+
+TEST_CASE("DiagnosticsCollector.property_type_mismatch_read_only", "[diagnostics][property-type]")
+{
+    auto const diagnostics = collectDiagnostics("shell_is_interactive <- true");
+    REQUIRE(!diagnostics.empty());
+
+    auto found = false;
+    for (auto const& d: diagnostics)
+    {
+        if (d.message.find("read-only property") != std::string::npos
+            && d.message.find("shell_is_interactive") != std::string::npos)
+        {
+            found = true;
+            CHECK(d.severity == DiagnosticSeverity::Error);
+        }
+    }
+    CHECK(found);
+}

--- a/src/endo-language/types/TypeInferencer.cpp
+++ b/src/endo-language/types/TypeInferencer.cpp
@@ -1,12 +1,57 @@
 // SPDX-License-Identifier: Apache-2.0
+#include <endo-language/builtins/PropertyDescriptors.hpp>
+#include <endo-language/parser/DiagnosticsAdapter.hpp>
 #include <endo-language/types/TypeInferencer.hpp>
 
+#include <algorithm>
 #include <format>
 #include <ranges>
 #include <utility>
 
 namespace endo
 {
+
+namespace
+{
+    /// Maps an HM type to a CoreVM literal type for property-setter matching.
+    /// Returns nullopt when the HM type doesn't map cleanly (type variable, record,
+    /// union, etc.) — callers must treat `nullopt` as "skip the check" rather than
+    /// "rejected", to avoid false positives while the mapping grows.
+    [[nodiscard]] std::optional<CoreVM::LiteralType> typeToLiteralType(TypePtr const& type)
+    {
+        if (!type)
+            return std::nullopt;
+        if (auto const* prim = type->asPrimitive())
+        {
+            switch (prim->kind)
+            {
+                case PrimitiveType::Int: return CoreVM::LiteralType::Number;
+                case PrimitiveType::Float: return CoreVM::LiteralType::Float;
+                case PrimitiveType::Str: return CoreVM::LiteralType::String;
+                case PrimitiveType::Bool: return CoreVM::LiteralType::Boolean;
+                case PrimitiveType::Unit: return CoreVM::LiteralType::Void;
+            }
+            return std::nullopt;
+        }
+        // Any function shape (including captured identifiers for named F# functions)
+        // is compatible with a `Function`-typed setter.
+        if (type->isFunction())
+            return CoreVM::LiteralType::Function;
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::string joinLiteralTypes(std::span<CoreVM::LiteralType const> types)
+    {
+        auto out = std::string {};
+        for (auto const& t: types)
+        {
+            if (!out.empty())
+                out += " | ";
+            out += CoreVM::tos(t);
+        }
+        return out;
+    }
+} // namespace
 
 TypeInferencer::TypeInferencer(TypeEnvPtr env): _env(std::move(env))
 {
@@ -795,6 +840,44 @@ TypeInferencer::InferResult TypeInferencer::inferExpr(ast::Expr const& expr,
             return valResult;
         auto [valType, s1] = *valResult;
 
+        // Builtin property setter type check. Runs only when the caller wired up a
+        // runtime + report (shell, LSP, DiagnosticsCollector); non-interactive
+        // unit tests that don't care about property typing pass `nullptr` and
+        // get the pre-existing behavior.
+        if (_runtime && _report && !env->lookup(mutExpr->name))
+        {
+            if (auto const* prop = _runtime->findProperty(mutExpr->name))
+            {
+                auto const loc = mutExpr->value && mutExpr->value->location
+                                     ? toCoreLoc(*mutExpr->value->location)
+                                     : CoreVM::SourceLocation {};
+                if (!prop->hasSetter())
+                {
+                    _report->typeErrorWithSuggestions(
+                        loc,
+                        { "This property is read-only and cannot be assigned." },
+                        std::nullopt,
+                        "Cannot assign to read-only property '{}'",
+                        std::string_view(mutExpr->name));
+                }
+                else
+                {
+                    auto const& accepted = prop->acceptedSetterTypes();
+                    auto const rhsType = typeToLiteralType(s1.apply(valType));
+                    if (rhsType && std::ranges::find(accepted, *rhsType) == accepted.end())
+                    {
+                        auto const acceptedStr = joinLiteralTypes(accepted);
+                        _report->typeErrorWithSuggestions(loc,
+                                                          { std::format("Accepted types: {}", acceptedStr) },
+                                                          std::nullopt,
+                                                          "Property '{}' cannot accept a value of type {}",
+                                                          std::string_view(mutExpr->name),
+                                                          CoreVM::tos(*rhsType));
+                    }
+                }
+            }
+        }
+
         // Unify with existing binding type if available
         if (auto scheme = env->lookup(mutExpr->name))
         {
@@ -1548,6 +1631,43 @@ std::expected<Substitution, std::string> TypeInferencer::inferStmt(ast::Statemen
             return subst;
         }
         auto [valType, s1] = *valResult;
+
+        // Builtin property setter type check. Same logic as the MutAssignExpr
+        // branch in `inferExpr` — this handles statement-level `name <- value`,
+        // which parses as MutAssignStmt rather than MutAssignExpr.
+        if (_runtime && _report && !env->lookup(mutAssign->name))
+        {
+            if (auto const* prop = _runtime->findProperty(mutAssign->name))
+            {
+                auto const loc = mutAssign->value && mutAssign->value->location
+                                     ? toCoreLoc(*mutAssign->value->location)
+                                     : CoreVM::SourceLocation {};
+                if (!prop->hasSetter())
+                {
+                    _report->typeErrorWithSuggestions(
+                        loc,
+                        { "This property is read-only and cannot be assigned." },
+                        std::nullopt,
+                        "Cannot assign to read-only property '{}'",
+                        std::string_view(mutAssign->name));
+                }
+                else
+                {
+                    auto const& accepted = prop->acceptedSetterTypes();
+                    auto const rhsType = typeToLiteralType(s1.apply(valType));
+                    if (rhsType && std::ranges::find(accepted, *rhsType) == accepted.end())
+                    {
+                        auto const acceptedStr = joinLiteralTypes(accepted);
+                        _report->typeErrorWithSuggestions(loc,
+                                                          { std::format("Accepted types: {}", acceptedStr) },
+                                                          std::nullopt,
+                                                          "Property '{}' cannot accept a value of type {}",
+                                                          std::string_view(mutAssign->name),
+                                                          CoreVM::tos(*rhsType));
+                    }
+                }
+            }
+        }
 
         // Unify with existing binding type if available
         auto scheme = env->lookup(mutAssign->name);

--- a/src/endo-language/types/TypeInferencer.hpp
+++ b/src/endo-language/types/TypeInferencer.hpp
@@ -7,6 +7,8 @@
 #include <endo-language/types/TypeEnv.hpp>
 #include <endo-language/types/Unification.hpp>
 
+#include <CoreVM/CoreVM.hpp>
+
 #include <expected>
 #include <optional>
 #include <string>
@@ -46,6 +48,17 @@ class TypeInferencer
   public:
     /// Construct a type inferencer with the given base environment.
     explicit TypeInferencer(TypeEnvPtr env);
+
+    /// Injects a non-owning runtime + diagnostic report for checks that require
+    /// cross-component knowledge. Currently used to validate RHS types of
+    /// builtin-property assignments (`shell_prompt_indicator <- …`) against the
+    /// property's accepted setter types. Both pointers must outlive the inferencer.
+    /// Optional: without them, property checks are skipped.
+    void setRuntimeContext(CoreVM::Runtime const* runtime, CoreVM::diagnostics::Report* report) noexcept
+    {
+        _runtime = runtime;
+        _report = report;
+    }
 
     /// Infer types for all top-level definitions in a statement.
     [[nodiscard]] InferenceResult inferProgram(ast::Statement const& root);
@@ -105,6 +118,11 @@ class TypeInferencer
     InferenceResult _result; ///< Accumulated inference results
     ast::ShellCaptureMode _captureMode =
         ast::ShellCaptureMode::Capture; ///< Current shell capture mode context
+
+    /// Optional runtime + report for builtin-property type checking. When null,
+    /// property checks are skipped (e.g. unit-test runs without a runtime).
+    CoreVM::Runtime const* _runtime = nullptr;
+    CoreVM::diagnostics::Report* _report = nullptr;
 };
 
 } // namespace endo

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -786,6 +786,12 @@ Shell::Shell(TTY& tty, EnvironmentProvider& env, FileSystem& fs):
     //     the ability to set these options from the command line.
     registerBuiltinFunctions();
 
+    // Wire the prompt's dynamic-field resolver so that user-assigned function
+    // values on `shell_prompt_indicator` (and future dynamic fields) are invoked
+    // at each prompt render.
+    prompt.setDynamicFieldResolver(
+        [this](std::string const& fnName) { return invokePromptCallback(fnName); });
+
     _dirConfigManager =
         std::make_unique<DirectoryConfigManager>(*this, _fs, _env, stderrDiagnosticSink(_tty));
 
@@ -1159,6 +1165,89 @@ void Shell::ensureInteractiveReady()
     prompt.setHistory(&history);
     prompt.setEnvironmentProvider(&_env);
     prompt.setFileSystem(&_fs);
+}
+
+std::optional<std::string> Shell::invokePromptCallback(std::string const& functionName)
+{
+    // Only named persisted F# functions are invocable as prompt callbacks.
+    if (!_fsharpState.functions.contains(functionName))
+        return std::nullopt;
+
+    // Build a one-line source that calls the user function and captures its
+    // return value via the `__prompt_capture_string` builtin. Reuses the full
+    // parse/sema/irgen/target pipeline via Shell::execute so that user-defined
+    // functions, modules, and builtins are all visible.
+    auto const source = "__prompt_capture_string (" + functionName + " ())";
+
+    _promptCallbackResult.clear();
+
+    // RAII scope guard: runs a callable at scope exit regardless of normal/exception path.
+    class ScopeExit
+    {
+      public:
+        explicit ScopeExit(std::function<void()> fn): _fn { std::move(fn) } {}
+
+        ~ScopeExit()
+        {
+            if (_fn)
+                _fn();
+        }
+
+        ScopeExit(ScopeExit const&) = delete;
+        ScopeExit& operator=(ScopeExit const&) = delete;
+
+      private:
+        std::function<void()> _fn;
+    };
+
+    // Re-entrant safety: save outer VM state that execute() replaces, mirroring
+    // Shell::executeConfigScript(). Without this, a prompt callback fired during
+    // render would clobber _currentProgram/_runner used elsewhere in the shell.
+    auto savedProgram = std::move(_currentProgram);
+    auto* const savedRunner = _runner;
+    auto const savedExitCode = _exitCode;
+    auto const savedDuration = _lastCommandDuration;
+    auto const savedUnusedDetection = _unusedValueDetection;
+    // Snapshot retainedASTs size so we can drop anything this invocation pushes —
+    // prompt callbacks fire on every context change, and retaining their trivial
+    // invocation AST would grow memory unboundedly.
+    auto const savedRetainedASTsSize = _fsharpState.retainedASTs.size();
+
+    ++_configScriptDepth;          // Suppress auto-display and unused-value detection.
+    _unusedValueDetection = false; // Avoid spurious diagnostics from unused bindings in callbacks.
+
+    ScopeExit const restore { [this,
+                               savedRunner,
+                               savedExitCode,
+                               savedDuration,
+                               savedUnusedDetection,
+                               savedRetainedASTsSize,
+                               &savedProgram] {
+        --_configScriptDepth;
+        _unusedValueDetection = savedUnusedDetection;
+        _exitCode = savedExitCode;
+        _lastCommandDuration = savedDuration;
+        _currentProgram = std::move(savedProgram);
+        _runner = savedRunner;
+        if (_fsharpState.retainedASTs.size() > savedRetainedASTsSize)
+            _fsharpState.retainedASTs.resize(savedRetainedASTsSize);
+    } };
+
+    try
+    {
+        CoreVM::diagnostics::BufferedReport report;
+        execute(source, report, "<prompt-callback>");
+    }
+    catch (...)
+    {
+        // Swallow any exception — the prompt must stay alive. Guards restore state.
+        return std::nullopt;
+    }
+
+    if (_promptCallbackResult.empty())
+        return std::nullopt;
+
+    return std::exchange(_promptCallbackResult, std::string {});
 }
 
 int Shell::run()

--- a/src/shell/Shell.hpp
+++ b/src/shell/Shell.hpp
@@ -157,6 +157,18 @@ class Shell final: public SignalCallback
     /// @brief Called when the working directory changes, to load/unload directory configs.
     void onDirectoryChanged();
 
+    /// @brief Invokes a user-defined F# callback `() -> string` by name and returns
+    /// the produced string. Used by the prompt render path for dynamic fields like
+    /// `shell_prompt_indicator` when they hold a function value.
+    ///
+    /// Runs synchronously on the calling (main) thread. Intended to be called from
+    /// prompt-render code between REPL inputs, when the shell's REPL Runner is idle.
+    /// On any error (unknown function, compilation failure, exception), returns
+    /// std::nullopt and leaves the shell state unchanged.
+    ///
+    /// @param functionName The user-facing name (without the `fsharp.` compiler prefix).
+    [[nodiscard]] std::optional<std::string> invokePromptCallback(std::string const& functionName);
+
 #if defined(ENDO_ENABLE_AGENT) && ENDO_ENABLE_AGENT
     /// @brief Runs the agent in headless/batch mode (no TUI).
     /// @param options Parsed command-line options for the headless run.
@@ -616,6 +628,10 @@ class Shell final: public SignalCallback
     std::optional<ProcessId> _rightPid;
 
     int _exitCode = -1;
+    /// Scratch buffer populated by the `__prompt_capture_string` builtin when
+    /// `invokePromptCallback` runs a user-defined prompt function. Read once and
+    /// cleared by `invokePromptCallback`; not thread-safe.
+    std::string _promptCallbackResult;
     std::chrono::milliseconds _lastCommandDuration { 0 }; ///< Duration of the last command
     bool _interactive = true;                             ///< Whether running in interactive mode
     unsigned _configScriptDepth = 0;    ///< Nesting depth of config script / command substitution execution

--- a/src/shell/builtins/Registration.cpp
+++ b/src/shell/builtins/Registration.cpp
@@ -923,13 +923,50 @@ void Shell::registerPromptBuiltins()
 
     _runtime.registerProperty("shell_prompt_indicator", CoreVM::LiteralType::String)
         .onGet([this](CoreVM::Params& args) {
-            args.setResult(std::string(prompt.promptConfig().indicator));
+            // When the user has assigned a zero-argument function, the getter
+            // reflects the currently-effective value by invoking it. This matches
+            // what the prompt actually renders and avoids the surprising case
+            // where a successful `<- fun () -> "…"` leaves the getter reporting
+            // the prior static string.
+            auto const& config = prompt.promptConfig();
+            if (config.indicatorFn.has_value())
+            {
+                if (auto result = invokePromptCallback(*config.indicatorFn))
+                {
+                    args.setResult(std::move(*result));
+                    return;
+                }
+            }
+            args.setResult(std::string(config.indicator));
         })
         .onSet([this](CoreVM::Params& args) {
             auto config = prompt.promptConfig();
             config.indicator = std::string(args.getString(1)) + " ";
+            config.indicatorFn.reset(); // Static string clears any prior dynamic override.
+            prompt.setPromptConfig(std::move(config));
+        })
+        // Function overload: `shell_prompt_indicator <- myFn` where `myFn : () -> string`.
+        // Stores the function's user-facing name (without the `fsharp.` compiler prefix);
+        // the prompt render path looks it up each render via the Shell's invocation helper.
+        .onSet(CoreVM::LiteralType::Function, [this](CoreVM::Params& args) {
+            auto config = prompt.promptConfig();
+            auto const* fn = args.getFunction(1);
+            if (fn)
+            {
+                auto const& fullName = fn->name();
+                auto const prefix = std::string_view { "fsharp." };
+                auto const name = fullName.starts_with(prefix)
+                                      ? fullName.substr(prefix.size())
+                                      : fullName;
+                config.indicatorFn = std::string(name);
+            }
+            else
+            {
+                config.indicatorFn.reset();
+            }
             prompt.setPromptConfig(std::move(config));
         });
+    _runtime.registerPropertySetterOverload("shell_prompt_indicator", CoreVM::LiteralType::Function);
 
     _runtime.registerProperty("shell_prompt_layout", CoreVM::LiteralType::String)
         .onGet([this](CoreVM::Params& args) {
@@ -1067,41 +1104,96 @@ void Shell::registerPromptBuiltins()
             prompt.setPromptConfig(std::move(config));
         });
 
-    // Table-driven registration for non-background color properties
+    // Table-driven registration for non-background color properties.
+    // Each property accepts either a static string ("#RRGGBB", gradient, "theme")
+    // or a zero-arg F# function returning such a string. The function form is
+    // invoked at every prompt render, enabling context-sensitive colors (e.g.
+    // exit-code-driven indicator color).
     auto registerColorProp = [this](
         char const* name,
+        std::string_view colorKey,
         std::optional<ColorSpec> PromptColorOverrides::* field)
     {
+        auto const key = std::string { colorKey }; // captured by value in each lambda
         _runtime.registerProperty(name, CoreVM::LiteralType::String)
-            .onGet([this, field](CoreVM::Params& args) {
+            .onGet([this, field, key](CoreVM::Params& args) {
                 auto const& ov = prompt.promptConfig().colorOverrides;
+                // Dynamic form wins: reflect the currently-effective color by invoking
+                // the user-assigned function, so reading the property matches what
+                // the prompt renders.
+                if (auto it = ov.colorFns.find(key); it != ov.colorFns.end())
+                {
+                    if (auto result = invokePromptCallback(it->second))
+                    {
+                        args.setResult(std::move(*result));
+                        return;
+                    }
+                }
                 args.setResult((ov.*field) ? formatColorSpec(*(ov.*field)) : std::string("theme"));
             })
-            .onSet([this, field](CoreVM::Params& args) {
+            .onSet([this, field, key](CoreVM::Params& args) {
                 auto const& value = args.getString(1);
                 auto config = prompt.promptConfig();
+                auto assigned = false;
                 if (value == "theme" || value == "reset")
+                {
                     (config.colorOverrides.*field).reset();
+                    assigned = true;
+                }
                 else if (auto parsed = parseColorSpec(value))
+                {
                     config.colorOverrides.*field = *parsed;
+                    assigned = true;
+                }
+                // Only clear a prior dynamic resolver when the static assignment actually
+                // took effect — an unparseable string (typo) should not silently drop the
+                // user's previously-configured function.
+                if (assigned)
+                    config.colorOverrides.colorFns.erase(key);
+                prompt.setPromptConfig(std::move(config));
+            })
+            // Function overload: `shell_prompt_color_X <- myFn` where `myFn : () -> string`.
+            .onSet(CoreVM::LiteralType::Function, [this, key](CoreVM::Params& args) {
+                auto config = prompt.promptConfig();
+                auto const* fn = args.getFunction(1);
+                if (fn)
+                {
+                    auto const& fullName = fn->name();
+                    auto const prefix = std::string_view { "fsharp." };
+                    auto const fnName = fullName.starts_with(prefix) ? fullName.substr(prefix.size())
+                                                                     : fullName;
+                    config.colorOverrides.colorFns[key] = std::string(fnName);
+                }
+                else
+                {
+                    config.colorOverrides.colorFns.erase(key);
+                }
                 prompt.setPromptConfig(std::move(config));
             });
+        _runtime.registerPropertySetterOverload(name, CoreVM::LiteralType::Function);
     };
 
-    registerColorProp("shell_prompt_color_path",            &PromptColorOverrides::path);
-    registerColorProp("shell_prompt_color_git_clean",       &PromptColorOverrides::gitClean);
-    registerColorProp("shell_prompt_color_git_dirty",       &PromptColorOverrides::gitDirty);
-    registerColorProp("shell_prompt_color_git_staged",      &PromptColorOverrides::gitStaged);
-    registerColorProp("shell_prompt_color_indicator",       &PromptColorOverrides::indicator);
-    registerColorProp("shell_prompt_color_indicator_error", &PromptColorOverrides::indicatorError);
-    registerColorProp("shell_prompt_color_exit_code",       &PromptColorOverrides::exitCode);
-    registerColorProp("shell_prompt_color_duration",        &PromptColorOverrides::duration);
-    registerColorProp("shell_prompt_color_hostname",        &PromptColorOverrides::hostname);
-    registerColorProp("shell_prompt_color_separator",       &PromptColorOverrides::separator);
-    registerColorProp("shell_prompt_color_badge",           &PromptColorOverrides::badge);
-    registerColorProp("shell_prompt_color_badge_text",      &PromptColorOverrides::badgeText);
-    registerColorProp("shell_prompt_color_clock",           &PromptColorOverrides::clock);
+    registerColorProp("shell_prompt_color_path",            "path",            &PromptColorOverrides::path);
+    registerColorProp("shell_prompt_color_git_clean",       "git_clean",       &PromptColorOverrides::gitClean);
+    registerColorProp("shell_prompt_color_git_dirty",       "git_dirty",       &PromptColorOverrides::gitDirty);
+    registerColorProp("shell_prompt_color_git_staged",      "git_staged",      &PromptColorOverrides::gitStaged);
+    registerColorProp("shell_prompt_color_indicator",       "indicator",       &PromptColorOverrides::indicator);
+    registerColorProp("shell_prompt_color_indicator_error", "indicator_error", &PromptColorOverrides::indicatorError);
+    registerColorProp("shell_prompt_color_exit_code",       "exit_code",       &PromptColorOverrides::exitCode);
+    registerColorProp("shell_prompt_color_duration",        "duration",        &PromptColorOverrides::duration);
+    registerColorProp("shell_prompt_color_hostname",        "hostname",        &PromptColorOverrides::hostname);
+    registerColorProp("shell_prompt_color_separator",       "separator",       &PromptColorOverrides::separator);
+    registerColorProp("shell_prompt_color_badge",           "badge",           &PromptColorOverrides::badge);
+    registerColorProp("shell_prompt_color_badge_text",      "badge_text",      &PromptColorOverrides::badgeText);
+    registerColorProp("shell_prompt_color_clock",           "clock",           &PromptColorOverrides::clock);
     // clang-format on
+
+    // Internal helper invoked by `invokePromptCallback` to capture the return value
+    // of a user-defined prompt function. Not intended for direct user use.
+    _runtime.registerFunction("__prompt_capture_string")
+        .param<CoreVM::CoreString>("value")
+        .returnType(CoreVM::LiteralType::Void)
+        .bind([this](CoreVM::Params& args) { _promptCallbackResult = std::string(args.getString(1)); });
 }
 
 #if defined(ENDO_ENABLE_AGENT) && ENDO_ENABLE_AGENT

--- a/src/shell/ui/Prompt.cpp
+++ b/src/shell/ui/Prompt.cpp
@@ -81,6 +81,8 @@ void Prompt::initialize()
     _promptComponent->setPromptConfig(_promptConfig);
     _promptComponent->setPrompt(_promptStr);
     _promptComponent->setMultiline(_multilineEnabled);
+    if (_pendingDynamicFieldResolver)
+        _promptComponent->setDynamicFieldResolver(std::move(_pendingDynamicFieldResolver));
     _promptComponent->setCompleter(_completer);
     _promptComponent->setHistory(_history);
     _promptComponent->setCommandResolver(_commandResolver.get());
@@ -596,6 +598,17 @@ void Prompt::setPromptContext(PromptContext context)
 {
     if (_promptComponent)
         _promptComponent->setPromptContext(std::move(context));
+}
+
+void Prompt::setDynamicFieldResolver(PromptComponent::DynamicFieldResolver resolver)
+{
+    // The Shell installs its resolver from its constructor, which runs before the
+    // terminal-dependent `initialize()` has created `_promptComponent`. Cache the
+    // resolver so it can be forwarded to the component the moment it's built.
+    if (_promptComponent)
+        _promptComponent->setDynamicFieldResolver(std::move(resolver));
+    else
+        _pendingDynamicFieldResolver = std::move(resolver);
 }
 
 GitModule const* Prompt::gitModule() const noexcept

--- a/src/shell/ui/Prompt.hpp
+++ b/src/shell/ui/Prompt.hpp
@@ -106,6 +106,12 @@ class Prompt
     /// @param context The new prompt context.
     void setPromptContext(PromptContext context);
 
+    /// @brief Installs a resolver that evaluates user-defined prompt field callbacks.
+    ///
+    /// Forwards to the underlying PromptComponent. See
+    /// PromptComponent::setDynamicFieldResolver for semantics.
+    void setDynamicFieldResolver(PromptComponent::DynamicFieldResolver resolver);
+
     /// @brief Returns the Terminal for color scheme access.
     [[nodiscard]] tui::Terminal& terminal() noexcept { return _terminal; }
 
@@ -201,6 +207,12 @@ class Prompt
     bool _multilineEnabled = true; ///< Enable multiline editing by default
     PromptComponent::Action _lastAction = PromptComponent::Action::None; ///< Action from last read() call.
     bool _displayDrewCurrentState = false; ///< True when display() already drew the current state.
+
+    /// Dynamic-field resolver cached before `_promptComponent` is created (the Shell
+    /// installs it from its constructor, which runs before `initialize()`). It is
+    /// forwarded to the component in `initialize()` so that the first render picks up
+    /// user-assigned function values on properties like `shell_prompt_indicator`.
+    PromptComponent::DynamicFieldResolver _pendingDynamicFieldResolver;
 
     void initialize();
 

--- a/src/shell/ui/PromptComponent.cpp
+++ b/src/shell/ui/PromptComponent.cpp
@@ -201,6 +201,12 @@ std::vector<PromptSegments> PromptComponent::buildModuleVector(
 
 void PromptComponent::setPromptConfig(PromptConfig config)
 {
+    // Dropping the entire cache is the simplest correct response to a config update:
+    // if the user changed any dynamic-resolver assignment (e.g. `shell_prompt_indicator <- newFn`
+    // or reassigned a color function), cached outputs from the previous function are stale.
+    // The cost is one re-evaluation per field on the next render.
+    _dynamicCallbackCache.clear();
+
     _config = std::move(config);
     _auroraFadeCacheWidth = 0; // Invalidate sixel fade cache
 
@@ -239,9 +245,24 @@ void PromptComponent::setPromptContext(PromptContext context)
     {
         for (auto& [name, mod]: _modules)
             mod->invalidateCache();
+        // Dynamic-callback cache mirrors module caches: invalidate on any context change
+        // so user callbacks see current CWD, exit code, etc.
+        _dynamicCallbackCache.clear();
     }
 
     _context = std::move(context);
+}
+
+std::optional<std::string> PromptComponent::evaluateDynamicCallback(std::string const& fnName)
+{
+    if (!_dynamicFieldResolver)
+        return std::nullopt;
+    if (auto it = _dynamicCallbackCache.find(fnName); it != _dynamicCallbackCache.end())
+        return it->second;
+    auto result = _dynamicFieldResolver(fnName);
+    if (result)
+        _dynamicCallbackCache.emplace(fnName, *result);
+    return result;
 }
 
 void PromptComponent::setTerminalFocused(bool focused) noexcept
@@ -260,6 +281,16 @@ void PromptComponent::setTerminalFocused(bool focused) noexcept
 
 void PromptComponent::render(tui::Canvas& canvas)
 {
+    // Resolve dynamic prompt fields before module evaluation. Each configured
+    // `*Fn` names a user F# function; the installed resolver runs it and returns
+    // the string to use for this render. nullopt falls back to the static field.
+    // Results are cached per fnName and invalidated on context change (see
+    // setPromptContext), so intra-render and per-keystroke renders are cheap.
+    if (_config.indicatorFn.has_value())
+        _context.indicatorOverride = evaluateDynamicCallback(*_config.indicatorFn);
+    else
+        _context.indicatorOverride.reset();
+
     auto const& theme = tui::currentTheme();
     auto const canvasWidth = canvas.width();
     auto const totalLines = _inputField.lineCount();
@@ -269,9 +300,57 @@ void PromptComponent::render(tui::Canvas& canvas)
     // Effective content width (excluding margins)
     auto const contentWidth = canvasWidth - (2 * HorizontalMargin);
 
+    // Apply dynamic color overrides: for each color key in `colorFns`, invoke the
+    // named F# function, parse the returned string as a ColorSpec, and populate the
+    // corresponding member of a frame-local copy of the overrides. The static config
+    // is unchanged; only this frame's `resolved` colors reflect the dynamic values.
+    //
+    // Copying PromptColorOverrides is only necessary when dynamic resolvers are actually
+    // configured; otherwise we resolve directly against the static config to avoid the
+    // per-keystroke copy overhead (PromptColorOverrides contains an unordered_map).
+    PromptColorOverrides const* overridesForResolve = &_config.colorOverrides;
+    auto frameOverridesStorage = std::optional<PromptColorOverrides> {};
+    if (_dynamicFieldResolver && !_config.colorOverrides.colorFns.empty())
+    {
+        frameOverridesStorage.emplace(_config.colorOverrides);
+        overridesForResolve = &*frameOverridesStorage;
+
+        using ColorField = std::optional<ColorSpec> PromptColorOverrides::*;
+        static std::pair<std::string_view, ColorField> const colorFieldMap[] = {
+            { "path", &PromptColorOverrides::path },
+            { "git_clean", &PromptColorOverrides::gitClean },
+            { "git_dirty", &PromptColorOverrides::gitDirty },
+            { "git_staged", &PromptColorOverrides::gitStaged },
+            { "indicator", &PromptColorOverrides::indicator },
+            { "indicator_error", &PromptColorOverrides::indicatorError },
+            { "exit_code", &PromptColorOverrides::exitCode },
+            { "duration", &PromptColorOverrides::duration },
+            { "hostname", &PromptColorOverrides::hostname },
+            { "separator", &PromptColorOverrides::separator },
+            { "badge", &PromptColorOverrides::badge },
+            { "badge_text", &PromptColorOverrides::badgeText },
+            { "clock", &PromptColorOverrides::clock },
+        };
+        for (auto const& [colorKey, fnName]: frameOverridesStorage->colorFns)
+        {
+            auto resolvedStr = evaluateDynamicCallback(fnName);
+            if (!resolvedStr)
+                continue;
+            auto spec = parseColorSpec(*resolvedStr);
+            if (!spec)
+                continue;
+            for (auto const& [mapKey, field]: colorFieldMap)
+                if (mapKey == colorKey)
+                {
+                    (*frameOverridesStorage).*field = *spec;
+                    break;
+                }
+        }
+    }
+
     // Resolve prompt colors: merge overrides with theme defaults.
     // Stored as a local; the pointer in _context is valid only for this render frame.
-    auto const resolved = resolvePromptColors(_config.colorOverrides, theme.promptColors);
+    auto const resolved = resolvePromptColors(*overridesForResolve, theme.promptColors);
     _context.resolvedColors = &resolved;
     // Guard: null out after render scope (see end of this function).
 
@@ -619,8 +698,10 @@ void PromptComponent::render(tui::Canvas& canvas)
         continuationStr += "\xc2\xb7\xc2\xb7"; // ··
     }
 
-    // Set up InputField with prompt, continuation, ghost text style, and decorator
-    _inputField.setPrompt(_promptStr);
+    // Set up InputField with prompt, continuation, ghost text style, and decorator.
+    // When a dynamic indicator function is configured, the override computed above
+    // (via evaluateDynamicCallback) replaces the static `_promptStr` for this frame.
+    _inputField.setPrompt(_context.indicatorOverride.value_or(_promptStr));
     _inputField.setContinuationPrompt(continuationStr);
     _inputField.setStyles(tui::InputFieldStyles {
         .text = promptStyle,

--- a/src/shell/ui/PromptComponent.hpp
+++ b/src/shell/ui/PromptComponent.hpp
@@ -18,6 +18,7 @@
 #include <tui/TextDecorator.hpp>
 
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <set>
@@ -161,6 +162,21 @@ class PromptComponent: public tui::Component
     /// @param context The new prompt context.
     void setPromptContext(PromptContext context);
 
+    /// @brief Resolver used to evaluate dynamic prompt field callbacks.
+    ///
+    /// When the user assigns a function value to `shell_prompt_indicator` (or future
+    /// dynamic fields), the prompt config stores the function's name. During render,
+    /// PromptComponent calls this resolver to obtain the current string value.
+    /// Returns std::nullopt to fall back to the static field value.
+    using DynamicFieldResolver = std::function<std::optional<std::string>(std::string const& fnName)>;
+
+    /// @brief Installs a resolver that evaluates user-defined prompt callbacks.
+    /// Called by Shell during construction. No-op if never set — falls back to static config.
+    void setDynamicFieldResolver(DynamicFieldResolver resolver)
+    {
+        _dynamicFieldResolver = std::move(resolver);
+    }
+
     /// @brief Returns ms until next module refresh, or -1 if no module needs refresh.
     [[nodiscard]] int moduleRefreshTimeoutMs() const;
 
@@ -261,10 +277,24 @@ class PromptComponent: public tui::Component
     std::string _promptStr = "> ";
 
     // Prompt theming
-    PromptConfig _config;             ///< Layout and module configuration.
-    PromptContext _context;           ///< Current shell context for module evaluation.
-    PromptLayoutEngine _layoutEngine; ///< Layout rendering engine.
+    PromptConfig _config;                       ///< Layout and module configuration.
+    PromptContext _context;                     ///< Current shell context for module evaluation.
+    PromptLayoutEngine _layoutEngine;           ///< Layout rendering engine.
+    DynamicFieldResolver _dynamicFieldResolver; ///< Resolver for user-defined prompt callbacks.
+
+    /// Cached results from user-defined prompt callbacks, keyed by F# function name.
+    /// Render is invoked on every keystroke for features like ghost text; invoking user
+    /// callbacks each time would compile+run the AST N times per second. This cache
+    /// holds the last resolved string per callback and is cleared on every context
+    /// change (CWD / exit code / duration), which matches user expectations for when
+    /// the indicator and colors should update.
+    std::unordered_map<std::string, std::string> _dynamicCallbackCache;
+
     std::unordered_map<std::string, std::unique_ptr<PromptModule>> _modules; ///< Module registry.
+
+    /// @brief Evaluates a user callback, using the per-render cache. Returns std::nullopt
+    /// if the resolver is not installed or the callback failed.
+    [[nodiscard]] std::optional<std::string> evaluateDynamicCallback(std::string const& fnName);
 
     /// @brief Initializes the module registry with all available modules.
     void initializeModules();

--- a/src/shell/ui/PromptConfig.hpp
+++ b/src/shell/ui/PromptConfig.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace endo
@@ -80,6 +81,15 @@ struct PromptColorOverrides
     std::optional<ColorSpec> badgeText; ///< Badge text color.
     std::optional<ColorSpec> clock;     ///< Clock text color.
     bool transparentBackground = false; ///< When true, background = terminal default (no bg color emitted).
+
+    /// @brief Per-color dynamic resolvers (F# function names, without the "fsharp." prefix).
+    ///
+    /// Keys are the public color names (e.g. "path", "indicator", "git_clean"). At each
+    /// prompt render, PromptComponent invokes the named function; the returned string is
+    /// parsed via `parseColorSpec` and overrides the corresponding ColorSpec field for
+    /// that frame only. This map is orthogonal to the static ColorSpec fields: assigning
+    /// a string to a color property clears its entry here, and assigning a function sets it.
+    std::unordered_map<std::string, std::string> colorFns;
 };
 
 /// @brief Configuration for prompt rendering.
@@ -93,6 +103,10 @@ struct PromptConfig
     SeparatorStyle separator = SeparatorStyle::Bar;      ///< Separator style.
     TransientMode transient = TransientMode::Off;        ///< Transient prompt mode.
     std::string indicator = "> ";                        ///< Indicator character(s) on the input line.
+    /// Optional name of a user-defined F# function () -> string that produces the indicator
+    /// dynamically at each prompt render. When set, overrides the static `indicator` string.
+    /// The name is stored without any "fsharp." compiler prefix.
+    std::optional<std::string> indicatorFn;
     std::vector<std::string> infoLineModules = { "path", "git" }; ///< Modules for the info line.
     std::vector<std::string> rightPromptModules;                  ///< Modules for the right-aligned section.
     int promptSpacing = 1;              ///< Number of blank lines above and below the prompt (0 or 1).

--- a/src/shell/ui/PromptModule.hpp
+++ b/src/shell/ui/PromptModule.hpp
@@ -82,6 +82,13 @@ struct PromptContext
     int cellPixelHeight = 0;                              ///< Cell height in pixels (0 if unknown).
     int shellLevel = 0;                                   ///< Shell nesting depth (0 = outermost).
     std::string currentInput;                             ///< Current input text being edited.
+
+    /// @brief When set, overrides the static `PromptConfig::indicator` string for this render.
+    ///
+    /// Populated by the render pipeline when the user has assigned a function value to
+    /// `shell_prompt_indicator` (resolved against the shell's F# persistent state).
+    /// IndicatorModule consumes this preferentially over its configured static string.
+    std::optional<std::string> indicatorOverride;
 };
 
 /// @brief Abstract interface for a pluggable prompt module.

--- a/src/shell/ui/modules/IndicatorModule.cpp
+++ b/src/shell/ui/modules/IndicatorModule.cpp
@@ -21,7 +21,10 @@ PromptSegments IndicatorModule::evaluate(PromptContext const& ctx) const
                                            : ctx.theme->promptColors.indicator;
     }
 
-    return { PromptSegment { .text = _indicator, .style = style } };
+    // Prefer the dynamically-resolved override (from a user-assigned function
+    // value via shell_prompt_indicator) when present; otherwise fall back to
+    // the static indicator string configured on this module.
+    return { PromptSegment { .text = ctx.indicatorOverride.value_or(_indicator), .style = style } };
 }
 
 } // namespace endo

--- a/tests/session/prompt_indicator_lambda_persists.endo
+++ b/tests/session/prompt_indicator_lambda_persists.endo
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: A lambda assigned to shell_prompt_indicator survives across REPL prompts (must be persisted under a non-__lambda_ name).
+# expect: ok1
+# expect: ok2
+# mode: shell
+# session-separator: NEXT
+
+shell_prompt_indicator <- fun () -> "L"
+println "ok1"
+# NEXT
+println "ok2"

--- a/tests/shell/prompt_color_function.endo
+++ b/tests/shell/prompt_color_function.endo
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: shell_prompt_color_* accepts a function value (resolved at each render)
+# expect: ok
+# mode: shell
+
+let red () = "#FF0000"
+
+shell_prompt_color_indicator <- red
+shell_prompt_color_path <- fun () -> "#00FF00"
+println "ok"

--- a/tests/shell/prompt_color_typecheck_bool.endo
+++ b/tests/shell/prompt_color_typecheck_bool.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Assigning a bool to shell_prompt_color_indicator is rejected at the semantic checking phase.
+# expect-error: cannot accept a value of type bool
+
+shell_prompt_color_indicator <- true

--- a/tests/shell/prompt_indicator_function.endo
+++ b/tests/shell/prompt_indicator_function.endo
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: shell_prompt_indicator accepts a function value (no runtime error)
+# expect: ok
+# mode: shell
+
+let myPrompt () = "=> "
+
+shell_prompt_indicator <- myPrompt
+println "ok"

--- a/tests/shell/prompt_indicator_lambda.endo
+++ b/tests/shell/prompt_indicator_lambda.endo
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: shell_prompt_indicator accepts an anonymous lambda literal (no runtime error)
+# expect: ok
+# mode: shell
+
+shell_prompt_indicator <- fun () -> "=> "
+println "ok"

--- a/tests/shell/prompt_indicator_string.endo
+++ b/tests/shell/prompt_indicator_string.endo
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: shell_prompt_indicator string form continues to work unchanged (legacy setter appends a trailing space)
+# expect: $ .
+# mode: shell
+
+shell_prompt_indicator <- "$"
+println $"{shell_prompt_indicator}."

--- a/tests/shell/prompt_indicator_typecheck_int.endo
+++ b/tests/shell/prompt_indicator_typecheck_int.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Assigning an int to shell_prompt_indicator is rejected at the semantic checking phase.
+# expect-error: cannot accept a value of type int
+
+shell_prompt_indicator <- 42


### PR DESCRIPTION
Resolves #97. `shell_prompt_indicator` and every `shell_prompt_color_*` property now accept either a string or a zero-argument F# function returning a string. The function form is invoked at each prompt render and overrides the static value for that frame; the property getter reports the currently-effective value rather than the last static assignment.

```endo
let myPrompt () = $"{(env "PWD")?} => "
shell_prompt_indicator <- myPrompt
shell_prompt_indicator <- fun () -> "=> "
shell_prompt_color_indicator <- fun () -> "#FF5555"
```

The issue reporter's original attempt — `shell_prompt_indicator <- "${pwd} => "` — was rendering `${pwd}` verbatim because the string form has no template expansion. Assigning a function is the supported way to produce dynamic content.

Type mismatches such as `shell_prompt_indicator <- 42` are caught at the semantic checking phase, so the shell's live prompt diagnostics and the LSP underline the bad token as the user types and list the accepted types (`string | FunctionRef`) in the hint. The code generator only ever sees type-checked ASTs.

## Changes

- **CoreVM multi-overload setters.** `NativeProperty` carries setter callbacks keyed by argument `LiteralType`; `Runtime::registerPropertySetterOverload` appends overloads and records the accepted type on the property.
- **Shared descriptor for accepted setter types.** `PropertyDescriptor::extraSetterTypes` is read by `registerPromptPropertyBuiltins` so the shell, stub and test runtimes expose identical accepted-type sets — what sema checks is what the shell runs.
- **Sema property-type check.** `TypeInferencer` takes a non-owning `CoreVM::Runtime` + `CoreVM::diagnostics::Report`; `MutAssignStmt` / `MutAssignExpr` reject assignments whose RHS literal type isn't in the property's accepted set and flag read-only properties, with suggestions that survive the `DiagnosticsCollector` filter and reach the live prompt.
- **Codegen support.** `tryEmitFunctionRef` emits a `FunctionRefInstr` for lambda literals and named-function identifiers at Function-typed property-assignment sites; lambdas use a `__promptcb_` prefix so the persistence pass in `IRGenerator::generate` keeps them across REPL prompts. Setter dispatch picks the callback by the RHS's IR type and asserts that one exists — sema guarantees it.
- **Shell wiring.** `PromptConfig::indicatorFn` + `PromptColorOverrides::colorFns`. `Shell::invokePromptCallback` compiles and runs the named callback via `execute()` with RAII guards saving/restoring `_currentProgram`, `_runner`, `_configScriptDepth`, `_unusedValueDetection`, `_exitCode`, `_lastCommandDuration`, and trimming the transient `retainedASTs` entry. `PromptComponent` caches results per fn-name and invalidates on context change or config change so typing never re-runs the callback. `Prompt` buffers the dynamic-field resolver until `_promptComponent` is built so the Shell's ctor-time install isn't dropped.
- **Docs.** `docs/shell/configuration.md` spells out both forms, the lambda syntax, and that the string form is rendered verbatim — addressing the reporter's `${pwd}` misconception directly.