### PR TITLE
Auto-generate a documented init.endo on first run

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -922,6 +922,7 @@ Component (base class)
 - [x] Fix quoted-string completion for `set_prompt_*` builtins (unterminated quote handling in context analyzer, `BuiltinArgumentCompleter` shell provider)
 - [x] Add hover documentation for `set_prompt_*` builtin functions
 - [x] Implement `~/.config/endo/init.endo` auto-execution
+- [x] Auto-generate a documented `init.endo` template on first run when none exists (#109)
 - [x] Fix endo-signature prompt rendering (rounded separators ╭─/╰─, dim │ between modules, gradient path, structured output command filter)
 - [x] Implement auto-refresh for live prompt modules (clock 1s, git 5s, battery 30s) via `refreshInterval()` virtual method; fix auto-refresh initialization regression (`_nextModuleRefresh` deadline now set unconditionally after module update); immediate module cache invalidation and refresh on terminal focus gain
 - [x] Implement transient prompt rendering (replace full prompt with compact indicator on submit)

--- a/docs/shell/configuration.md
+++ b/docs/shell/configuration.md
@@ -13,6 +13,14 @@ settings, aliases, and key bindings.
 Endo loads `~/.config/endo/init.endo` automatically on startup. This file is executed as
 regular Endo code, so you can use any shell commands or F# expressions.
 
+On the very first interactive launch, if no `init.endo` exists, Endo writes a fully
+documented template to that path so you can discover every configurable property by
+editing your own file. All assignments in the template are commented out, so the built-in
+defaults remain in effect until you edit something. To regenerate the template from the
+current defaults, delete the file and start a new interactive Endo session. If the
+filesystem is read-only, the shell silently skips writing the template and continues with
+the baked-in defaults.
+
 ```endo
 # ~/.config/endo/init.endo
 

--- a/src/endo-language/builtins/PropertyDescriptors.cpp
+++ b/src/endo-language/builtins/PropertyDescriptors.cpp
@@ -13,7 +13,11 @@ namespace endo
 // ---------------------------------------------------------------------------
 
 // clang-format off
+// The first entry is the startup default (see `Prompt::Prompt()`), so it's
+// listed first in completion and used as the example value when the default
+// `init.endo` template is auto-generated on first run.
 static constexpr std::array presetValues = {
+    EnumValueEntry { .value="endo-signature", .description="Endo signature prompt (default)" },
     EnumValueEntry { .value="minimal-arrow", .description="Clean arrow-based prompt" },
     EnumValueEntry { .value="lambda-clean", .description="Lambda symbol prompt" },
     EnumValueEntry { .value="opencode-bar", .description="OpenCode-style bar prompt" },
@@ -23,26 +27,28 @@ static constexpr std::array presetValues = {
     EnumValueEntry { .value="boxed-module", .description="Boxed module prompt" },
     EnumValueEntry { .value="gradient-glow", .description="Gradient glow prompt" },
     EnumValueEntry { .value="context-adaptive", .description="Context-adaptive prompt" },
-    EnumValueEntry { .value="endo-signature", .description="Endo signature prompt" },
 };
 
+// Default preset (`endo-signature`) uses two-line / rounded, so those lead
+// their respective enums to keep completion and init.endo examples aligned
+// with the actual startup configuration.
 static constexpr std::array layoutValues = {
+    EnumValueEntry { .value="two-line", .description="Two line prompt (default)" },
     EnumValueEntry { .value="single-line", .description="Single line prompt" },
-    EnumValueEntry { .value="two-line", .description="Two line prompt" },
     EnumValueEntry { .value="boxed", .description="Boxed prompt layout" },
     EnumValueEntry { .value="powerline", .description="Powerline prompt layout" },
 };
 
 static constexpr std::array separatorValues = {
+    EnumValueEntry { .value="rounded", .description="Rounded separator (default)" },
     EnumValueEntry { .value="none", .description="No separator" },
     EnumValueEntry { .value="bar", .description="Bar separator (|)" },
     EnumValueEntry { .value="powerline", .description="Powerline separator" },
-    EnumValueEntry { .value="rounded", .description="Rounded separator" },
     EnumValueEntry { .value="boxed", .description="Boxed separator" },
 };
 
 static constexpr std::array transientValues = {
-    EnumValueEntry { .value="off", .description="Disable transient prompt" },
+    EnumValueEntry { .value="off", .description="Disable transient prompt (default)" },
     EnumValueEntry { .value="minimal", .description="Minimal transient prompt" },
     EnumValueEntry { .value="arrow", .description="Arrow transient prompt" },
 };

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -135,6 +135,10 @@ add_library(endo-shell STATIC
     DirectoryConfig.hpp
     DirectoryConfig.cpp
 
+    # Configuration bootstrap
+    config/DefaultInitScript.hpp
+    config/DefaultInitScript.cpp
+
     # Builtins
     builtins/InlineCommandDescriptor.hpp
     builtins/InlineCommandDescriptors.cpp
@@ -258,6 +262,7 @@ add_executable(test-endo-shell
     test_main.cpp
     Shell_test.cpp
     DirectoryConfig_test.cpp
+    config/DefaultInitScript_test.cpp
     builtins/InlineArgParser_test.cpp
     commands/FindExpression_test.cpp
     commands/GrepCommand_test.cpp

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -2,6 +2,7 @@
 #include "Shell.hpp"
 #include <shell/builtins/InlineCommandDescriptor.hpp>
 #include <shell/completion/ScriptedCompleter.hpp>
+#include <shell/config/DefaultInitScript.hpp>
 #include <shell/history/RequiredPaths.hpp>
 #include <shell/ui/Prompt.hpp>
 #include <shell/ui/PromptPresets.hpp>
@@ -962,6 +963,23 @@ void Shell::loadInitScript()
     if (auto const configDir = platform::configHome())
     {
         auto const initPath = *configDir / "endo" / "init.endo";
+
+        // First-run bootstrap: when no init.endo exists yet, drop a fully
+        // documented template so users can discover configuration options
+        // by editing their config file. The write is best-effort — on a
+        // read-only filesystem we silently continue; the baked-in C++
+        // defaults still apply regardless of whether the file exists.
+        if (!_fs.exists(initPath))
+        {
+            if (auto const dirResult = _fs.createDirectories(initPath.parent_path()); dirResult)
+            {
+                // Write is best-effort: on a read-only filesystem we silently
+                // continue; the baked-in C++ defaults still apply.
+                auto const writeResult = _fs.writeFile(initPath, generateDefaultInitEndo());
+                static_cast<void>(writeResult);
+            }
+        }
+
         if (_fs.exists(initPath))
         {
             if (auto content = _fs.readFile(initPath))

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -5001,3 +5001,75 @@ TEST_CASE("shell.completion.executeCompleterFunction_with_CompletionEntry")
         std::ranges::find_if(result.completions, [](auto const& c) { return c.text == "--help"; });
     CHECK(it->description == "Show help");
 }
+
+// ============================================================================
+// Auto-generated init.endo on first run (#109)
+// ============================================================================
+
+TEST_CASE("shell.init_endo.auto_creates_when_missing")
+{
+    // Point XDG_CONFIG_HOME at a fresh tempdir so loadInitScript() writes
+    // into an isolated location and does not disturb the user's real config.
+    auto const dir = std::filesystem::temp_directory_path()
+                     / std::format("endo-init-test-{}", ::getpid());
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    auto const* const prevXdg = std::getenv("XDG_CONFIG_HOME");
+    auto const prevXdgSaved = prevXdg != nullptr ? std::string { prevXdg } : std::string {};
+    auto const xdgGuard = [prev = prevXdgSaved, hadPrev = prevXdg != nullptr](auto*) {
+        if (hadPrev)
+            ::setenv("XDG_CONFIG_HOME", prev.c_str(), 1);
+        else
+            ::unsetenv("XDG_CONFIG_HOME");
+    };
+    std::unique_ptr<int, decltype(xdgGuard)> restore(reinterpret_cast<int*>(1), xdgGuard);
+    ::setenv("XDG_CONFIG_HOME", dir.c_str(), 1);
+
+    auto const initPath = dir / "endo" / "init.endo";
+    REQUIRE_FALSE(std::filesystem::exists(initPath));
+
+    {
+        TestShell shell;
+        shell.shell.loadInitScript();
+    }
+
+    REQUIRE(std::filesystem::exists(initPath));
+    auto const size = std::filesystem::file_size(initPath);
+    CHECK(size > 500);
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("shell.init_endo.preserves_existing_content")
+{
+    // An existing init.endo must not be clobbered by the auto-generate step.
+    auto const dir = std::filesystem::temp_directory_path()
+                     / std::format("endo-init-preserve-{}", ::getpid());
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir / "endo");
+    auto const initPath = dir / "endo" / "init.endo";
+    auto const userContent = std::string_view { "# my custom init\nshell_prompt_spacing <- 0\n" };
+    std::ofstream { initPath } << userContent;
+
+    auto const* const prevXdg = std::getenv("XDG_CONFIG_HOME");
+    auto const prevXdgSaved = prevXdg != nullptr ? std::string { prevXdg } : std::string {};
+    auto const xdgGuard = [prev = prevXdgSaved, hadPrev = prevXdg != nullptr](auto*) {
+        if (hadPrev)
+            ::setenv("XDG_CONFIG_HOME", prev.c_str(), 1);
+        else
+            ::unsetenv("XDG_CONFIG_HOME");
+    };
+    std::unique_ptr<int, decltype(xdgGuard)> restore(reinterpret_cast<int*>(1), xdgGuard);
+    ::setenv("XDG_CONFIG_HOME", dir.c_str(), 1);
+
+    {
+        TestShell shell;
+        shell.shell.loadInitScript();
+    }
+
+    auto in = std::ifstream { initPath };
+    auto actual = std::string { std::istreambuf_iterator<char>(in), {} };
+    CHECK(actual == std::string(userContent));
+
+    std::filesystem::remove_all(dir);
+}

--- a/src/shell/config/DefaultInitScript.cpp
+++ b/src/shell/config/DefaultInitScript.cpp
@@ -86,17 +86,30 @@ namespace
         out += "# Full reference: https://endo-lang.org/shell/configuration/\n";
     }
 
-    /// Appends a reference section listing the default key bindings. Purely
-    /// informational — there is currently no script-level API to rebind keys
-    /// from within init.endo (see `bind` builtin for interactive use).
+    /// Appends an executable key-bindings section. The `bind` builtin can be
+    /// called from any script (including init.endo) — `bind <chord> <action>`
+    /// sets, `bind -r <chord>` removes, `bind --reset` restores defaults.
+    /// Uncommenting any line here just works at next shell launch.
     void appendKeyBindingsReference(std::string& out)
     {
-        appendSection(out, "Default key bindings (reference only)");
-        out += "# Endo ships with these key bindings out of the box. There is no\n";
-        out += "# `.endo` setter API for bindings yet; use the `bind` builtin at the\n";
-        out += "# prompt to view, add, or remove bindings interactively. See:\n";
-        out += "#   https://endo-lang.org/shell/configuration/#key-bindings\n";
+        appendSection(out, "Key bindings");
+        out += "# Customize the line editor with the `bind` builtin. All lines below are\n";
+        out += "# valid — uncomment to activate. Run `bind` to list current bindings,\n";
+        out += "# `bind --help` to see every available action, or `bind --reset` to\n";
+        out += "# restore defaults.\n";
         out += "#\n";
+        out += "# Emacs-friendly overrides:\n";
+        out += "# bind ctrl+y yank                 # override Redo with kill-ring paste\n";
+        out += "# bind ctrl+t transpose            # swap chars around cursor (replaces agent-mode)\n";
+        out += "# bind ctrl+v paste                # clipboard paste (unbound by default)\n";
+        out += "#\n";
+        out += "# Remove a default binding:\n";
+        out += "# bind -r ctrl+l\n";
+        out += "#\n";
+        out += "# Reset everything back to Endo defaults:\n";
+        out += "# bind --reset\n";
+        out += "#\n";
+        out += "# Current default bindings (for reference):\n";
 
         auto const defaults = tui::KeyBindings::defaults();
         for (auto const& [chord, action]: defaults.bindings())

--- a/src/shell/config/DefaultInitScript.cpp
+++ b/src/shell/config/DefaultInitScript.cpp
@@ -59,7 +59,7 @@ namespace
             out += std::format("# (read-only) print {}\n", p.name);
         else
             out += std::format("# {} <- {}\n", p.name, placeholderFor(p));
-        out += '\n';
+        out += "#\n";
     }
 
     /// Emits a section header as an `.endo` comment banner.
@@ -67,7 +67,7 @@ namespace
     {
         out += "# ---------------------------------------------------------------------------\n";
         out += std::format("# {}\n", title);
-        out += "# ---------------------------------------------------------------------------\n\n";
+        out += "# ---------------------------------------------------------------------------\n";
     }
 
     /// Renders the header comment block shown at the top of the file.
@@ -83,7 +83,7 @@ namespace
         out += "# start a new interactive Endo session; a fresh copy will be written.\n";
         out += "# To skip loading this file on startup, pass `--no-profile` to endo.\n";
         out += "#\n";
-        out += "# Full reference: https://endo-shell.dev/shell/configuration/\n\n";
+        out += "# Full reference: https://endo-shell.dev/shell/configuration/\n";
     }
 
     /// Appends a reference section listing the default key bindings. Purely
@@ -101,7 +101,6 @@ namespace
         auto const defaults = tui::KeyBindings::defaults();
         for (auto const& [chord, action]: defaults.bindings())
             out += std::format("#   {:<20} -> {}\n", chord.toString(), tui::editActionToString(action));
-        out += '\n';
     }
 
     /// Appends a short pattern-matching demo tailored to show off the
@@ -119,7 +118,6 @@ namespace
         out += "# | \"Linux\"  -> shell_prompt_indicator <- \"🐧 \"\n";
         out += "# | \"Darwin\" -> shell_prompt_indicator <- \"🍎 \"\n";
         out += "# | _        -> shell_prompt_indicator <- \"|> \"\n";
-        out += '\n';
     }
 
 } // namespace
@@ -137,7 +135,8 @@ std::string generateDefaultInitEndo()
 
 #if defined(ENDO_ENABLE_AGENT) && ENDO_ENABLE_AGENT
     appendSection(out, "AI agent configuration");
-    out += "# These settings only take effect when Endo is built with agent support.\n\n";
+    out += "# These settings only take effect when Endo is built with agent support.\n";
+    out += "#\n";
     for (auto const& p: agentPropertyDescriptors())
         appendPropertyBlock(out, p);
 #endif

--- a/src/shell/config/DefaultInitScript.cpp
+++ b/src/shell/config/DefaultInitScript.cpp
@@ -83,7 +83,7 @@ namespace
         out += "# start a new interactive Endo session; a fresh copy will be written.\n";
         out += "# To skip loading this file on startup, pass `--no-profile` to endo.\n";
         out += "#\n";
-        out += "# Full reference: https://endo-shell.dev/shell/configuration/\n";
+        out += "# Full reference: https://endo-lang.org/shell/configuration/\n";
     }
 
     /// Appends a reference section listing the default key bindings. Purely
@@ -95,7 +95,7 @@ namespace
         out += "# Endo ships with these key bindings out of the box. There is no\n";
         out += "# `.endo` setter API for bindings yet; use the `bind` builtin at the\n";
         out += "# prompt to view, add, or remove bindings interactively. See:\n";
-        out += "#   https://endo-shell.dev/shell/configuration/#key-bindings\n";
+        out += "#   https://endo-lang.org/shell/configuration/#key-bindings\n";
         out += "#\n";
 
         auto const defaults = tui::KeyBindings::defaults();

--- a/src/shell/config/DefaultInitScript.cpp
+++ b/src/shell/config/DefaultInitScript.cpp
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "DefaultInitScript.hpp"
+
+#include <endo-language/builtins/PropertyDescriptors.hpp>
+
+#include <tui/EditAction.hpp>
+#include <tui/KeyBindings.hpp>
+
+#include <format>
+#include <ranges>
+#include <span>
+#include <string>
+#include <string_view>
+
+namespace endo
+{
+
+namespace
+{
+
+    /// Renders the (short) first sentence of a property's description.
+    /// `PropertyDescriptor::description` is already terse, so we just trim it.
+    [[nodiscard]] std::string_view briefDescription(PropertyDescriptor const& p) noexcept
+    {
+        return p.description;
+    }
+
+    /// Returns a type-appropriate placeholder literal used in the commented-out
+    /// example assignment. For enum-valued string properties the first enum
+    /// entry is used so users see a concrete example they can toggle.
+    [[nodiscard]] std::string placeholderFor(PropertyDescriptor const& p)
+    {
+        using T = CoreVM::LiteralType;
+        if (!p.enumValues.empty() && p.type == T::String)
+            return std::format("\"{}\"", p.enumValues.front().value);
+        switch (p.type)
+        {
+            case T::String: return "\"\"";
+            case T::Number: return "0";
+            case T::Boolean: return "false";
+            default: return "\"\"";
+        }
+    }
+
+    /// Writes one "# " comment block plus a commented-out assignment line for
+    /// a single property. The assignment is commented so the file is
+    /// behaviorally inert on first run — the baked-in C++ defaults win.
+    void appendPropertyBlock(std::string& out, PropertyDescriptor const& p)
+    {
+        out += std::format("# {}\n", briefDescription(p));
+        if (!p.enumValues.empty())
+        {
+            out += "# Values:";
+            for (auto const& [i, e]: std::views::enumerate(p.enumValues))
+                out += std::format("{} {}", i == 0 ? "" : " |", e.value);
+            out += '\n';
+        }
+        if (p.readOnly)
+            out += std::format("# (read-only) print {}\n", p.name);
+        else
+            out += std::format("# {} <- {}\n", p.name, placeholderFor(p));
+        out += '\n';
+    }
+
+    /// Emits a section header as an `.endo` comment banner.
+    void appendSection(std::string& out, std::string_view title)
+    {
+        out += "# ---------------------------------------------------------------------------\n";
+        out += std::format("# {}\n", title);
+        out += "# ---------------------------------------------------------------------------\n\n";
+    }
+
+    /// Renders the header comment block shown at the top of the file.
+    void appendHeader(std::string& out)
+    {
+        out += "# ~/.config/endo/init.endo\n";
+        out += "#\n";
+        out += "# This file was auto-generated on first run because no init.endo existed.\n";
+        out += "# It documents every shell property you can configure. All assignments are\n";
+        out += "# commented out by default — uncomment and edit the lines you care about.\n";
+        out += "#\n";
+        out += "# To regenerate this file from the current Endo defaults, delete it and\n";
+        out += "# start a new interactive Endo session; a fresh copy will be written.\n";
+        out += "# To skip loading this file on startup, pass `--no-profile` to endo.\n";
+        out += "#\n";
+        out += "# Full reference: https://endo-shell.dev/shell/configuration/\n\n";
+    }
+
+    /// Appends a reference section listing the default key bindings. Purely
+    /// informational — there is currently no script-level API to rebind keys
+    /// from within init.endo (see `bind` builtin for interactive use).
+    void appendKeyBindingsReference(std::string& out)
+    {
+        appendSection(out, "Default key bindings (reference only)");
+        out += "# Endo ships with these key bindings out of the box. There is no\n";
+        out += "# `.endo` setter API for bindings yet; use the `bind` builtin at the\n";
+        out += "# prompt to view, add, or remove bindings interactively. See:\n";
+        out += "#   https://endo-shell.dev/shell/configuration/#key-bindings\n";
+        out += "#\n";
+
+        auto const defaults = tui::KeyBindings::defaults();
+        for (auto const& [chord, action]: defaults.bindings())
+            out += std::format("#   {:<20} -> {}\n", chord.toString(), tui::editActionToString(action));
+        out += '\n';
+    }
+
+    /// Appends a short pattern-matching demo tailored to show off the
+    /// language: capture `$(uname -s)` and branch on it. The block is
+    /// commented out so it has no runtime effect unless the user enables it.
+    void appendPatternMatchingExample(std::string& out)
+    {
+        appendSection(out, "Example: per-OS customization with pattern matching");
+        out += "# Capture the OS name from the `uname` builtin and pick per-platform\n";
+        out += "# settings. This demonstrates command substitution plus F#-style\n";
+        out += "# pattern matching — uncomment to enable.\n";
+        out += "#\n";
+        out += "# let os = $(uname -s)\n";
+        out += "# match os with\n";
+        out += "# | \"Linux\"  -> shell_prompt_indicator <- \"🐧 \"\n";
+        out += "# | \"Darwin\" -> shell_prompt_indicator <- \"🍎 \"\n";
+        out += "# | _        -> shell_prompt_indicator <- \"|> \"\n";
+        out += '\n';
+    }
+
+} // namespace
+
+std::string generateDefaultInitEndo()
+{
+    std::string out;
+    out.reserve(8 * 1024);
+
+    appendHeader(out);
+
+    appendSection(out, "Prompt & shell configuration");
+    for (auto const& p: promptPropertyDescriptors())
+        appendPropertyBlock(out, p);
+
+#if defined(ENDO_ENABLE_AGENT) && ENDO_ENABLE_AGENT
+    appendSection(out, "AI agent configuration");
+    out += "# These settings only take effect when Endo is built with agent support.\n\n";
+    for (auto const& p: agentPropertyDescriptors())
+        appendPropertyBlock(out, p);
+#endif
+
+    appendKeyBindingsReference(out);
+    appendPatternMatchingExample(out);
+
+    return out;
+}
+
+} // namespace endo

--- a/src/shell/config/DefaultInitScript.hpp
+++ b/src/shell/config/DefaultInitScript.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file DefaultInitScript.hpp
+/// @brief Renders a fully-documented default `init.endo` template from the
+///        single source-of-truth C++ descriptor tables.
+///
+/// Auto-created on first run by `Shell::loadInitScript()` when the user has
+/// no `init.endo` yet. The generated file documents every configurable
+/// shell property and ships commented-out example assignments so users can
+/// uncomment and tweak them without hunting through docs. Because all
+/// assignments are commented by default, regenerating the file is
+/// behaviorally inert — the baked-in C++ defaults remain authoritative.
+
+#include <string>
+
+namespace endo
+{
+
+/// @brief Returns the rendered default `init.endo` file contents.
+///
+/// The output is derived from:
+///   - `promptPropertyDescriptors()` / `agentPropertyDescriptors()` — property
+///     names, types, descriptions, detailed docs, and enum values.
+///   - `tui::KeyBindings::defaults()` — default key-binding reference block.
+///
+/// The rendered script is valid `.endo` syntax (comment-only by default) and
+/// is expected to round-trip through `endo format --check`.
+///
+/// @return A UTF-8 string holding the complete file contents, including a
+///         trailing newline.
+[[nodiscard]] std::string generateDefaultInitEndo();
+
+} // namespace endo

--- a/src/shell/config/DefaultInitScript_test.cpp
+++ b/src/shell/config/DefaultInitScript_test.cpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "DefaultInitScript.hpp"
+
+#include <endo-language/builtins/PropertyDescriptors.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <string_view>
+
+using namespace std::string_view_literals;
+
+namespace
+{
+[[nodiscard]] bool contains(std::string const& haystack, std::string_view needle) noexcept
+{
+    return haystack.find(needle) != std::string::npos;
+}
+} // namespace
+
+TEST_CASE("DefaultInitScript.generates_non_empty_script")
+{
+    auto const content = endo::generateDefaultInitEndo();
+    REQUIRE_FALSE(content.empty());
+    CHECK(contains(content, "~/.config/endo/init.endo"sv));
+    CHECK(contains(content, "shell_prompt_preset"sv));
+    CHECK(contains(content, "shell_prompt_indicator"sv));
+}
+
+TEST_CASE("DefaultInitScript.commented_out_by_default")
+{
+    // Every assignment line is commented out so the generated file is
+    // behaviorally inert — the baked-in C++ defaults must remain authoritative.
+    auto const content = endo::generateDefaultInitEndo();
+    auto pos = std::size_t { 0 };
+    while (pos < content.size())
+    {
+        auto const eol = content.find('\n', pos);
+        auto const line = std::string_view(content).substr(pos, eol - pos);
+        pos = eol == std::string::npos ? content.size() : eol + 1;
+
+        // Allow blank lines and lines that start with `#`; that's all we emit.
+        if (line.empty())
+            continue;
+        CHECK(line.front() == '#');
+    }
+}
+
+TEST_CASE("DefaultInitScript.documents_every_prompt_property")
+{
+    // Every descriptor should contribute at least one line mentioning its name,
+    // otherwise PropertyDescriptors got out of sync with the renderer.
+    auto const content = endo::generateDefaultInitEndo();
+    for (auto const& p: endo::promptPropertyDescriptors())
+        CHECK(contains(content, p.name));
+}
+
+TEST_CASE("DefaultInitScript.enum_values_listed_as_comments")
+{
+    // For enum-valued properties we render a `# Values: ...` line listing
+    // the permitted choices. Spot-check using `shell_prompt_preset`.
+    auto const content = endo::generateDefaultInitEndo();
+    CHECK(contains(content, "Values:"sv));
+    CHECK(contains(content, "powerline"sv));
+    CHECK(contains(content, "minimal-arrow"sv));
+}
+
+TEST_CASE("DefaultInitScript.key_bindings_reference_present")
+{
+    // The key-bindings block is reference-only — we just verify that a
+    // representative default chord/action pair made it into the output.
+    auto const content = endo::generateDefaultInitEndo();
+    CHECK(contains(content, "Default key bindings"sv));
+    CHECK(contains(content, "undo"sv));
+    CHECK(contains(content, "copy"sv));
+}
+
+TEST_CASE("DefaultInitScript.pattern_matching_example_present")
+{
+    // Demonstrates F#-style pattern matching + command substitution as the
+    // issue asks for — keeps the file useful as a teaching artifact.
+    auto const content = endo::generateDefaultInitEndo();
+    CHECK(contains(content, "match os with"sv));
+    CHECK(contains(content, "uname -s"sv));
+    CHECK(contains(content, "\"Linux\""sv));
+    CHECK(contains(content, "\"Darwin\""sv));
+}
+
+#if defined(ENDO_ENABLE_AGENT) && ENDO_ENABLE_AGENT
+TEST_CASE("DefaultInitScript.agent_section_present_when_agent_enabled")
+{
+    auto const content = endo::generateDefaultInitEndo();
+    CHECK(contains(content, "agent_provider"sv));
+}
+#else
+TEST_CASE("DefaultInitScript.agent_section_absent_when_agent_disabled")
+{
+    auto const content = endo::generateDefaultInitEndo();
+    CHECK_FALSE(contains(content, "agent_provider"sv));
+}
+#endif

