### PR TITLE
Delete whole space-delimited word on Alt+Backspace

### DIFF
--- a/docs/shell/configuration.md
+++ b/docs/shell/configuration.md
@@ -554,7 +554,7 @@ All bindable action names for use with `bind`:
 | Category | Actions |
 |----------|---------|
 | Movement | `move-forward-char`, `move-backward-char`, `move-forward-word`, `move-backward-word`, `move-to-line-start`, `move-to-line-end`, `move-to-buffer-start`, `move-to-buffer-end`, `move-up`, `move-down`, `smart-move-to-line-start`, `smart-move-to-line-end` |
-| Editing | `delete-char-backward`, `delete-char-forward`, `delete-word`, `delete-word-backward`, `kill-to-end`, `kill-to-start`, `transpose` |
+| Editing | `delete-char-backward`, `delete-char-forward`, `delete-word`, `delete-word-backward`, `delete-big-word-backward`, `kill-to-end`, `kill-to-start`, `transpose` |
 | Undo / Redo | `undo`, `redo` |
 | Kill Ring | `yank`, `yank-pop` |
 | Selection | `select-all` |

--- a/docs/shell/index.md
+++ b/docs/shell/index.md
@@ -128,7 +128,8 @@ See [Configuration](configuration.md) for full prompt customization options.
 | Ctrl+Y | Redo |
 | Ctrl+A / Ctrl+E | Smart cursor to line start / end |
 | Ctrl+K / Ctrl+U | Kill to end / start of line |
-| Ctrl+W | Delete word backward |
+| Ctrl+W / Ctrl+Backspace | Delete word backward (stops at `/`, `.`, `-` boundaries) |
+| Alt+Backspace | Delete whole whitespace-delimited word backward |
 | Ctrl+D | Delete character (or EOF on empty line) |
 | Ctrl+L | Clear screen |
 | Ctrl+R | History search |

--- a/src/tui/EditAction.hpp
+++ b/src/tui/EditAction.hpp
@@ -35,14 +35,15 @@ enum class EditAction : std::uint8_t
     SmartMoveToLineEnd,   ///< Move to line end; if already there, move to next line's end
 
     // === Editing ===
-    DeleteCharBackward, ///< Delete character before cursor (Backspace)
-    DeleteCharForward,  ///< Delete character at cursor (Delete)
-    DeleteWord,         ///< Delete word after cursor
-    DeleteWordBackward, ///< Delete word before cursor
-    KillToEnd,          ///< Kill (cut to kill ring) from cursor to end of line
-    KillToStart,        ///< Kill from cursor to start of line
-    Transpose,          ///< Transpose characters around cursor
-    ClearBuffer,        ///< Clear the entire input buffer
+    DeleteCharBackward,    ///< Delete character before cursor (Backspace)
+    DeleteCharForward,     ///< Delete character at cursor (Delete)
+    DeleteWord,            ///< Delete word after cursor
+    DeleteWordBackward,    ///< Delete word before cursor
+    DeleteBigWordBackward, ///< Delete whitespace-delimited word before cursor (Fish Alt+Backspace bigword)
+    KillToEnd,             ///< Kill (cut to kill ring) from cursor to end of line
+    KillToStart,           ///< Kill from cursor to start of line
+    Transpose,             ///< Transpose characters around cursor
+    ClearBuffer,           ///< Clear the entire input buffer
 
     // === Undo/Redo ===
     Undo, ///< Undo last edit

--- a/src/tui/InputField.cpp
+++ b/src/tui/InputField.cpp
@@ -776,6 +776,10 @@ auto InputField::executeAction(EditAction action) -> InputFieldAction
             killWordBackward(); // Adjusts ghost text internally (re-prepend or clear).
             return InputFieldAction::Changed;
 
+        case EditAction::DeleteBigWordBackward:
+            killBigWordBackward(); // Adjusts ghost text internally (re-prepend or clear).
+            return InputFieldAction::Changed;
+
         case EditAction::KillToEnd:
             killToEnd(); // Forward kill: clears ghost only if it actually deletes.
             return InputFieldAction::Changed;
