### PR TITLE
Fix compiling error for GCC 15.2.0

### DIFF
--- a/src/tui/platform/TerminalOutput.cpp
+++ b/src/tui/platform/TerminalOutput.cpp
@@ -426,7 +426,7 @@ void TerminalOutput::writeSixel(std::string_view sixelData)
 
 void TerminalOutput::copyToClipboard(std::string_view text)
 {
-    // OSC 52 format: ESC ] 52 ; c ; <base64-data> ESC \
+    // OSC 52 format: 'ESC ] 52 ; c ; <base64-data> ESC \'
     // 'c' means system clipboard (could also use 'p' for primary selection)
     _buffer += "\033]52;c;";
     _buffer += base64Encode(text);


### PR DESCRIPTION
I got this error:
```
/usr/bin/c++ -DHAVE_BACKTRACE -DHAVE_BACKTRACE_SYMBOLS -DHAVE_CXXABI_H -DHAVE_DLADDR -DHAVE_DLFCN_H -DHAVE_DLSYM -DHAVE_EXECINFO_H -DHAVE_SYS_SELECT_H -DHAVE_UNWIND_H -I/dev/shm/endo/src/tui/.. -I/dev/shm/endo/src/platform/.. -isystem /dev/shm/endo/build-rel/_deps/libunicode-src/src -isystem /dev/shm/endo/build-rel/_deps/libunicode-src/src/libunicode/.. -isystem /dev/shm/endo/src -isystem /dev/shm/endo/build-rel/_deps/boxed-cpp-src/include -isystem /dev/shm/endo/build-rel/_deps/reflection-cpp-src/include -isystem /dev/shm/endo/build-rel/_deps/stb-src -O3 -DNDEBUG -std=c++23 -Werror -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wnull-dereference -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough -Wall -maes -E -x c++ /dev/shm/endo/src/tui/platform/TerminalOutput.cpp -MT src/tui/CMakeFiles/tui.dir/platform/TerminalOutput.cpp.o.ddi -MD -MF src/tui/CMakeFiles/tui.dir/platform/TerminalOutput.cpp.o.ddi.d -fmodules-ts -fdeps-file=src/tui/CMakeFiles/tui.dir/platform/TerminalOutput.cpp.o.ddi -fdeps-target=src/tui/CMakeFiles/tui.dir/platform/TerminalOutput.cpp.o -fdeps-format=p1689r5 -o src/tui/CMakeFiles/tui.dir/platform/TerminalOutput.cpp.o.ddi.i
/dev/shm/endo/src/tui/platform/TerminalOutput.cpp:429:5: error: multi-line comment [-Werror=comment]
  429 |     // OSC 52 format: ESC ] 52 ; c ; <base64-data> ESC \
      |     ^
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```