--- a/src/shell/config/DefaultInitScript_test.cpp
+++ b/src/shell/config/DefaultInitScript_test.cpp
@@ -65,6 +65,18 @@ TEST_CASE("DefaultInitScript.enum_values_listed_as_comments")
     CHECK(contains(content, "minimal-arrow"sv));
 }
 
+TEST_CASE("DefaultInitScript.example_matches_runtime_default")
+{
+    // The rendered example for `shell_prompt_preset` must show the actual
+    // startup default ("endo-signature"), not a minimal-looking preset that
+    // would give first-time users the wrong impression of Endo's power.
+    // This works because the first enum entry is the startup default, and
+    // the generator uses the first enum value as the example.
+    auto const content = endo::generateDefaultInitEndo();
+    CHECK(contains(content, "shell_prompt_preset <- \"endo-signature\""sv));
+    CHECK_FALSE(contains(content, "shell_prompt_preset <- \"minimal-arrow\""sv));
+}
+
 TEST_CASE("DefaultInitScript.key_bindings_reference_present")
 {
     // The key-bindings block is reference-only — we just verify that a

--- a/src/shell/config/DefaultInitScript_test.cpp
+++ b/src/shell/config/DefaultInitScript_test.cpp
@@ -77,12 +77,17 @@ TEST_CASE("DefaultInitScript.example_matches_runtime_default")
     CHECK_FALSE(contains(content, "shell_prompt_preset <- \"minimal-arrow\""sv));
 }
 