@@ -1150,13 +1154,23 @@ void InputField::killWord()
 
 void InputField::killWordBackward()
 {
+    killWordBackwardWith(&InputField::isWordChar);
+}
+
+void InputField::killBigWordBackward()
+{
+    killWordBackwardWith(&InputField::isBigWordChar);
+}
+
+void InputField::killWordBackwardWith(bool (*isWordCharFn)(char))
+{
     auto const end = _cursor;
     bool const wasAtEnd = _cursor == _buffer.size();
     // Find start position without modifying cursor
     auto startPos = _cursor;
-    while (startPos > 0 && !isWordChar(_buffer[prevGraphemeCluster(startPos)]))
+    while (startPos > 0 && !isWordCharFn(_buffer[prevGraphemeCluster(startPos)]))
         startPos = prevGraphemeCluster(startPos);
-    while (startPos > 0 && isWordChar(_buffer[prevGraphemeCluster(startPos)]))
+    while (startPos > 0 && isWordCharFn(_buffer[prevGraphemeCluster(startPos)]))
         startPos = prevGraphemeCluster(startPos);
 
     if (startPos < end)
@@ -1433,6 +1447,14 @@ auto InputField::isWordChar(char c) -> bool
         return true;
     // Everything else (including '/', '.', '-', whitespace, etc.) is a boundary
     return false;
+}
+
+auto InputField::isBigWordChar(char c) -> bool
+{
+    // Fish-style "bigword" boundaries: only whitespace separates words. Every non-whitespace
+    // character (including '/', '.', '-', and punctuation) is part of the word, so a backward
+    // kill removes a whole space-delimited token (e.g. all of "git checkout -b" at once).
+    return std::isspace(static_cast<unsigned char>(c)) == 0;
 }
 
 // ============================================================================

--- a/src/tui/InputField.hpp
+++ b/src/tui/InputField.hpp
@@ -412,7 +412,8 @@ class InputField: public Component
     void killToEnd();            ///< Ctrl+K: Kill from cursor to end of line.
     void killToStart();          ///< Ctrl+U: Kill from cursor to start of line.
     void killWord();             ///< Alt+D: Kill word forward.
-    void killWordBackward();     ///< Alt+Backspace / Ctrl+W: Kill word backward.
+    void killWordBackward();     ///< Ctrl+W / Ctrl+Backspace: Kill word backward.
+    void killBigWordBackward();  ///< Alt+Backspace: Kill whitespace-delimited word backward.
     void yank();                 ///< Ctrl+Y: Yank (paste) from kill ring.
     void yankPop();              ///< Alt+Y: Cycle kill ring.
     void deleteChar();           ///< Delete / Ctrl+D: Delete character at cursor.
@@ -458,8 +459,15 @@ class InputField: public Component
 
     // Word boundary helpers (fish-style: path separators break words)
     [[nodiscard]] static auto isWordChar(char c) -> bool;
+    [[nodiscard]] static auto isBigWordChar(char c) -> bool;
     [[nodiscard]] auto findWordStart(std::size_t pos) const -> std::size_t;
     [[nodiscard]] auto findWordEnd(std::size_t pos) const -> std::size_t;
+
+    /// Kill backward from the cursor to the start of the previous word, using the given
+    /// boundary predicate to decide which characters count as part of a word. Handles ghost
+    /// text, the kill ring, and undo state. Backs both small-word and bigword backward kills.
+    /// @param isWordCharFn Returns true for characters that belong to a word (non-boundary).
+    void killWordBackwardWith(bool (*isWordCharFn)(char));
 
     // Mouse helpers
     [[nodiscard]] auto detectClickCount(int line, int column) -> int;

--- a/src/tui/InputField_test.cpp
+++ b/src/tui/InputField_test.cpp
@@ -2040,6 +2040,75 @@ TEST_CASE("InputField.ghost_text_accept_seed_is_single_line")
     CHECK(field.ghostText().find('\n') == std::string_view::npos);
 }
 
