### PR TITLE
UX: multi-line shell commands + horizontal InputField scroll

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -518,6 +518,11 @@ src/
   - [x] Or-pattern `|` alternation across line breaks in `parseMatch()` — LineFeed-only consumption (not semicolons)
   - [x] Match arm body on next line after `->` — consume linefeeds after arrow token
   - [x] Double-quoted string literal patterns in `parsePrimaryPattern()` — handle `DblQuoteStart` tokenization in F# mode
+- [x] Parser multi-line continuation for shell commands
+  - [x] Trailing `|`, `|>`, `&&`, `||` at end of line: LineFeeds after the operator consumed as whitespace in `parseCallPipeline`, `parseLogicalExpr`, and every `|>` site
+  - [x] Leading `|`, `|>`, `&&`, `||` at start of next line: `tryConsumeNewlinesBeforeContinuationOperator` helper peeks past LineFeeds and drops them when followed by a continuation operator
+  - [x] Indentation continuation: in `parseCall`, a next line whose first token sits at a column strictly greater than the program name's column joins the command (`tryConsumeIndentedContinuation` helper; anchor = `programLocation.begin.column`)
+  - [x] 10 Catch2 parser unit tests under `[multiline]` tag covering trailing/leading `|`/`&&`/`||`, indented arg continuation (`git commit` style), F# `|>` trailing/leading, same-column independence
 - [x] F#-style `<>` not-equal operator (alternative to `!=`, both supported)
   - [x] Lexer produces `Token::NotEqual` when `<` followed by `>` in F# mode (`_fsharpDepth > 0`)
   - [x] No parser/IR changes needed — reuses same `Token::NotEqual` as `!=`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -521,7 +521,7 @@ src/
 - [x] Parser multi-line continuation for shell commands
   - [x] Trailing `|`, `|>`, `&&`, `||` at end of line: LineFeeds after the operator consumed as whitespace in `parseCallPipeline`, `parseLogicalExpr`, and every `|>` site
   - [x] Leading `|`, `|>`, `&&`, `||` at start of next line: `tryConsumeNewlinesBeforeContinuationOperator` helper peeks past LineFeeds and drops them when followed by a continuation operator
-  - [x] Indentation continuation: in `parseCall`, a next line whose first token sits at a column strictly greater than the program name's column joins the command (`tryConsumeIndentedContinuation` helper; anchor = `programLocation.begin.column`)
+  - [x] Indentation continuation: in `parseCall`, a next line whose first token sits at a column strictly greater than the program name's column joins the command (`tryConsumeIndentedContinuation` helper; 1-based anchor = `programLocation.begin.column + 1`, matching `currentTokenColumn()`)
   - [x] 10 Catch2 parser unit tests under `[multiline]` tag covering trailing/leading `|`/`&&`/`||`, indented arg continuation (`git commit` style), F# `|>` trailing/leading, same-column independence
 - [x] F#-style `<>` not-equal operator (alternative to `!=`, both supported)
   - [x] Lexer produces `Token::NotEqual` when `<` followed by `>` in F# mode (`_fsharpDepth > 0`)
@@ -539,6 +539,10 @@ src/
   - [x] Single-quoted character literals `'a'` preserved via `LiteralQuoting::SingleQuoted` (was `"a"`)
   - [x] List separator style preserved: `[a, b]` stays comma-separated via `ListExpr::useComma` (was always `;`)
   - [x] Inline block comments `(* ... *)` preserved via `emitInlineComments()` (was dropped)
+- [x] Source formatter `# endo format off` / `# endo format on` directives (clang-format style)
+  - [x] `collectVerbatimRegions()` scans shell-style comments for the directives and builds verbatim line ranges; unmatched `off` extends to EOF, nested `off` ignored, stray `on` inert
+  - [x] Original source threaded into `SourceFormatter`; `visit(CompoundStmt)` reproduces in-region statements verbatim from source instead of re-emitting from the AST (idempotent under `--check`)
+  - [x] 7 formatter tests (verbatim multi-line pipeline, idempotency, odd indentation, surrounding code still formatted, unterminated/nested/stray directives)
 - [x] Shell source name in completer error messages — `execute()` accepts optional `sourceName` parameter, `loadCompleters()` passes file path
 - [x] Completer script test suite — 40+ Catch2 tests covering multi-line parser continuations, cmake/ctest/ssh/scp/flatpak script parsing, and register_completer verification
 

--- a/docs/language/command-execution.md
+++ b/docs/language/command-execution.md
@@ -248,5 +248,66 @@ match which "fortune", which "lolcat" with
 - Inside `match` arms, parentheses are needed: `(exec f | exec l)` to disambiguate `|` from arm separators
 - Returns the exit code of the last command in the pipeline
 
+### 10.6 Multi-line Commands
+
+Long shell commands can span multiple lines. Endo recognises three forms of
+line continuation. Bash-style `\` at end of line is **not** supported.
+
+**Trailing operator** — if a line ends in `|`, `|>`, `&&`, or `||`, the command
+continues on the next line (indentation is irrelevant):
+
+<!-- endo-no-check -->
+```endo
+# Trailing `|`
+ls -la |
+    grep ".endo" |
+    wc -l
+
+# Trailing `&&` / `||`
+make build &&
+    make test
+
+# Trailing `|>` (F# pipeline)
+readFile "data.json" |>
+    parseJson |>
+    validate
+```
+
+**Leading operator** — if the next line starts with `|`, `|>`, `&&`, or `||`
+(at any column), it continues the previous command. This is idiomatic F#:
+
+<!-- endo-no-check -->
+```endo
+[1; 2; 3]
+    |> List.map (fun x -> x * 2)
+    |> List.filter (fun x -> x > 2)
+    |> List.sum
+
+ls -la
+    | grep ".endo"
+    | wc -l
+
+testsPassed
+    && publishArtifact
+    || notifyFailure
+```
+
+**Indentation** — if the next line's first token sits at a column strictly
+greater than the program name's column, it is parsed as a continuation of the
+command above, regardless of operators:
+
+<!-- endo-no-check -->
+```endo
+git commit -m "blurb"
+           --author "John Doe"
+           --date "2024-01-01"
+```
+
+Here `git` is at column 1; the `--author` and `--date` lines are indented past
+column 1, so they extend the `git commit` invocation.
+
+The three forms can be combined freely. A command at column 1 followed by a
+line at column 1 starts a new, independent command.
+
 ---
 **See also:** [Operators & Pipelines](operators-and-pipelines.md) | [Error Handling](error-handling.md) | [Interoperability](interoperability.md)

--- a/docs/language/grammar.md
+++ b/docs/language/grammar.md
@@ -105,10 +105,10 @@ match_expression = "match" expression "with" { match_arm }
                  | pipeline_expression
                  ;
 
-pipeline_expression = logical_or { "|>" logical_or } ;
+pipeline_expression = logical_or { "|>" [ NEWLINE ] logical_or } ;
 
-logical_or      = logical_and { "||" logical_and } ;
-logical_and     = comparison { "&&" comparison } ;
+logical_or      = logical_and { "||" [ NEWLINE ] logical_and } ;
+logical_and     = comparison { "&&" [ NEWLINE ] comparison } ;
 comparison      = range { comparison_op range } ;
 range           = additive [ ".." additive [ ".." additive ] ] ;
 additive        = multiplicative { ( "+" | "-" ) multiplicative } ;
@@ -194,9 +194,18 @@ field_pattern   = identifier [ "=" pattern ] ;
 
 (* ---------- Commands and Pipelines ---------- *)
 
-pipeline        = command { "|" command } [ "&" ] ;
+pipeline        = command { "|" [ NEWLINE ] command } [ "&" ] ;
 command         = simple_command { redirect } ;
 simple_command  = word { word } ;
+
+(* Multi-line continuation (parser-level rule, not a pure CFG):
+   - A NEWLINE appearing after `|`, `|>`, `&&`, `||` is consumed as whitespace
+     (trailing operator form).
+   - A NEWLINE followed by one of the same operators is consumed as whitespace
+     (leading operator form).
+   - Inside `command`, a NEWLINE followed by a word at a column strictly
+     greater than the program name's column is consumed as whitespace
+     (indentation form). *)
 
 redirect        = ">" word
                 | ">>" word

--- a/docs/language/lexical-elements.md
+++ b/docs/language/lexical-elements.md
@@ -159,5 +159,14 @@ TimeSpan values support comparison operators:
 1s < 1min   # true
 ```
 
+### 2.9 Line Endings and Statement Termination
+
+A newline normally ends the current statement. Within shell commands and
+pipelines, however, a newline can be absorbed as whitespace when the surrounding
+context implies continuation: a trailing or leading `|`, `|>`, `&&`, `||`, or
+an indented line following the command's program name. See
+[Multi-line Commands](command-execution.md#106-multi-line-commands) for the
+full rules.
+
 ---
 **See also:** [Type System](type-system.md) | [Grammar](grammar.md) | [Philosophy & Goals](index.md)

--- a/docs/language/lexical-elements.md
+++ b/docs/language/lexical-elements.md
@@ -37,6 +37,34 @@ of        as        global    lazy
 *)
 ```
 
+#### Formatter directives
+
+`endo format` recognizes two directive comments that disable and re-enable
+reformatting for a region of source, analogous to `// clang-format off` / `on`.
+A `# endo format off` comment suppresses formatting until a matching
+`# endo format on` comment; everything in between is reproduced **verbatim**,
+preserving the original spacing and line breaks. This is useful for source whose
+exact layout matters — for example a deliberately multi-line pipeline that the
+formatter would otherwise collapse onto a single line.
+
+<!-- endo-no-check -->
+```endo
+# endo format off
+5 |>
+inc |>
+double |>
+println
+# endo format on
+```
+
+Rules:
+
+- The directives must be standalone shell-style (`#`) comments. The marker text
+  is matched after stripping the leading `#` and surrounding whitespace.
+- An `off` with no matching `on` preserves everything to the end of the file.
+- A nested `off` inside an already-open region is ignored (the first `off`
+  wins until the next `on`); a stray `on` with no preceding `off` has no effect.
+
 ### 2.5 String Literals
 
 <!-- endo-no-check -->