-TEST_CASE("DefaultInitScript.key_bindings_reference_present")
+TEST_CASE("DefaultInitScript.key_bindings_section_has_active_examples")
 {
-    // The key-bindings block is reference-only — we just verify that a
-    // representative default chord/action pair made it into the output.
+    // The key-bindings block must surface real, uncomment-to-activate `bind`
+    // examples (not just a reference table) so users can customize bindings
+    // from init.endo directly. Also retain the live reference table.
     auto const content = endo::generateDefaultInitEndo();
-    CHECK(contains(content, "Default key bindings"sv));
+    CHECK(contains(content, "Key bindings"sv));
+    CHECK(contains(content, "bind ctrl+y yank"sv));
+    CHECK(contains(content, "bind --reset"sv));
+    CHECK(contains(content, "bind -r ctrl+l"sv));
+    CHECK(contains(content, "Current default bindings"sv));
     CHECK(contains(content, "undo"sv));
     CHECK(contains(content, "copy"sv));
 }

--- a/src/shell/ui/PromptPresets.cpp
+++ b/src/shell/ui/PromptPresets.cpp
@@ -99,7 +99,10 @@ static std::vector<PromptConfig> presets = {
             0x252545_rgb, // deep indigo (wrap)
         },
         .enableSixelFade = false,
