### PR TITLE
feat: use system crash dump handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,8 @@ endif()
 # crispy is vendored from contour — pass through its testing flag
 set(CONTOUR_TESTING ${ENDO_TESTING})
 
+option(ENDO_BUILTIN_CRARHDUMP "Enable built-in crashdump reporter, say NO to use system wide crashdump collection like coredumpctl [default: ON]" ON)
+
 # Apply Emscripten compatibility patches to vendored sources.
 # crispy is symlinked from contour, so we use sed for in-place patching
 # (GNU patch does not follow symlinked directories).
@@ -188,6 +190,7 @@ message(STATUS "endo trace parser   ${ENDO_TRACE_PARSER}")
 message(STATUS "endo trace lexer    ${ENDO_TRACE_LEXER}")
 message(STATUS "Testing             ${ENDO_TESTING}")
 message(STATUS "Static linking      ${ENABLE_STATIC_LINKING}")
+message(STATUS "Built in crashdump  ${ENDO_BUILTIN_CRARHDUMP}")
 if(NOT EMSCRIPTEN)
     message(STATUS "Address Sanitizer   ${ENABLE_ASAN}")
     message(STATUS "UB Sanitizer        ${ENABLE_UBSAN}")

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -12,8 +12,6 @@ add_library(endo-shell STATIC
     ProcessGroup.hpp
     TTY.hpp
     TTY.cpp
-    CrashHandler.hpp
-    CrashHandler.cpp
 
     # UI (Prompt, Syntax Highlighting, Grapheme Handling)
     ui/Prompt.hpp
@@ -190,6 +188,13 @@ add_library(endo-shell STATIC
     completion/ProcessNameQueryProvider.cpp
 )
 
+if(NOT ENDO_BUILTIN_CRARHDUMP)
+  target_sources(endo-shell PRIVATE
+    CrashHandler.hpp
+    CrashHandler.cpp
+    )
+endif()
+
 # Platform-specific implementations
 if(WIN32)
     target_sources(endo-shell PRIVATE
@@ -263,7 +268,6 @@ add_executable(test-endo-shell
     commands/GrepCommand_test.cpp
     commands/TimeoutCommand_test.cpp
     commands/PkillCommand_test.cpp
-    CrashHandler_test.cpp
     ui/PromptComponent_test.cpp
     ui/modules/GitModule_test.cpp
     ui/Gradient_test.cpp
@@ -282,6 +286,12 @@ add_executable(test-endo-shell
     ui/RichConsoleReport_test.cpp
     ui/SyntaxHighlighter_test.cpp
 )
+
+if(NOT ENDO_BUILTIN_CRARHDUMP)
+target_sources(test-endo-shell PUBLIC
+  CrashHandler_test.cpp
+)
+endif()
 
 target_link_libraries(test-endo-shell endo-shell Catch2::Catch2)
 target_compile_definitions(test-endo-shell PRIVATE

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -23,7 +23,9 @@
     #include <windows.h>
 #endif
 
+#if defined(ENDO_BUILTIN_CRARHDUMP)
 #include "CrashHandler.hpp"
+#endif
 #include "FormatCommand.hpp"
 #include "HelpPrinter.hpp"
 #include "Shell.hpp"
@@ -270,7 +272,9 @@ int main(int argc, char const* argv[])
     setupWindowsUtf8();
 #endif
 
+#if defined(ENDO_BUILTIN_CRARHDUMP)
     endo::CrashHandler::initialize(std::string(Version).c_str());
+#endif
 
     auto const args = std::span(argv, static_cast<size_t>(argc));
     auto const programName = args.empty() ? "endo"sv : std::string_view(args[0]);


### PR DESCRIPTION
Many systems, particularly most Linux desktop environments, have a system-wide crash dump handler coredumpctl [1].

coredumpctl can be used to retrieve stack traces of crashed processes and to recover their memory state, which can give more information than a simple stack trace alone.

I added a built-time option `ENDO_BUILTIN_CRARHDUMP` . If set to `OFF`, then `endo` will not use the built-in crashdump handler and will rely on the system-wide coredump collector.

[1] https://www.freedesktop.org/software/systemd/man/latest/coredumpctl.html