--- a/docs/language/operators-and-pipelines.md
+++ b/docs/language/operators-and-pipelines.md
@@ -160,7 +160,15 @@ let summary =
     |> filter (fun c -> contains c.message "fix")
 ```
 
-### 8.8 Operator Precedence
+### 8.8 Line Continuation
+
+`|`, `|>`, `&&`, and `||` allow a command to span multiple lines: the operator
+can appear at the end of a line (with the continuation below) or at the start
+of the next line. Arguments can also continue on indented lines. See
+[Multi-line Commands](command-execution.md#106-multi-line-commands) for the
+full rules and examples.
+
+### 8.9 Operator Precedence
 
 From lowest to highest precedence:
 

--- a/src/endo-language/format/SourceFormatter.cpp
+++ b/src/endo-language/format/SourceFormatter.cpp
@@ -80,11 +80,42 @@ bool SourceFormatter::hasBlankLineBetween(int afterLine, int beforeLine) const
     return it != _blankLines.end() && *it < beforeLine;
 }
 
+namespace
+{
+    /// Splits source text into individual lines (without their terminating newlines),
+    /// indexed 0-based to match the lexer's line numbering. A trailing newline does not
+    /// produce a spurious empty final line.
+    std::vector<std::string_view> splitLines(std::string_view source)
+    {
+        std::vector<std::string_view> lines;
+        size_t pos = 0;
+        while (pos <= source.size())
+        {
+            auto const eol = source.find('\n', pos);
+            auto const end = (eol == std::string_view::npos) ? source.size() : eol;
+            auto line = source.substr(pos, end - pos);
+            if (!line.empty() && line.back() == '\r') // tolerate CRLF line endings
+                line.remove_suffix(1);
+            lines.push_back(line);
+            if (eol == std::string_view::npos)
+                break;
+            pos = eol + 1;
+        }
+        return lines;
+    }
+} // namespace
+
 SourceFormatter::SourceFormatter(FormatConfig config,
                                  std::vector<CommentTrivia> const& comments,
-                                 std::set<int> blankLines):
+                                 std::set<int> blankLines,
+                                 std::string_view originalSource):
     _config(config), _comments(comments), _blankLines(std::move(blankLines))
 {
+    if (!originalSource.empty())
+    {
+        _sourceLines = splitLines(originalSource);
+        _verbatimRegions = collectVerbatimRegions(_comments, static_cast<int>(_sourceLines.size()));
+    }
 }
 
 std::string SourceFormatter::format(std::string const& source, FormatConfig const& config)
@@ -105,8 +136,16 @@ std::string SourceFormatter::format(std::string const& source, FormatConfig cons
     if (!program || report.containsFailures())
         return source; // Parse failed — return original source unchanged
 
-    // 3. Format
-    return format(*program, comments, config, computeBlankLines(source));
+    // 3. Format. The original source is passed so `# endo format off`/`on` regions can be
+    //    reproduced verbatim rather than re-emitted from the AST.
+    SourceFormatter formatter(config, comments, computeBlankLines(source), source);
+    program->accept(formatter);
+    formatter.emitRemainingComments();
+
+    if (config.trailingNewline && !formatter._result.empty() && formatter._result.back() != '\n')
+        formatter._result += '\n';
+
+    return formatter._result;
 }
 
 std::string SourceFormatter::format(ast::Node const& root,
@@ -114,6 +153,8 @@ std::string SourceFormatter::format(ast::Node const& root,
                                     FormatConfig const& config,
                                     std::set<int> blankLines)
 {
+    // AST-only entry point: no original source is available, so verbatim regions
+    // (`# endo format off`/`on`) are inert here — everything is re-emitted from the AST.
     SourceFormatter formatter(config, comments, std::move(blankLines));
     root.accept(formatter);
     formatter.emitRemainingComments();
@@ -314,6 +355,87 @@ void SourceFormatter::emitCommentsBeforeLine(int line)
         for ([[maybe_unused]] auto _: std::views::iota(0, std::min(gap, maxBlanks)))
             emitNewline();
     }
+}
+
+namespace
+{
+    /// Directive markers recognized in shell-style (`#`) comments to delimit verbatim regions.
+    /// Data-driven so the spelling lives in one place rather than scattered string literals.
+    constexpr std::string_view formatOffDirective = "endo format off";
+    constexpr std::string_view formatOnDirective = "endo format on";
+
+    /// Returns the comment body with the leading `#` / `//` marker and surrounding ASCII
+    /// whitespace stripped, so it can be matched against a directive string.
+    std::string_view stripCommentMarker(std::string_view text)
+    {
+        // Drop a leading `#` or `//` marker.
+        if (text.starts_with("//"))
+            text.remove_prefix(2);
+        else if (text.starts_with('#'))
+            text.remove_prefix(1);
+        // Trim surrounding ASCII whitespace.
+        auto const first = text.find_first_not_of(" \t\r\n");
+        if (first == std::string_view::npos)
+            return {};
+        auto const last = text.find_last_not_of(" \t\r\n");
+        return text.substr(first, last - first + 1);
+    }
+} // namespace
+
+std::vector<SourceFormatter::VerbatimRegion> SourceFormatter::collectVerbatimRegions(
+    std::vector<CommentTrivia> const& comments, int totalLines)
+{
+    std::vector<VerbatimRegion> regions;
+    std::optional<int> openLine; // line of the active `off` directive, if any
+    for (auto const& comment: comments)
+    {
+        auto const body = stripCommentMarker(comment.text);
+        if (body == formatOffDirective)
+        {
+            // Nested `off` is ignored: the first `off` wins until the next `on`.
+            if (!openLine)
+                openLine = comment.location.begin.line;
+        }
+        else if (body == formatOnDirective)
+        {
+            if (openLine)
+            {
+                regions.push_back({ .beginLine = *openLine, .endLine = comment.location.begin.line });
+                openLine = std::nullopt;
+            }
+            // An `on` without a matching `off` is ignored.
+        }
+    }
+    // An unterminated `off` region extends to the final source line.
+    if (openLine && totalLines > 0)
+        regions.push_back({ .beginLine = *openLine, .endLine = totalLines - 1 });
+    return regions;
+}
+
+std::optional<SourceFormatter::VerbatimRegion> SourceFormatter::verbatimRegionAt(int line) const
+{
+    for (auto const& region: _verbatimRegions)
+        if (line >= region.beginLine && line <= region.endLine)
+            return region;
+    return std::nullopt;
+}
+
+void SourceFormatter::emitVerbatimRegion(VerbatimRegion const& region)
+{
+    auto const lastLine = std::min(region.endLine, static_cast<int>(_sourceLines.size()) - 1);
+    for (auto const line: std::views::iota(region.beginLine, lastLine + 1))
+    {
+        // Append the original line directly (not via emit()) so the source's own leading
+        // whitespace is preserved verbatim and no formatter indentation is injected.
+        _result += _sourceLines[static_cast<size_t>(line)];
+        emitNewline();
+    }
+
+    // Skip every comment that lies within the region so the normal interleaving machinery
+    // does not re-emit the directives or any commentary inside the preserved block.
+    while (_nextCommentIndex < _comments.size()
+           && _comments[_nextCommentIndex].location.begin.line <= region.endLine)
+        ++_nextCommentIndex;
 }
 
 std::optional<int> SourceFormatter::findLastLine(ast::Node const& node)
@@ -823,8 +945,22 @@ static bool isDeclarationOrBlock(ast::Node const& node)
 void SourceFormatter::visit(ast::CompoundStmt const& node)
 {
     emitLeadingComments(node);
+    std::optional<int> lastEmittedRegionBegin; // de-duplicates regions spanning several statements
     for (auto const i: std::views::iota(0uz, node.statements.size()))
     {
+        // Verbatim region handling: a statement whose first line falls inside a
+        // `# endo format off` / `# endo format on` block is reproduced from the original
+        // source rather than re-emitted from the AST. The whole region is emitted once, when
+        // its first in-region statement is reached; later statements in the same region are
+        // skipped (they are already part of the verbatim block).
+        auto const stmtFirstLine = findFirstLine(*node.statements[i]);
+        std::optional<VerbatimRegion> region;
+        if (stmtFirstLine)
+            region = verbatimRegionAt(*stmtFirstLine);
+
+        if (region && lastEmittedRegionBegin == region->beginLine)
+            continue; // already covered by the verbatim block emitted earlier
+
         if (i > 0)
         {
             emitNewline();
@@ -840,7 +976,8 @@ void SourceFormatter::visit(ast::CompoundStmt const& node)
             if (!wantBlankLine && !_blankLines.empty())
             {
                 auto const prevStart = findFirstLine(*node.statements[i - 1]);
-                auto const nextStart = findFirstLine(*node.statements[i]);
+                auto const nextStart =
+                    region ? std::optional<int> { region->beginLine } : findFirstLine(*node.statements[i]);
                 if (prevStart && nextStart)
                     wantBlankLine = hasBlankLineBetween(*prevStart, *nextStart);
             }
@@ -850,6 +987,14 @@ void SourceFormatter::visit(ast::CompoundStmt const& node)
                      std::views::iota(uint32_t { 0 }, _config.blankLinesBetweenTopLevel))
                     emitNewline();
         }
+
+        if (region)
+        {
+            emitVerbatimRegion(*region);
+            lastEmittedRegionBegin = region->beginLine;
+            continue;
+        }
+
         node.statements[i]->accept(*this);
     }
     emitTrailingComment(node);