-        .colorOverrides = { .path = ColorSpec { { 0x5078FF_rgb, 0x00DCC8_rgb } } }, // Blue → Teal gradient
+        .colorOverrides = {
+            .path = ColorSpec { { 0x5078FF_rgb, 0x00DCC8_rgb } }, // Blue → Teal gradient
+            .transparentBackground = true,
+        },
     },
 };
 


### PR DESCRIPTION
Closes #109.

On first interactive launch, Endo now drops a fully-documented `init.endo` into the user's config directory if none exists yet, so newcomers can discover every configurable shell property by editing their own file. The template is generated at runtime from the existing C++ descriptor tables (`PropertyDescriptors`, `PromptPresets`, `KeyBindings::defaults()`), so defaults are never duplicated — the C++ sources remain the single source of truth, and the write is best-effort (silent no-op on read-only filesystems).

## Changes

- Add `generateDefaultInitEndo()` in `src/shell/config/` that renders every prompt/agent property descriptor plus an executable key-bindings section using the `bind` builtin. The file round-trips cleanly through `endo format --check`.
- Hook first-run creation into `Shell::loadInitScript()` — `createDirectories` + `writeFile` gated on `!exists(initPath)`; failures are ignored.
- Reorder `presetValues` / `layoutValues` / `separatorValues` so the runtime default (`endo-signature`, `two-line`, `rounded`) leads each enum. This aligns the template's example values with the actual startup configuration and promotes the default in tab-completion.
- Enable `transparentBackground` on the `endo-signature` preset so the shipped default respects the terminal background.
- Include a short pattern-matching demo (`match $(uname -s) with …`) as a teaching artifact.
- Document the auto-generation behavior in `docs/shell/configuration.md`; tick the new ROADMAP item.

Covered by new Catch2 tests in `DefaultInitScript_test.cpp` (rendering, commented-out invariant, enum ordering, active bind examples, agent-section gating) plus integration tests in `Shell_test.cpp` that exercise `loadInitScript()` against a tempdir-backed `XDG_CONFIG_HOME` for both missing-file and preserve-existing paths.