+TEST_CASE("InputField.bigword_backward_deletes_whole_space_delimited_token")
+{
+    // Alt+Backspace (DeleteBigWordBackward) uses whitespace-only boundaries, so it removes a whole
+    // space-delimited token at once — including any '-' or '/' inside it.
+    InputField field;
+    field.setText("git checkout -b");
+    field.setCursor(15);
+    (void) field.processEvent(specialKey(KeyCode::Backspace, Modifier::Alt)); // Alt+Backspace
+    CHECK(field.text() == "git checkout ");
+}
+
+TEST_CASE("InputField.bigword_backward_diverges_from_ctrl_w_small_word")
+{
+    // The two granularities differ on a token containing '-': bigword (Alt+Backspace) takes the
+    // whole "-b", while small-word (Ctrl+W) stops at the '-' boundary.
+    InputField big;
+    big.setText("git checkout -b");
+    big.setCursor(15);
+    (void) big.processEvent(specialKey(KeyCode::Backspace, Modifier::Alt));
+    CHECK(big.text() == "git checkout ");
+
+    InputField small;
+    small.setText("git checkout -b");
+    small.setCursor(15);
+    (void) small.processEvent(charKey('w', Modifier::Ctrl));
+    CHECK(small.text() == "git checkout -"); // small word stops at the '-' boundary
+}
+
+TEST_CASE("InputField.bigword_backward_deletes_whole_path")
+{
+    // A path like "foo/bar/baz" is a single bigword: Alt+Backspace clears it entirely, whereas
+    // Ctrl+W would only remove the trailing "baz" path component.
+    InputField big;
+    big.setText("foo/bar/baz");
+    big.setCursor(11);
+    (void) big.processEvent(specialKey(KeyCode::Backspace, Modifier::Alt));
+    CHECK(big.text().empty());
+
+    InputField small;
+    small.setText("foo/bar/baz");
+    small.setCursor(11);
+    (void) small.processEvent(charKey('w', Modifier::Ctrl));
+    CHECK(small.text() == "foo/bar/");
+}
+
+TEST_CASE("InputField.bigword_backward_at_start_is_noop")
+{
+    InputField field;
+    field.setText("foo");
+    field.setCursor(0);
+    (void) field.processEvent(specialKey(KeyCode::Backspace, Modifier::Alt));
+    CHECK(field.text() == "foo");
+}
+
+TEST_CASE("InputField.bigword_backward_restores_ghost_text_after_accept")
+{
+    // Bigword backward delete must adjust ghost text just like the small-word path: deleting the
+    // accepted tail restores it as the ghost (no flash). Mirrors the Ctrl+W ghost test.
+    InputField field;
+    field.setText("cmake");
+    field.setCursor(5);
+    field.setGhostText(" install");
+    field.acceptGhostText();
+    REQUIRE(field.text() == "cmake install");
+    (void) field.processEvent(specialKey(KeyCode::Backspace, Modifier::Alt)); // delete "install"
+    CHECK(field.text() == "cmake ");
+    CHECK(field.ghostText() == "install"); // restored synchronously — no flash
+}
+
 TEST_CASE("InputField.ghost_text_cleared_on_backspace_when_cursor_not_at_end")
 {
     InputField field;

--- a/src/tui/KeyBindings.cpp
+++ b/src/tui/KeyBindings.cpp
@@ -95,7 +95,7 @@ namespace
         EditAction action;
     };
 