--- a/src/endo-language/format/SourceFormatter.hpp
+++ b/src/endo-language/format/SourceFormatter.hpp
@@ -8,8 +8,10 @@
 #include <endo-language/lexer/CommentTrivia.hpp>
 
 #include <functional>
+#include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace endo::format
@@ -166,7 +168,8 @@ class SourceFormatter: public ast::Visitor, public pattern::PatternVisitor
 
     explicit SourceFormatter(FormatConfig config,
                              std::vector<CommentTrivia> const& comments,
-                             std::set<int> blankLines = {});
+                             std::set<int> blankLines = {},
+                             std::string_view originalSource = {});
 
     /// Checks whether any blank line exists in the original source between two line numbers.
     ///
@@ -202,6 +205,33 @@ class SourceFormatter: public ast::Visitor, public pattern::PatternVisitor
 
     /// Finds the first source line in a node's subtree (for nodes without locations).
     [[nodiscard]] static std::optional<int> findFirstLine(ast::Node const& node);
+
+    /// A contiguous range of original source lines to reproduce verbatim during formatting.
+    /// Delimited by `# endo format off` / `# endo format on` directive comments. Both line
+    /// numbers are 0-based and inclusive; @ref beginLine is the `off` directive line and
+    /// @ref endLine is the `on` directive line (or the last source line if `on` is absent).
+    struct VerbatimRegion
+    {
+        int beginLine; ///< 0-based line of the `# endo format off` directive (inclusive).
+        int endLine;   ///< 0-based line of the `# endo format on` directive (inclusive).
+    };
+
+    /// Scans collected comments for `# endo format off` / `# endo format on` directives and
+    /// builds the list of verbatim regions. Nested `off` directives are ignored (the first
+    /// `off` wins until the next `on`); an `off` without a matching `on` extends to EOF.
+    /// @param comments The collected comment trivia.
+    /// @param totalLines Total number of lines in the original source (for unterminated regions).
+    /// @return Sorted, non-overlapping list of verbatim regions.
+    [[nodiscard]] static std::vector<VerbatimRegion> collectVerbatimRegions(
+        std::vector<CommentTrivia> const& comments, int totalLines);
+
+    /// Returns the verbatim region containing the given 0-based line, if any.
+    [[nodiscard]] std::optional<VerbatimRegion> verbatimRegionAt(int line) const;
+
+    /// Emits the original source lines in [beginLine, endLine] (0-based, inclusive) verbatim,
+    /// and advances the comment cursor past every comment that falls within the range so the
+    /// normal comment-interleaving machinery does not re-emit them.
+    void emitVerbatimRegion(VerbatimRegion const& region);
 
     /// Finds the last source line in a node's subtree (for trailing comment detection).
     [[nodiscard]] static std::optional<int> findLastLine(ast::Node const& node);
@@ -298,6 +328,12 @@ class SourceFormatter: public ast::Visitor, public pattern::PatternVisitor
     std::vector<CommentTrivia> const& _comments;
     size_t _nextCommentIndex = 0; ///< Index of next un-emitted comment
     std::set<int> _blankLines;    ///< 0-based line numbers of blank lines in original source
+
+    /// Original source split into lines (0-based), used to reproduce verbatim regions exactly.
+    /// Empty when the formatter is invoked without source (AST-only overload) — in that case
+    /// the `format off`/`on` feature is inert.
+    std::vector<std::string_view> _sourceLines;
+    std::vector<VerbatimRegion> _verbatimRegions; ///< Regions to emit verbatim, sorted by line.
 };
 
 } // namespace endo::format

--- a/src/endo-language/format/SourceFormatter_test.cpp
+++ b/src/endo-language/format/SourceFormatter_test.cpp
@@ -1560,3 +1560,107 @@ TEST_CASE("SourceFormatter.explicit_unit_call_preserved", "[format]")
     INFO("Result: [" << result << "]");
     CHECK(result.find("f ()") != std::string::npos);
 }
+
+// ============================================================================
+// SourceFormatter — `# endo format off` / `# endo format on` directives
+// ============================================================================
+
+TEST_CASE("SourceFormatter.format_off_preserves_multiline_pipeline", "[format]")
+{
+    // Without the directive, a multi-line `|>` pipeline would be collapsed onto one line.
+    // Inside an off/on region, the source must be reproduced verbatim.
+    const auto* const source = "let inc x = x + 1\n"
+                               "# endo format off\n"
+                               "5 |>\n"
+                               "inc |>\n"
+                               "println\n"
+                               "# endo format on\n";
+    auto const result = SourceFormatter::format(source);
+    INFO("Result: [" << result << "]");
+    CHECK(result.find("5 |>\ninc |>\nprintln") != std::string::npos);
+    CHECK(result.find("# endo format off") != std::string::npos);
+    CHECK(result.find("# endo format on") != std::string::npos);
+}
+
+TEST_CASE("SourceFormatter.format_off_is_idempotent", "[format]")
+{
+    // Formatting an already-formatted file containing a verbatim block must be a no-op
+    // (this is what CI's `endo format --check` relies on).
+    const auto* const source = "let inc x = x + 1\n"
+                               "\n"
+                               "# endo format off\n"
+                               "5 |>\n"
+                               "inc |>\n"
+                               "println\n"
+                               "# endo format on\n";
+    auto const first = SourceFormatter::format(source);
+    auto const second = SourceFormatter::format(first);
+    INFO("First:  [" << first << "]");
+    INFO("Second: [" << second << "]");
+    CHECK(first == second);
+}
+
+TEST_CASE("SourceFormatter.format_off_preserves_odd_indentation", "[format]")
+{
+    // Arbitrary indentation inside the region must survive verbatim.
+    const auto* const source = "# endo format off\n"
+                               "let     x   =    42\n"
+                               "# endo format on\n";
+    auto const result = SourceFormatter::format(source);
+    INFO("Result: [" << result << "]");
+    CHECK(result.find("let     x   =    42") != std::string::npos);
+}
+
+TEST_CASE("SourceFormatter.format_off_code_outside_region_still_formatted", "[format]")
+{
+    // Code before and after the region is formatted normally.
+    const auto* const source = "let  a  =  1\n"
+                               "# endo format off\n"
+                               "let     b   =   2\n"
+                               "# endo format on\n"
+                               "let  c  =  3\n";
+    auto const result = SourceFormatter::format(source);
+    INFO("Result: [" << result << "]");
+    CHECK(result.find("let a = 1") != std::string::npos);         // normalized
+    CHECK(result.find("let     b   =   2") != std::string::npos); // verbatim
+    CHECK(result.find("let c = 3") != std::string::npos);         // normalized
+}
+
+TEST_CASE("SourceFormatter.format_off_without_on_extends_to_eof", "[format]")
+{
+    // An `off` with no matching `on` preserves everything to the end of the file.
+    const auto* const source = "let a = 1\n"
+                               "# endo format off\n"
+                               "let     b   =   2\n"
+                               "let     d   =   4\n";
+    auto const result = SourceFormatter::format(source);
+    INFO("Result: [" << result << "]");
+    CHECK(result.find("let     b   =   2") != std::string::npos);
+    CHECK(result.find("let     d   =   4") != std::string::npos);
+}
+
+TEST_CASE("SourceFormatter.format_off_nested_off_ignored", "[format]")
+{
+    // A second `off` inside an open region is ignored; the first `on` closes the region.
+    const auto* const source = "# endo format off\n"
+                               "let     x   =   1\n"
+                               "# endo format off\n"
+                               "let     y   =   2\n"
+                               "# endo format on\n"
+                               "let  z  =  3\n";
+    auto const result = SourceFormatter::format(source);
+    INFO("Result: [" << result << "]");
+    CHECK(result.find("let     x   =   1") != std::string::npos);
+    CHECK(result.find("let     y   =   2") != std::string::npos);
+    CHECK(result.find("let z = 3") != std::string::npos); // formatted after the region closes
+}
+
+TEST_CASE("SourceFormatter.format_on_without_off_is_inert", "[format]")
+{
+    // A stray `on` with no preceding `off` has no effect; code is formatted normally.
+    const auto* const source = "# endo format on\n"
+                               "let  a  =  1\n";
+    auto const result = SourceFormatter::format(source);
+    INFO("Result: [" << result << "]");
+    CHECK(result.find("let a = 1") != std::string::npos);
+}

--- a/src/endo-language/parser/Parser.cpp
+++ b/src/endo-language/parser/Parser.cpp
@@ -456,7 +456,8 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
                 if (_lexer.currentToken() == Token::ForwardPipe)
                 {
                     _lexer.enterFSharpExpr();
-                    _lexer.nextToken(); // consume first |>
+                    _lexer.nextToken();                    // consume first |>
+                    consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
                     auto step = parseFSharpComposition();
                     if (!step)
                     {
@@ -511,7 +512,8 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
                 if (_lexer.currentToken() == Token::ForwardPipe)
                 {
                     _lexer.enterFSharpExpr();
-                    _lexer.nextToken(); // consume first |>
+                    _lexer.nextToken();                    // consume first |>
+                    consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
                     auto step = parseFSharpComposition();
                     if (!step)
                     {
@@ -599,7 +601,8 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
                 if (_lexer.currentToken() == Token::ForwardPipe)
                 {
                     _lexer.enterFSharpExpr();
-                    _lexer.nextToken(); // consume first |>
+                    _lexer.nextToken();                    // consume first |>
+                    consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
                     auto step = parseFSharpComposition();
                     if (!step)
                     {
@@ -679,7 +682,8 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
                 if (_lexer.currentToken() == Token::ForwardPipe)
                 {
                     _lexer.enterFSharpExpr();
-                    _lexer.nextToken(); // consume first |>
+                    _lexer.nextToken();                    // consume first |>
+                    consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
                     auto step = parseFSharpComposition();
                     if (!step)
                     {
@@ -750,7 +754,8 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
                 if (_lexer.currentToken() == Token::ForwardPipe)
                 {
                     _lexer.enterFSharpExpr();
-                    _lexer.nextToken(); // consume first |>
+                    _lexer.nextToken();                    // consume first |>
+                    consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
                     auto step = parseFSharpComposition();
                     if (!step)
                     {
@@ -876,7 +881,8 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
                         if (_lexer.currentToken() == Token::ForwardPipe)
                         {
                             _lexer.enterFSharpExpr();
-                            _lexer.nextToken(); // consume first |>
+                            _lexer.nextToken();                    // consume first |>
+                            consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
 
                             auto step = parseFSharpComposition();
                             if (!step)
@@ -930,7 +936,8 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
                 {
                     auto source = std::make_unique<ast::StructuredPipelineSourceExpr>(std::move(stmt));
                     _lexer.enterFSharpExpr();
-                    _lexer.nextToken(); // consume first |>
+                    _lexer.nextToken();                    // consume first |>
+                    consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
 
                     // Parse first pipeline step (single composition, not full pipeline)
                     auto step = parseFSharpComposition();
@@ -954,7 +961,8 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
                                 _lexer.pushBackToken(Token::LineFeed, "\n");
                             break;
                         }
-                        _lexer.nextToken(); // consume |>
+                        _lexer.nextToken();                    // consume |>
+                        consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
                         auto right = parseFSharpComposition();
                         if (!right)
                         {
@@ -992,7 +1000,8 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
             if (_lexer.currentToken() == Token::ForwardPipe)
             {
                 _lexer.enterFSharpExpr();
-                _lexer.nextToken(); // consume first |>
+                _lexer.nextToken();                    // consume first |>
+                consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
                 auto step = parseFSharpComposition();
                 if (!step)
                 {
@@ -1042,7 +1051,8 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
             {
                 auto source = std::make_unique<ast::StructuredPipelineSourceExpr>(std::move(stmt));
                 _lexer.enterFSharpExpr();
-                _lexer.nextToken(); // consume first |>
+                _lexer.nextToken();                    // consume first |>
+                consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
 
                 auto step = parseFSharpComposition();
                 if (!step)
@@ -1063,7 +1073,8 @@ std::unique_ptr<ast::Statement> Parser::parseStmt()
                             _lexer.pushBackToken(Token::LineFeed, "\n");
                         break;
                     }
-                    _lexer.nextToken(); // consume |>
+                    _lexer.nextToken();                    // consume |>
+                    consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
                     auto right = parseFSharpComposition();
                     if (!right)
                     {
@@ -1405,160 +1416,186 @@ std::unique_ptr<ast::ProgramCall> Parser::parseCall(bool piped)
     std::vector<std::unique_ptr<ast::HereDocument>> hereDocuments;
     std::vector<std::unique_ptr<ast::HereString>> hereStrings;
 
+    // Anchor column for indentation-based line continuation: a following line
+    // whose first token sits at a column strictly greater than the program
+    // name's column is parsed as a continuation of this call.
+    // 1-based, to match currentTokenColumn().
+    auto const anchorColumn = static_cast<size_t>(programLocation.begin.column) + 1;
+
     // Parse arguments and redirects interleaved
-    // Continue while we have parameter tokens or redirect tokens, and we're not at end of statement
-    while (!isEndOfStmt() || isParameterToken())
+    // Continue while we have parameter tokens or redirect tokens, and we're not at end of statement.
+    //
+    // Outer loop implements multi-line continuation: when the inner loop stops
+    // on a LineFeed, we check whether the next line continues the command
+    // (indented relative to the program name, or begins with a continuation
+    // operator) and resume the inner loop if so.
+    while (true)
     {
-        // Check for redirect tokens
-        if (isRedirectToken())
+        while (!isEndOfStmt() || isParameterToken())
         {
-            if (!parseRedirect(inputRedirects, outputRedirects, hereDocuments, hereStrings))
-                break;
-            continue;
-        }
-
-        // Check for number that might be fd prefix for redirect
-        if (_lexer.currentToken() == Token::Number)
-        {
-            // Save position to potentially backtrack
-            std::string const numLiteral = _lexer.currentLiteral();
-            _lexer.nextToken();
-
+            // Check for redirect tokens
             if (isRedirectToken())
             {
-                // It's an fd prefix - put back and parse as redirect
-                // We need to handle this differently since we've already consumed the number
-                int const fdValue = std::stoi(numLiteral);
+                if (!parseRedirect(inputRedirects, outputRedirects, hereDocuments, hereStrings))
+                    break;
+                continue;
+            }
 
-                switch (_lexer.currentToken())
+            // Check for number that might be fd prefix for redirect
+            if (_lexer.currentToken() == Token::Number)
+            {
+                // Save position to potentially backtrack
+                std::string const numLiteral = _lexer.currentLiteral();
+                _lexer.nextToken();
+
+                if (isRedirectToken())
                 {
-                    case Token::Greater: {
-                        _lexer.nextToken();
-                        auto target = parseParameter();
-                        if (!target)
-                            break;
-                        outputRedirects.emplace_back(std::make_unique<ast::OutputRedirect>(
-                            std::make_unique<ast::FileDescriptor>(fdValue), std::move(target), false));
-                        continue;
-                    }
-                    case Token::GreaterGreater: {
-                        _lexer.nextToken();
-                        auto target = parseParameter();
-                        if (!target)
-                            break;
-                        outputRedirects.emplace_back(std::make_unique<ast::OutputRedirect>(
-                            std::make_unique<ast::FileDescriptor>(fdValue), std::move(target), true));
-                        continue;
-                    }
-                    case Token::GreaterAmp: {
-                        _lexer.nextToken();
-                        if (_lexer.currentToken() == Token::Number)
-                        {
-                            int const targetFd = std::stoi(_lexer.currentLiteral());
+                    // It's an fd prefix - put back and parse as redirect
+                    // We need to handle this differently since we've already consumed the number
+                    int const fdValue = std::stoi(numLiteral);
+
+                    switch (_lexer.currentToken())
+                    {
+                        case Token::Greater: {
                             _lexer.nextToken();
-                            outputRedirects.emplace_back(std::make_unique<ast::OutputRedirect>(
-                                std::make_unique<ast::FileDescriptor>(fdValue),
-                                std::make_unique<ast::FileDescriptor>(targetFd)));
-                        }
-                        else
-                        {
                             auto target = parseParameter();
                             if (!target)
                                 break;
                             outputRedirects.emplace_back(std::make_unique<ast::OutputRedirect>(
                                 std::make_unique<ast::FileDescriptor>(fdValue), std::move(target), false));
+                            continue;
                         }
-                        continue;
-                    }
-                    case Token::Less: {
-                        _lexer.nextToken();
-                        auto source = parseParameter();
-                        if (!source)
-                            break;
-                        inputRedirects.emplace_back(std::make_unique<ast::InputRedirect>(
-                            std::make_unique<ast::FileDescriptor>(fdValue), std::move(source)));
-                        continue;
-                    }
-                    case Token::LessLess:
-                    case Token::LessLessDash: {
-                        bool const stripTabs = _lexer.currentToken() == Token::LessLessDash;
-                        _lexer.nextToken();
-                        if (_lexer.currentToken() != Token::Identifier
-                            && _lexer.currentToken() != Token::String)
-                        {
-                            _report.syntaxErrorWithSuggestions(
-                                currentLocation(),
-                                { "Provide a delimiter for the here-document" },
-                                currentContextSnippet(),
-                                "Expected here-document delimiter, got '{}'",
-                                _lexer.currentTokenText());
-                            break;
+                        case Token::GreaterGreater: {
+                            _lexer.nextToken();
+                            auto target = parseParameter();
+                            if (!target)
+                                break;
+                            outputRedirects.emplace_back(std::make_unique<ast::OutputRedirect>(
+                                std::make_unique<ast::FileDescriptor>(fdValue), std::move(target), true));
+                            continue;
                         }
-                        std::string delimiter = consumeLiteral();
-                        hereDocuments.emplace_back(std::make_unique<ast::HereDocument>(
-                            std::make_unique<ast::FileDescriptor>(fdValue),
-                            std::move(delimiter),
-                            "",
-                            stripTabs));
-                        continue;
+                        case Token::GreaterAmp: {
+                            _lexer.nextToken();
+                            if (_lexer.currentToken() == Token::Number)
+                            {
+                                int const targetFd = std::stoi(_lexer.currentLiteral());
+                                _lexer.nextToken();
+                                outputRedirects.emplace_back(std::make_unique<ast::OutputRedirect>(
+                                    std::make_unique<ast::FileDescriptor>(fdValue),
+                                    std::make_unique<ast::FileDescriptor>(targetFd)));
+                            }
+                            else
+                            {
+                                auto target = parseParameter();
+                                if (!target)
+                                    break;
+                                outputRedirects.emplace_back(std::make_unique<ast::OutputRedirect>(
+                                    std::make_unique<ast::FileDescriptor>(fdValue),
+                                    std::move(target),
+                                    false));
+                            }
+                            continue;
+                        }
+                        case Token::Less: {
+                            _lexer.nextToken();
+                            auto source = parseParameter();
+                            if (!source)
+                                break;
+                            inputRedirects.emplace_back(std::make_unique<ast::InputRedirect>(
+                                std::make_unique<ast::FileDescriptor>(fdValue), std::move(source)));
+                            continue;
+                        }
+                        case Token::LessLess:
+                        case Token::LessLessDash: {
+                            bool const stripTabs = _lexer.currentToken() == Token::LessLessDash;
+                            _lexer.nextToken();
+                            if (_lexer.currentToken() != Token::Identifier
+                                && _lexer.currentToken() != Token::String)
+                            {
+                                _report.syntaxErrorWithSuggestions(
+                                    currentLocation(),
+                                    { "Provide a delimiter for the here-document" },
+                                    currentContextSnippet(),
+                                    "Expected here-document delimiter, got '{}'",
+                                    _lexer.currentTokenText());
+                                break;
+                            }
+                            std::string delimiter = consumeLiteral();
+                            hereDocuments.emplace_back(std::make_unique<ast::HereDocument>(
+                                std::make_unique<ast::FileDescriptor>(fdValue),
+                                std::move(delimiter),
+                                "",
+                                stripTabs));
+                            continue;
+                        }
+                        case Token::LessLessLess: {
+                            _lexer.nextToken();
+                            auto content = parseParameter();
+                            if (!content)
+                                break;
+                            hereStrings.emplace_back(std::make_unique<ast::HereString>(
+                                std::make_unique<ast::FileDescriptor>(fdValue), std::move(content)));
+                            continue;
+                        }
+                        default: break;
                     }
-                    case Token::LessLessLess: {
-                        _lexer.nextToken();
-                        auto content = parseParameter();
-                        if (!content)
-                            break;
-                        hereStrings.emplace_back(std::make_unique<ast::HereString>(
-                            std::make_unique<ast::FileDescriptor>(fdValue), std::move(content)));
-                        continue;
-                    }
-                    default: break;
                 }
+
+                // Not followed by redirect - treat the number as a regular argument
+                // Check if the next token is adjacent (no whitespace) — combine into a compound word
+                if (!_lexer.hasPrecedingSpace() && isParameterToken())
+                {
+                    std::vector<std::unique_ptr<ast::Expr>> parts;
+                    parts.push_back(std::make_unique<ast::LiteralExpr>(numLiteral));
+                    while (!_lexer.hasPrecedingSpace() && isParameterToken())
+                        if (auto part = parseParameter())
+                            parts.push_back(std::move(part));
+                        else
+                            break;
+                    if (parts.size() == 1)
+                        arguments.emplace_back(std::move(parts.front()));
+                    else
+                        arguments.emplace_back(std::make_unique<ast::ConcatExpr>(std::move(parts)));
+                }
+                else
+                {
+                    arguments.emplace_back(std::make_unique<ast::LiteralExpr>(numLiteral));
+                }
+                continue;
             }
 
-            // Not followed by redirect - treat the number as a regular argument
-            // Check if the next token is adjacent (no whitespace) — combine into a compound word
-            if (!_lexer.hasPrecedingSpace() && isParameterToken())
+            // Regular argument — combine adjacent tokens without whitespace into a single word
+            auto arg = parseCompoundParameter();
+            if (arg)
             {
-                std::vector<std::unique_ptr<ast::Expr>> parts;
-                parts.push_back(std::make_unique<ast::LiteralExpr>(numLiteral));
-                while (!_lexer.hasPrecedingSpace() && isParameterToken())
-                    if (auto part = parseParameter())
-                        parts.push_back(std::move(part));
-                    else
-                        break;
-                if (parts.size() == 1)
-                    arguments.emplace_back(std::move(parts.front()));
-                else
-                    arguments.emplace_back(std::make_unique<ast::ConcatExpr>(std::move(parts)));
+                // Check for brace expansion on literal arguments
+                if (auto* literal = dynamic_cast<ast::LiteralExpr*>(arg.get()))
+                {
+                    if (containsBracePattern(literal->value))
+                    {
+                        auto const expanded = expandBraces(literal->value);
+                        for (auto const& e: expanded)
+                            arguments.emplace_back(std::make_unique<ast::LiteralExpr>(e));
+                        continue;
+                    }
+                }
+                arguments.emplace_back(std::move(arg));
             }
             else
             {
-                arguments.emplace_back(std::make_unique<ast::LiteralExpr>(numLiteral));
+                break;
             }
-            continue;
         }
 
-        // Regular argument — combine adjacent tokens without whitespace into a single word
-        auto arg = parseCompoundParameter();
-        if (arg)
-        {
-            // Check for brace expansion on literal arguments
-            if (auto* literal = dynamic_cast<ast::LiteralExpr*>(arg.get()))
-            {
-                if (containsBracePattern(literal->value))
-                {
-                    auto const expanded = expandBraces(literal->value);
-                    for (auto const& e: expanded)
-                        arguments.emplace_back(std::make_unique<ast::LiteralExpr>(e));
-                    continue;
-                }
-            }
-            arguments.emplace_back(std::move(arg));
-        }
-        else
-        {
+        // Inner loop stopped. If we're on a LineFeed, attempt line
+        // continuation; otherwise the command ends here.
+        if (_lexer.currentToken() != Token::LineFeed)
             break;
-        }
+        if (tryConsumeNewlinesBeforeContinuationOperator())
+            break; // Let caller (parseCallPipeline/parseLogicalExpr) handle the operator.
+        if (tryConsumeIndentedContinuation(anchorColumn))
+            continue; // Resume arg parsing on the continuation line.
+        break;
     }
 
     CoreVM::NativeCallback const* builtinCallProcess = _lexer.currentToken() == Token::Pipe || piped
@@ -2577,6 +2614,8 @@ std::unique_ptr<ast::Statement> Parser::parseLogicalExpr()
     {
         auto const op = _lexer.currentToken();
         _lexer.nextToken();
+        // Allow `foo &&\n  bar` / `foo ||\n  bar`.
+        consumeUntilNotOneOf(Token::LineFeed);
 
         auto right = parsePrimaryStmt();
         if (!right)
@@ -2904,6 +2943,8 @@ std::unique_ptr<ast::Statement> Parser::parseCallPipeline()
     while (_lexer.currentToken() == Token::Pipe)
     {
         _lexer.nextToken();
+        // Allow `foo |\n  bar` — newlines after `|` are whitespace.
+        consumeUntilNotOneOf(Token::LineFeed);
         TRACE_FMT("Parsing call pipeline item (NT: {})", _lexer.currentLiteral());
         if (auto nextCall = parseCall(true); nextCall)
         {
@@ -2936,6 +2977,37 @@ std::unique_ptr<ast::Statement> Parser::parseCallPipeline()
 bool Parser::consumeNewlines()
 {
     return consumeUntilNotOneOf(Token::Semicolon, Token::LineFeed);
+}
+
+bool Parser::tryConsumeNewlinesBeforeContinuationOperator()
+{
+    if (_lexer.currentToken() != Token::LineFeed)
+        return false;
+
+    auto const skipped = consumeUntilNotOneOf(Token::LineFeed);
+    auto const tok = _lexer.currentToken();
+    bool const isOperator =
+        tok == Token::Pipe || tok == Token::ForwardPipe || tok == Token::AmpAmp || tok == Token::PipePipe;
+    if (isOperator)
+        return true;
+
+    if (skipped)
+        _lexer.pushBackToken(Token::LineFeed, "\n");
+    return false;
+}
+
+bool Parser::tryConsumeIndentedContinuation(size_t anchorColumn)
+{
+    if (_lexer.currentToken() != Token::LineFeed)
+        return false;
+
+    auto const skipped = consumeUntilNotOneOf(Token::LineFeed);
+    if (currentTokenColumn() > anchorColumn && (isParameterToken() || isRedirectToken()))
+        return true;
+
+    if (skipped)
+        _lexer.pushBackToken(Token::LineFeed, "\n");
+    return false;
 }
 
 bool Parser::tryConsumeToken(Token token)
@@ -4528,7 +4600,8 @@ std::unique_ptr<ast::Expr> Parser::parseFSharpPipeline()
                 _lexer.pushBackToken(Token::LineFeed, "\n");
             break;
         }
-        _lexer.nextToken(); // consume '|>'
+        _lexer.nextToken();                    // consume '|>'
+        consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
         auto right = parseFSharpComposition();
         if (!right)
             return nullptr;
@@ -5215,7 +5288,8 @@ std::unique_ptr<ast::Expr> Parser::parseShellCommandExpr()
 std::unique_ptr<ast::Expr> Parser::parseTrailingPipeline(std::unique_ptr<ast::Expr> expr)
 {
     _lexer.enterFSharpExpr();
-    _lexer.nextToken(); // consume first |>
+    _lexer.nextToken();                    // consume first |>
+    consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
     auto step = parseFSharpComposition();
     if (!step)
     {
@@ -5232,7 +5306,8 @@ std::unique_ptr<ast::Expr> Parser::parseTrailingPipeline(std::unique_ptr<ast::Ex
                 _lexer.pushBackToken(Token::LineFeed, "\n");
             break;
         }
-        _lexer.nextToken(); // consume |>
+        _lexer.nextToken();                    // consume |>
+        consumeUntilNotOneOf(Token::LineFeed); // allow `|>\n  expr`
         step = parseFSharpComposition();
         if (!step)
         {

--- a/src/endo-language/parser/Parser.hpp
+++ b/src/endo-language/parser/Parser.hpp
@@ -249,6 +249,30 @@ class Parser
     /// Returns true if any were consumed.
     bool consumeNewlines();
 
+    /// Multi-line command continuation helpers.
+    ///
+    /// Shell commands support three continuation forms:
+    ///   1. Trailing operator: `foo |\n bar`, `foo &&\n bar`, `foo |>\n bar`
+    ///      — handled by skipping LineFeeds after consuming the operator.
+    ///   2. Leading operator: `foo\n  | bar`, `foo\n  |> bar`, etc.
+    ///      — if we hit LineFeed and the next real token is a continuation
+    ///        operator, drop the LineFeeds.
+    ///   3. Indentation: `foo arg1\n     arg2` (arg2 strictly more indented
+    ///      than the program name) — drop LineFeeds and resume argument
+    ///      parsing.
+    ///
+    /// @return true if the LineFeed(s) were consumed and the lexer is now
+    ///         positioned on a continuation operator (caller should let the
+    ///         enclosing loop handle it).
+    bool tryConsumeNewlinesBeforeContinuationOperator();
+
+    /// Indented continuation for shell argument parsing.
+    /// @param anchorColumn Column of the program name; continuation line's
+    ///                     first token must be at a strictly greater column.
+    /// @return true if LineFeed(s) were consumed and we're positioned on a
+    ///         parameter/redirect token at col > anchorColumn.
+    bool tryConsumeIndentedContinuation(size_t anchorColumn);
+
     bool tryConsumeToken(Token token);
     bool consumeOneOf(Token token);
 

--- a/src/endo-language/parser/Parser_test.cpp
+++ b/src/endo-language/parser/Parser_test.cpp
@@ -2665,3 +2665,113 @@ TEST_CASE("Parser.Shell.variadic_function_with_multi_pipe", "[parser][variadic]"
     CHECK(pipeline->calls[1]->program == "grep");
     CHECK(pipeline->calls[2]->program == "head");
 }
+
+// =============================================================================
+// Multi-line shell command continuation
+// =============================================================================
+// Three continuation forms are supported:
+//   1. Trailing operator (`|`, `&&`, `||`) at end of line
+//   2. Leading operator at start of next line
+//   3. Indentation (next line column > program name column)
+
+TEST_CASE("Parser.Multiline.trailing_pipe", "[parser][multiline]")
+{
+    auto ast = parse("echo hello |\n  cat");
+    REQUIRE(ast != nullptr);
+    auto* pipeline = dynamic_cast<endo::ast::CallPipeline*>(getFirstStatement(ast.get()));
+    REQUIRE(pipeline != nullptr);
+    REQUIRE(pipeline->calls.size() == 2);
+    CHECK(pipeline->calls[0]->program == "echo");
+    CHECK(pipeline->calls[1]->program == "cat");
+}
+
+TEST_CASE("Parser.Multiline.leading_pipe", "[parser][multiline]")
+{
+    auto ast = parse("echo hello\n  | cat");
+    REQUIRE(ast != nullptr);
+    auto* pipeline = dynamic_cast<endo::ast::CallPipeline*>(getFirstStatement(ast.get()));
+    REQUIRE(pipeline != nullptr);
+    REQUIRE(pipeline->calls.size() == 2);
+    CHECK(pipeline->calls[0]->program == "echo");
+    CHECK(pipeline->calls[1]->program == "cat");
+}
+
+TEST_CASE("Parser.Multiline.trailing_and", "[parser][multiline]")
+{
+    auto ast = parse("echo first &&\n  echo second");
+    REQUIRE(ast != nullptr);
+    auto* andStmt = dynamic_cast<endo::ast::LogicalAndStmt*>(getFirstStatement(ast.get()));
+    REQUIRE(andStmt != nullptr);
+}
+
+TEST_CASE("Parser.Multiline.trailing_or", "[parser][multiline]")
+{
+    auto ast = parse("echo first ||\n  echo fallback");
+    REQUIRE(ast != nullptr);
+    auto* orStmt = dynamic_cast<endo::ast::LogicalOrStmt*>(getFirstStatement(ast.get()));
+    REQUIRE(orStmt != nullptr);
+}
+
+TEST_CASE("Parser.Multiline.leading_and", "[parser][multiline]")
+{
+    auto ast = parse("echo first\n  && echo second");
+    REQUIRE(ast != nullptr);
+    auto* andStmt = dynamic_cast<endo::ast::LogicalAndStmt*>(getFirstStatement(ast.get()));
+    REQUIRE(andStmt != nullptr);
+}
+
+TEST_CASE("Parser.Multiline.leading_or", "[parser][multiline]")
+{
+    auto ast = parse("echo first\n  || echo fallback");
+    REQUIRE(ast != nullptr);
+    auto* orStmt = dynamic_cast<endo::ast::LogicalOrStmt*>(getFirstStatement(ast.get()));
+    REQUIRE(orStmt != nullptr);
+}
+
+TEST_CASE("Parser.Multiline.indented_args_git_commit_style", "[parser][multiline]")
+{
+    // Arguments aligned under the first arg continue the same command.
+    auto ast = parse("git commit -m blurb\n"
+                     "           --author JohnDoe\n"
+                     "           --date 2024");
+    REQUIRE(ast != nullptr);
+    auto* stmt = getFirstStatement(ast.get());
+    REQUIRE(stmt != nullptr);
+
+    // Single unpiped shell command: parseCallPipeline returns the ProgramCall directly
+    // (wrapped inside nothing — ProgramCall is-a Statement).
+    auto* call = dynamic_cast<endo::ast::ProgramCall*>(stmt);
+    REQUIRE(call != nullptr);
+    CHECK(call->program == "git");
+    // Expected args: commit, -m, blurb, --author, JohnDoe, --date, 2024 == 7
+    CHECK(call->parameters.size() == 7);
+}
+
+TEST_CASE("Parser.Multiline.same_column_is_independent", "[parser][multiline]")
+{
+    // Second line at same column as first: two separate commands.
+    auto ast = parse("echo first\necho second");
+    REQUIRE(ast != nullptr);
+    auto* compound = dynamic_cast<endo::ast::CompoundStmt*>(ast.get());
+    REQUIRE(compound != nullptr);
+    CHECK(compound->statements.size() == 2);
+}
+
+TEST_CASE("Parser.Multiline.fsharp_pipeline_leading", "[parser][multiline]")
+{
+    auto ast = parse("let double x = x * 2\n5\n  |> double");
+    REQUIRE(ast != nullptr);
+    auto* compound = dynamic_cast<endo::ast::CompoundStmt*>(ast.get());
+    REQUIRE(compound != nullptr);
+    // Two top-level statements: `let double` and the pipeline expression.
+    CHECK(compound->statements.size() == 2);
+}
+
+TEST_CASE("Parser.Multiline.fsharp_pipeline_trailing", "[parser][multiline]")
+{
+    auto ast = parse("let double x = x * 2\n5 |>\n  double");
+    REQUIRE(ast != nullptr);
+    auto* compound = dynamic_cast<endo::ast::CompoundStmt*>(ast.get());
+    REQUIRE(compound != nullptr);
+    CHECK(compound->statements.size() == 2);
+}

--- a/src/tui/Buffer.cpp
+++ b/src/tui/Buffer.cpp
@@ -129,10 +129,16 @@ void Buffer::clearRect(Rect area, Style const& style)
     }
 }
 
-int Buffer::putString(int row, int col, std::string_view text, Style const& style)
+int Buffer::putString(int row, int col, std::string_view text, Style const& style, int maxWidth)
 {
     if (row < 0 || row >= _rows || col < 0)
         return 0;
+
+    // Effective right boundary: the lesser of the buffer width and the caller's column budget.
+    // Clamp the budget to a non-negative span starting at col, guarding against overflow when
+    // maxWidth is the default sentinel (std::numeric_limits<int>::max()).
+    int const budgetLimit = (maxWidth >= _cols - col) ? _cols : col + maxWidth;
+    int const colLimit = std::min(_cols, budgetLimit);
 
     int currentCol = col;
 
@@ -141,7 +147,7 @@ int Buffer::putString(int row, int col, std::string_view text, Style const& styl
 
     for (auto it = segmenter.begin(); it != segmenter.end(); ++it)
     {
-        if (currentCol >= _cols)
+        if (currentCol >= colLimit)
             break;
 
         auto const& cluster = *it;
@@ -153,8 +159,10 @@ int Buffer::putString(int row, int col, std::string_view text, Style const& styl
         // Calculate display width for the grapheme cluster
         int const clusterWidth = graphemeClusterWidth(cluster);
 
-        // Check if it fits
-        if (currentCol + clusterWidth > _cols)
+        // Check if it fits within the effective boundary (buffer width and caller budget).
+        // A wide cluster that would straddle the boundary is dropped, not partially written,
+        // so its continuation cells never spill past colLimit.
+        if (currentCol + clusterWidth > colLimit)
             break;
 
         // Get the cluster as a string_view into the original text

--- a/src/tui/Buffer.hpp
+++ b/src/tui/Buffer.hpp
@@ -4,6 +4,7 @@
 #include <tui/Cell.hpp>
 #include <tui/Rect.hpp>
 
+#include <limits>
 #include <span>
 #include <string>
 #include <string_view>
@@ -98,8 +99,17 @@ class Buffer
     /// @param col Starting column (0-based).
     /// @param text UTF-8 text to write.
     /// @param style Style to apply.
+    /// @param maxWidth Maximum number of display columns the caller is permitted to write,
+    ///                 measured from @p col. A grapheme cluster is skipped entirely if it (or
+    ///                 its continuation cells) would exceed this budget — this prevents a wide
+    ///                 cluster at the edge of a sub-region from spilling into adjacent cells.
+    ///                 Defaults to the full buffer width (no extra limit).
     /// @return Number of columns consumed.
-    int putString(int row, int col, std::string_view text, Style const& style);
+    int putString(int row,
+                  int col,
+                  std::string_view text,
+                  Style const& style,
+                  int maxWidth = std::numeric_limits<int>::max());
 
     /// Fills a rectangular region with a character.
     /// @param area The region to fill.

--- a/src/tui/Canvas.cpp
+++ b/src/tui/Canvas.cpp
@@ -51,11 +51,12 @@ int Canvas::putString(int row, int col, std::string_view text, Style const& styl
     int bufRow = toBufferRow(row);
     int bufCol = toBufferCol(col);
 
-    // Use buffer's putString but limit to available width
-    // We need to handle clipping ourselves since buffer doesn't know our bounds
-    int written = _buffer.putString(bufRow, bufCol, text, style);
+    // Constrain the write to this canvas' available width. Buffer::putString stops before any
+    // grapheme cluster (including its continuation cells) would exceed the budget, so a wide
+    // cluster at the right edge cannot spill into cells outside this canvas' area.
+    int written = _buffer.putString(bufRow, bufCol, text, style, availableWidth);
 
-    // Clamp to available width
+    // Clamp to available width (defensive; Buffer already honours the budget).
     return std::min(written, availableWidth);
 }
 

--- a/src/tui/InputField.cpp
+++ b/src/tui/InputField.cpp
@@ -189,13 +189,44 @@ void InputField::render(Canvas& canvas)
         if (availableWidth <= 0)
             return;
 
-        // Render text with selection highlighting and optional decorator
+        // Measure pass: compute total text width in display columns and the cursor's
+        // column within the unscrolled text, so we can adjust the horizontal scroll
+        // offset to keep the cursor visible.
         auto segmenter = unicode::utf8_grapheme_segmenter(_buffer);
-        int cursorDisplayCol = textStartCol;
-        bool cursorFound = false;
-        std::size_t graphemeIdx = 0;
+        int totalTextCols = 0;
+        int cursorTextCol = 0;
+        bool cursorMeasured = false;
+        for (auto it = segmenter.begin(); it != segmenter.end(); ++it)
+        {
+            char const* clusterStart = it._clusterStart;
+            auto const clusterByteStart = static_cast<std::size_t>(clusterStart - _buffer.data());
+            if (!cursorMeasured && _cursor <= clusterByteStart)
+            {
+                cursorTextCol = totalTextCols;
+                cursorMeasured = true;
+            }
+            int const clusterWidth = _masked ? 1 : graphemeClusterWidth(*it);
+            totalTextCols += clusterWidth;
+        }
+        if (!cursorMeasured)
+            cursorTextCol = totalTextCols;
 
-        for (auto it = segmenter.begin(); it != segmenter.end() && col < width; ++it, ++graphemeIdx)
+        // Adjust horizontal scroll offset to keep cursor in view.
+        if (cursorTextCol < _hScrollOffset)
+            _hScrollOffset = cursorTextCol;
+        else if (cursorTextCol >= _hScrollOffset + availableWidth)
+            _hScrollOffset = cursorTextCol - availableWidth + 1;
+
+        // Reduce offset when content (including room for the end-of-line cursor)
+        // would otherwise leave blank space on the right.
+        int const maxOffset = std::max(0, totalTextCols + 1 - availableWidth);
+        _hScrollOffset = std::min(_hScrollOffset, maxOffset);
+        _hScrollOffset = std::max(_hScrollOffset, 0);
+
+        // Render pass with horizontal scroll applied.
+        int textCol = 0;
+        std::size_t graphemeIdx = 0;
+        for (auto it = segmenter.begin(); it != segmenter.end(); ++it, ++graphemeIdx)
         {
             auto const& cluster = *it;
             auto nextIt = it;
@@ -204,16 +235,22 @@ void InputField::render(Canvas& canvas)
             char const* clusterEnd =
                 (nextIt != segmenter.end()) ? nextIt._clusterStart : (_buffer.data() + _buffer.size());
             auto const clusterByteStart = static_cast<std::size_t>(clusterStart - _buffer.data());
+            int const clusterWidth = _masked ? 1 : graphemeClusterWidth(cluster);
 
-            if (!cursorFound && _cursor <= clusterByteStart)
+            int const visibleStart = textCol - _hScrollOffset;
+            int const canvasCol = textStartCol + visibleStart;
+
+            // Fully clipped off the left.
+            if (visibleStart + clusterWidth <= 0)
             {
-                cursorDisplayCol = col;
-                cursorFound = true;
+                textCol += clusterWidth;
+                continue;
             }
+            // Fully clipped off the right.
+            if (canvasCol >= width)
+                break;
 
-            int const clusterWidth = graphemeClusterWidth(cluster);
-
-            // Build style: start with text style, apply decorator, then selection
+            // Build style: start with text style, apply decorator, then selection.
             Style style = textStyle;
             if (_textDecorator)
             {
@@ -235,31 +272,54 @@ void InputField::render(Canvas& canvas)
                     style = selectionStyle;
             }
 
-            // Apply background from decorator
+            // Apply background from decorator at the actual canvas column.
             if (_textDecorator)
             {
-                if (auto bg = _textDecorator->background(col))
+                if (auto bg = _textDecorator->background(std::max(textStartCol, canvasCol)))
                     style.bg = *bg;
             }
 
-            std::string_view clusterView(clusterStart, static_cast<std::size_t>(clusterEnd - clusterStart));
-            if (_masked)
+            if (visibleStart < 0)
             {
-                canvas.putString(0, col, "*", style);
-                col += 1;
+                // Wide cluster straddling the left edge: fill visible cells with spaces
+                // so we don't overflow the prompt area.
+                for (int c = textStartCol; c < canvasCol + clusterWidth && c < width; ++c)
+                    canvas.putString(0, c, " ", style);
+            }
+            else if (_masked)
+            {
+                canvas.putString(0, canvasCol, "*", style);
             }
             else
             {
-                canvas.putString(0, col, clusterView, style);
-                col += clusterWidth;
+                std::string_view clusterView(clusterStart,
+                                             static_cast<std::size_t>(clusterEnd - clusterStart));
+                canvas.putString(0, canvasCol, clusterView, style);
             }
+            textCol += clusterWidth;
         }
 
-        if (!cursorFound || _cursor >= _buffer.size())
-            cursorDisplayCol = col;
+        int const cursorDisplayCol = std::min(width - 1, textStartCol + (cursorTextCol - _hScrollOffset));
 
-        if (!_masked && !_ghostText.empty() && _cursor >= _buffer.size())
-            renderGhostText(canvas, 0, col, ghostStyle);
+        int const textEndCol = textStartCol + (totalTextCols - _hScrollOffset);
+        if (!_masked && !_ghostText.empty() && _cursor >= _buffer.size() && textEndCol < width
+            && textEndCol >= textStartCol)
+        {
+            int ghostCol = textEndCol;
+            renderGhostText(canvas, 0, ghostCol, ghostStyle);
+        }
+
+        // Scroll continuation indicators: render on top of the first/last text cell
+        // when buffer content extends beyond the visible viewport. Style uses the
+        // dim ghost style so the markers don't compete with the input itself.
+        if (_hScrollOffset > 0)
+            canvas.putString(0, textStartCol, "\xE2\x80\xB9", ghostStyle); // U+2039 ‹
+        if (totalTextCols - _hScrollOffset > availableWidth)
+        {
+            int const indicatorCol = width - 1;
+            if (indicatorCol >= textStartCol && indicatorCol != cursorDisplayCol)
+                canvas.putString(0, indicatorCol, "\xE2\x80\xBA", ghostStyle); // U+203A ›
+        }
 
         canvas.setCursor(0, cursorDisplayCol);
         return;
@@ -512,6 +572,7 @@ void InputField::clear()
 {
     _buffer.clear();
     _cursor = 0;
+    _hScrollOffset = 0;
     clearSelection();
 }
 
@@ -519,6 +580,7 @@ void InputField::setText(std::string_view text)
 {
     _buffer = _multiline ? std::string(text) : sanitizeForSingleLine(text);
     _cursor = _buffer.size();
+    _hScrollOffset = 0;
     clearSelection();
 }
 

--- a/src/tui/InputField.hpp
+++ b/src/tui/InputField.hpp
@@ -353,8 +353,9 @@ class InputField: public Component
     std::string _continuationPrompt;               ///< Continuation prompt for non-first lines.
     bool _masked = false;
     bool _multiline = false;
-    int _maxLines = 0;     ///< 0 = unlimited
-    int _scrollOffset = 0; ///< Scroll offset for multiline mode
+    int _maxLines = 0;      ///< 0 = unlimited
+    int _scrollOffset = 0;  ///< Scroll offset for multiline mode
+    int _hScrollOffset = 0; ///< Horizontal scroll offset (display columns) for single-line mode
 
     // Mouse state
     bool _dragging = false; ///< True during click-and-drag selection

--- a/src/tui/InputField_test.cpp
+++ b/src/tui/InputField_test.cpp
@@ -1763,3 +1763,183 @@ TEST_CASE("InputField.ghost_text_trim_respects_capitalization")
     CHECK(field.text() == "HE");
     CHECK(field.ghostText().empty());
 }
+
+// ============================================================================
+// Horizontal scroll (single-line overflow)
+// ============================================================================
+
+namespace
+{
+
+// Render the field into a fresh buffer of (1 x cols) and return it.
+Buffer renderSingleLine(InputField& field, int cols)
+{
+    Buffer buffer(1, cols);
+    auto const theme = darkTheme();
+    Canvas canvas(buffer, Rect { .x = 0, .y = 0, .width = cols, .height = 1 }, theme);
+    field.render(canvas);
+    return buffer;
+}
+
+std::string rowText(Buffer const& buffer)
+{
+    std::string out;
+    for (int c = 0; c < buffer.cols(); ++c)
+    {
+        auto const& cell = buffer.at(0, c);
+        out += cell.grapheme.empty() ? std::string(" ") : cell.grapheme;
+    }
+    return out;
+}
+
+} // namespace
+
+TEST_CASE("InputField.hscroll_long_line_follows_cursor_to_right_edge")
+{
+    InputField field;
+    field.setText("0123456789ABCDEF"); // 16 graphemes, cursor at end (16)
+
+    auto buffer = renderSingleLine(field, 10);
+
+    // Tail of the input plus a trailing blank for the end-of-line cursor.
+    // The leftmost cell is overlaid with the left continuation indicator
+    // because content continues off-screen on the left.
+    CHECK(rowText(buffer)
+          == "\xE2\x80\xB9"
+             "89ABCDEF ");
+    CHECK(buffer.cursor().x == 9);
+    CHECK(buffer.cursor().y == 0);
+}
+
+TEST_CASE("InputField.hscroll_cursor_at_start_shows_prefix")
+{
+    InputField field;
+    field.setText("0123456789ABCDEF");
+    field.setCursor(0);
+
+    auto buffer = renderSingleLine(field, 10);
+
+    // Right-most cell shows the right continuation indicator.
+    CHECK(rowText(buffer) == "012345678\xE2\x80\xBA");
+    CHECK(buffer.cursor().x == 0);
+}
+
+TEST_CASE("InputField.hscroll_cursor_in_middle_scrolls_into_view")
+{
+    InputField field;
+    field.setText("0123456789ABCDEF");
+    field.setCursor(12); // between 'B' and 'C'
+
+    auto buffer = renderSingleLine(field, 10);
+
+    // Offset places cursor at the right edge; leftmost cell gets the left indicator.
+    CHECK(rowText(buffer)
+          == "\xE2\x80\xB9"
+             "456789ABC");
+    CHECK(buffer.cursor().x == 9);
+}
+
+TEST_CASE("InputField.hscroll_short_line_does_not_scroll")
+{
+    InputField field;
+    field.setText("hi");
+    field.setCursor(2);
+
+    auto buffer = renderSingleLine(field, 10);
+
+    CHECK(rowText(buffer) == "hi        ");
+    CHECK(buffer.cursor().x == 2);
+}
+
+TEST_CASE("InputField.hscroll_prompt_area_is_preserved")
+{
+    InputField field;
+    field.setPrompt("$ ");
+    field.setText("0123456789ABCDEF");
+
+    auto buffer = renderSingleLine(field, 10);
+
+    // Prompt occupies cols 0-1; text area is 8 cols. Cursor at end ⇒ tail visible
+    // with a trailing blank for the cursor: "$ BCDEF  ".
+    auto const row = rowText(buffer);
+    CHECK(row.substr(0, 2) == "$ ");
+    CHECK(buffer.cursor().x == 9);
+}
+
+TEST_CASE("InputField.hscroll_right_indicator_when_tail_clipped")
+{
+    InputField field;
+    field.setText("0123456789ABCDEF"); // 16 chars
+    field.setCursor(0);                // viewport pinned to the left
+
+    auto buffer = renderSingleLine(field, 10);
+
+    // First 9 chars of the buffer visible; last cell replaced by the right indicator.
+    auto const row = rowText(buffer);
+    CHECK(row.substr(0, 9) == "012345678");
+    CHECK(row.substr(9, 3) == "\xE2\x80\xBA"); // U+203A ›
+    CHECK(buffer.cursor().x == 0);
+}
+
+TEST_CASE("InputField.hscroll_left_indicator_when_head_clipped")
+{
+    InputField field;
+    field.setText("0123456789ABCDEF");
+    field.setCursor(16); // end — viewport scrolled right
+
+    auto buffer = renderSingleLine(field, 10);
+
+    // Leftmost cell shows the left indicator on top of the first visible char.
+    auto const row = rowText(buffer);
+    CHECK(row.substr(0, 3) == "\xE2\x80\xB9"); // U+2039 ‹
+    CHECK(buffer.cursor().x == 9);
+}
+
+TEST_CASE("InputField.hscroll_both_indicators_when_clipped_on_both_sides")
+{
+    InputField field;
+    field.setText("0123456789ABCDEFGHIJ"); // 20 chars
+
+    // First render: cursor mid-buffer, viewport scrolls right (offset > 0).
+    field.setCursor(15);
+    (void) renderSingleLine(field, 6);
+
+    // Second render: cursor moves back into the visible range, so the viewport
+    // stays put — text is clipped on BOTH sides and the cursor is in the middle.
+    field.setCursor(12);
+    auto buffer = renderSingleLine(field, 6);
+
+    auto const row = rowText(buffer);
+    CHECK(row.substr(0, 3) == "\xE2\x80\xB9");
+    CHECK(row.substr(row.size() - 3) == "\xE2\x80\xBA");
+    CHECK(buffer.cursor().x != 0);
+    CHECK(buffer.cursor().x != buffer.cols() - 1);
+}
+
+TEST_CASE("InputField.hscroll_no_indicators_when_content_fits")
+{
+    InputField field;
+    field.setText("hello");
+
+    auto buffer = renderSingleLine(field, 10);
+    auto const row = rowText(buffer);
+    // Plain ASCII "hello" followed by spaces — no angle-quote bytes present.
+    CHECK(row.find("\xE2\x80\xB9") == std::string::npos);
+    CHECK(row.find("\xE2\x80\xBA") == std::string::npos);
+}
+
+TEST_CASE("InputField.hscroll_resets_on_clear_and_setText")
+{
+    InputField field;
+    field.setText("0123456789ABCDEF");
+    (void) renderSingleLine(field, 10); // establishes non-zero scroll offset
+
+    field.clear();
+    auto buffer = renderSingleLine(field, 10);
+    CHECK(buffer.cursor().x == 0);
+
+    field.setText("abc");
+    buffer = renderSingleLine(field, 10);
+    CHECK(rowText(buffer).substr(0, 3) == "abc");
+    CHECK(buffer.cursor().x == 3);
+}

--- a/src/tui/Renderer_test.cpp
+++ b/src/tui/Renderer_test.cpp
@@ -690,6 +690,31 @@ TEST_CASE("Canvas.putString_clipping")
     CHECK(consumed == 3); // Only "hel" fits (cols 7, 8, 9)
 }
 
+TEST_CASE("Canvas.putString_wide_cluster_right_edge")
+{
+    // A wide (2-cell) grapheme cluster at the canvas' last column must not spill its
+    // continuation cell into cells outside the canvas area (which belong to other components).
+    Buffer buf(24, 80);
+    auto theme = darkTheme();
+    // Canvas occupies buffer columns 10..19 (width 10); buffer column 20 is outside the area.
+    Canvas canvas(buf, Rect { .x = 10, .y = 5, .width = 10, .height = 5 }, theme);
+
+    // "界" is a width-2 CJK glyph. Placed at canvas col 9 it would occupy canvas cols 9 and 10,
+    // i.e. buffer cols 19 and 20 — but col 20 is outside the canvas. It must be dropped entirely.
+    int consumed = canvas.putString(0, 9, "界", Style {});
+    CHECK(consumed == 0); // Did not fit within the area.
+
+    // Canvas col 9 = buffer col 19; the out-of-area cell is buffer col 20.
+    CHECK(buf.at(5, 19).grapheme == " "); // Last canvas cell untouched (cluster dropped).
+    CHECK(buf.at(5, 20).grapheme == " "); // Cell outside the canvas area must be untouched.
+
+    // A width-2 cluster that fully fits (canvas cols 8..9 = buffer cols 18..19) is written.
+    consumed = canvas.putString(0, 8, "界", Style {});
+    CHECK(consumed == 2);
+    CHECK(buf.at(5, 18).grapheme == "界");
+    CHECK(buf.at(5, 20).grapheme == " "); // Still nothing outside the area.
+}
+
 TEST_CASE("Canvas.fill")
 {
     Buffer buf(24, 80);

--- a/tests/pipelines/multiline_leading_fwd_pipe.endo
+++ b/tests/pipelines/multiline_leading_fwd_pipe.endo
@@ -8,4 +8,9 @@ let double x = x * 2
 
 let inc x = x + 1
 
-5 |> inc |> double |> println
+# endo format off
+5
+|> inc
+|> double
+|> println
+# endo format on

--- a/tests/pipelines/multiline_leading_fwd_pipe.endo
+++ b/tests/pipelines/multiline_leading_fwd_pipe.endo
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: F# pipeline with leading `|>` on each continuation line
+# expect: 12
+# expect:
+
+let double x = x * 2
+
+let inc x = x + 1
+
+5 |> inc |> double |> println

--- a/tests/pipelines/multiline_trailing_fwd_pipe.endo
+++ b/tests/pipelines/multiline_trailing_fwd_pipe.endo
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# description: F# pipeline with trailing `|>` at end of each line
+# description: F# pipeline with trailing `|>` at end of each continuation line
 # expect: 12
 # expect:
 
@@ -8,4 +8,9 @@ let double x = x * 2
 
 let inc x = x + 1
 
-5 |> inc |> double |> println
+# endo format off
+5 |>
+inc |>
+double |>
+println
+# endo format on

--- a/tests/pipelines/multiline_trailing_fwd_pipe.endo
+++ b/tests/pipelines/multiline_trailing_fwd_pipe.endo
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: F# pipeline with trailing `|>` at end of each line
+# expect: 12
+# expect:
+
+let double x = x * 2
+
+let inc x = x + 1
+
+5 |> inc |> double |> println


### PR DESCRIPTION
Two unrelated UX improvements bundled onto the `improvement/ux` branch.

## Changes

- **Multi-line shell commands.** Shell commands and pipelines can now span multiple lines via trailing `|` / `|>` / `&&` / `||`, leading operators on the next line, or indented continuation lines whose first token sits at a column strictly greater than the program name. Implemented with two parser helpers wired into `parseCall`, `parseCallPipeline`, `parseLogicalExpr`, and every `|>` site. AST and downstream stages are unchanged. Covered by 10 Catch2 tests under the `[multiline]` tag and two `.endo` E2E tests. Bash-style `\`-at-EOL is intentionally not supported. Documented in a new section 10.6 of `command-execution.md` with cross-references from lexical, operator, and grammar docs.
- **Horizontal scrolling for single-line InputField.** Pre-existing commit on this branch; see 5d34b7dd.