-    constexpr std::array<ActionNameMapping, 40> actionNameMappings = { {
+    constexpr std::array<ActionNameMapping, 41> actionNameMappings = { {
         // Movement
         { .name = "move-forward-char",
           .description = "Move cursor forward one character",
@@ -146,6 +146,9 @@ namespace
         { .name = "delete-word-backward",
           .description = "Delete word before cursor",
           .action = EditAction::DeleteWordBackward },
+        { .name = "delete-big-word-backward",
+          .description = "Delete whitespace-delimited word before cursor",
+          .action = EditAction::DeleteBigWordBackward },
         { .name = "kill-to-end",
           .description = "Kill from cursor to end of line",
           .action = EditAction::KillToEnd },
@@ -454,7 +457,7 @@ KeyBindings KeyBindings::defaults()
     bindings.bind(K::fromKey(KeyCode::Backspace), A::DeleteCharBackward);
     bindings.bind(K::fromKey(KeyCode::Delete), A::DeleteCharForward);
     bindings.bind(K::fromKey(KeyCode::Backspace, M::Ctrl), A::DeleteWordBackward);
-    bindings.bind(K::fromKey(KeyCode::Backspace, M::Alt), A::DeleteWordBackward);
+    bindings.bind(K::fromKey(KeyCode::Backspace, M::Alt), A::DeleteBigWordBackward);
     bindings.bind(K::fromChar('w', M::Ctrl), A::DeleteWordBackward);
     bindings.bind(K::fromKey(KeyCode::Delete, M::Ctrl), A::DeleteWord);
     bindings.bind(K::fromChar('d', M::Alt), A::DeleteWord);

--- a/src/tui/KeyBindings_test.cpp
+++ b/src/tui/KeyBindings_test.cpp
@@ -332,6 +332,9 @@ TEST_CASE("KeyBindings.defaults_delete_backspace")
     CHECK(bindings.lookup(keyEvent(KeyCode::Backspace)) == EditAction::DeleteCharBackward);
     CHECK(bindings.lookup(keyEvent(KeyCode::Delete)) == EditAction::DeleteCharForward);
     CHECK(bindings.lookup(keyEvent(KeyCode::Backspace, Modifier::Ctrl)) == EditAction::DeleteWordBackward);
+    // Alt+Backspace deletes a whole whitespace-delimited word (Fish bigword), distinct from
+    // Ctrl+Backspace / Ctrl+W which use small-word boundaries.
+    CHECK(bindings.lookup(keyEvent(KeyCode::Backspace, Modifier::Alt)) == EditAction::DeleteBigWordBackward);
 }
 
 TEST_CASE("KeyBindings.defaults_kill")
@@ -550,6 +553,7 @@ TEST_CASE("parseEditAction.editing_actions")
     CHECK(parseEditAction("delete-char-forward") == EditAction::DeleteCharForward);
     CHECK(parseEditAction("delete-word") == EditAction::DeleteWord);
     CHECK(parseEditAction("delete-word-backward") == EditAction::DeleteWordBackward);
+    CHECK(parseEditAction("delete-big-word-backward") == EditAction::DeleteBigWordBackward);
     CHECK(parseEditAction("kill-to-end") == EditAction::KillToEnd);
     CHECK(parseEditAction("kill-to-start") == EditAction::KillToStart);
     CHECK(parseEditAction("transpose") == EditAction::Transpose);
@@ -614,6 +618,7 @@ TEST_CASE("editActionToString_parseEditAction_roundtrip")
     testRoundtrip(EditAction::Paste);
     testRoundtrip(EditAction::MoveForwardChar);
     testRoundtrip(EditAction::DeleteWordBackward);
+    testRoundtrip(EditAction::DeleteBigWordBackward);
     testRoundtrip(EditAction::KillToEnd);
     testRoundtrip(EditAction::Yank);
     testRoundtrip(EditAction::Submit);


### PR DESCRIPTION
Alt+Backspace now deletes a whole whitespace-delimited word, matching Fish's `backward-kill-bigword`. Previously it shared the small-word behavior of Ctrl+W, so on input like `git checkout -b` it removed only `b` and on `foo/bar/baz` only `baz`. Ctrl+W and Ctrl+Backspace keep their small-word boundaries (stopping at `/`, `.`, `-`).

## Changes

- Add `EditAction::DeleteBigWordBackward`, backed by `killBigWordBackward()` and a new `isBigWordChar()` predicate that treats only whitespace as a word boundary.
- Factor the backward-kill loop into `killWordBackwardWith(predicate)` so the small-word and bigword paths share the same ghost-text, kill-ring, and undo handling.
- Register the action in the data-driven `actionNameMappings` table, giving it config binding (`delete-big-word-backward`), parsing, and serialization for free.
- Document the binding in the shell docs.