### PR TITLE
Make unit-test compilation honor ENDO_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,18 @@ if(NOT DEFINED ENDO_TRACE_LEXER)
 endif()
 
 
+# ENDO_TESTING must be defined before include(EndoThirdParties): the Catch2 fetch
+# there is guarded by it, so the variable has to exist by the time it runs.
+if(EMSCRIPTEN)
+    set(ENDO_TESTING OFF)
+else()
+    option(ENDO_TESTING "Build unit tests [default: ON]" ON)
+endif()
+
+if(ENDO_TESTING)
+    enable_testing()
+endif()
+
 include(EnableCcache)
 include(StaticLinking)
 include(EndoThirdParties)
@@ -143,17 +155,8 @@ if(NOT EMSCRIPTEN AND CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_definitions(-D_GLIBCXX_ASSERTIONS)
 endif()
 
-if(EMSCRIPTEN)
-    set(ENDO_TESTING OFF)
-else()
-    option(ENDO_TESTING "Build unit tests [default: ON]" ON)
-endif()
-
-if(ENDO_TESTING)
-    enable_testing()
-endif()
-
 # crispy is vendored from contour — pass through its testing flag
+# (ENDO_TESTING is defined earlier, before include(EndoThirdParties).)
 set(CONTOUR_TESTING ${ENDO_TESTING})
 
 option(ENDO_BUILTIN_CRARHDUMP "Enable built-in crashdump reporter, say NO to use system wide crashdump collection like coredumpctl [default: ON]" ON)

--- a/cmake/EndoThirdParties.cmake
+++ b/cmake/EndoThirdParties.cmake
@@ -55,7 +55,7 @@ endmacro()
 # ==============================================================================
 # Catch2 v3 - Unit testing framework
 # ==============================================================================
-if(NOT EMSCRIPTEN)
+if(NOT EMSCRIPTEN AND ENDO_TESTING)
     find_package(Catch2 3 QUIET)
     if(TARGET Catch2::Catch2)
         set(THIRDPARTY_BUILTIN_Catch2 "system package")

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -130,7 +130,12 @@ if(ENDO_HAS_LOCAL_LLM)
 endif()
 target_include_directories(endo-agent PUBLIC ${CMAKE_SOURCE_DIR}/src)
 
+# Enable sanitizers and clang-tidy for the production library (always).
+enable_sanitizers(endo-agent)
+enable_clang_tidy(endo-agent)
+
 # Unit tests
+if(ENDO_TESTING)
 add_executable(test-endo-agent
     test_main.cpp
     Types_test.cpp
@@ -221,8 +226,6 @@ add_executable(test-endo-agent
 target_link_libraries(test-endo-agent endo-agent Catch2::Catch2)
 add_test(NAME test-endo-agent COMMAND test-endo-agent)
 
-# Enable sanitizers and clang-tidy
-enable_sanitizers(endo-agent)
-enable_clang_tidy(endo-agent)
 enable_sanitizers(test-endo-agent)
 enable_clang_tidy(test-endo-agent)
+endif()

--- a/src/dap/CMakeLists.txt
+++ b/src/dap/CMakeLists.txt
@@ -26,16 +26,18 @@ add_library(endo-dap STATIC
 target_link_libraries(endo-dap PUBLIC endo-editor-protocol endo nlohmann_json::nlohmann_json CoreVM)
 target_include_directories(endo-dap PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-# Tests
-add_executable(test-endo-dap
-    test_main.cpp
-    DapServer_test.cpp
-)
-target_link_libraries(test-endo-dap endo-dap Catch2::Catch2)
-add_test(NAME test-endo-dap COMMAND test-endo-dap)
-
-# Enable sanitizers and clang-tidy for all targets
+# Enable sanitizers and clang-tidy for the production library (always).
 enable_sanitizers(endo-dap)
 enable_clang_tidy(endo-dap)
-enable_sanitizers(test-endo-dap)
-enable_clang_tidy(test-endo-dap)
+
+# Tests
+if(ENDO_TESTING)
+    add_executable(test-endo-dap
+        test_main.cpp
+        DapServer_test.cpp
+    )
+    target_link_libraries(test-endo-dap endo-dap Catch2::Catch2)
+    add_test(NAME test-endo-dap COMMAND test-endo-dap)
+    enable_sanitizers(test-endo-dap)
+    enable_clang_tidy(test-endo-dap)
+endif()

--- a/src/endo-language/codegen/IRGenerator.cpp
+++ b/src/endo-language/codegen/IRGenerator.cpp
@@ -1562,24 +1562,8 @@ CoreVM::Value* IRGenerator::codegen(ast::Node const* node)
     return _result;
 }
 
-template <typename... Args>
-void IRGenerator::reportTypeError(std::format_string<Args...> f, Args&&... args)
-{
-    auto const msg = std::format(f, std::forward<Args>(args)...);
-    _report.typeError(_builder.sourceLocation(), "{}", std::string_view(msg));
-    _hasErrors = true;
-}
-
-template <typename... Args>
-void IRGenerator::reportTypeErrorWithSuggestions(std::vector<std::string> suggestions,
-                                                 std::format_string<Args...> f,
-                                                 Args&&... args)
-{
-    auto const msg = std::format(f, std::forward<Args>(args)...);
-    _report.typeErrorWithSuggestions(
-        _builder.sourceLocation(), std::move(suggestions), std::nullopt, "{}", std::string_view(msg));
-    _hasErrors = true;
-}
+// reportTypeError / reportTypeErrorWithSuggestions are defined as inline templates in
+// IRGenerator.hpp so that all calling translation units can instantiate them.
 
 std::string IRGenerator::wrappedTypeName(CoreVM::Value* value, uint16_t typeId)
 {

--- a/src/endo-language/codegen/IRGenerator.hpp
+++ b/src/endo-language/codegen/IRGenerator.hpp
@@ -12,6 +12,7 @@
 
 #include <CoreVM/CoreVM.hpp>
 
+#include <format>
 #include <memory>
 #include <optional>
 #include <span>
@@ -1006,5 +1007,29 @@ class IRGenerator final: public ast::Visitor
     /// Keeps body pointers valid until the end of IR generation.
     std::vector<std::unique_ptr<ast::Expr>> _syntheticAST;
 };
+
+// These variadic templates are defined here (not in the .cpp) so that every
+// translation unit that calls them — e.g. HOFCodegen.cpp, OptionCombinatorsCodegen.cpp —
+// can instantiate them. With the definitions in IRGenerator.cpp, instantiations used only
+// by other TUs were never emitted, breaking the link in builds where no test TU happened
+// to force them.
+template <typename... Args>
+void IRGenerator::reportTypeError(std::format_string<Args...> f, Args&&... args)
+{
+    auto const msg = std::format(f, std::forward<Args>(args)...);
+    _report.typeError(_builder.sourceLocation(), "{}", std::string_view(msg));
+    _hasErrors = true;
+}
+
+template <typename... Args>
+void IRGenerator::reportTypeErrorWithSuggestions(std::vector<std::string> suggestions,
+                                                 std::format_string<Args...> f,
+                                                 Args&&... args)
+{
+    auto const msg = std::format(f, std::forward<Args>(args)...);
+    _report.typeErrorWithSuggestions(
+        _builder.sourceLocation(), std::move(suggestions), std::nullopt, "{}", std::string_view(msg));
+    _hasErrors = true;
+}
 
 } // namespace endo

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -11,16 +11,18 @@ add_library(endo-http STATIC
 target_link_libraries(endo-http PUBLIC CURL::libcurl)
 target_include_directories(endo-http PUBLIC ${CMAKE_SOURCE_DIR}/src)
 
-# Unit tests
-add_executable(test-endo-http
-    test_main.cpp
-    HttpClient_test.cpp
-)
-target_link_libraries(test-endo-http endo-http Catch2::Catch2)
-add_test(NAME test-endo-http COMMAND test-endo-http)
-
-# Enable sanitizers and clang-tidy
+# Enable sanitizers and clang-tidy for the production library (always).
 enable_sanitizers(endo-http)
 enable_clang_tidy(endo-http)
-enable_sanitizers(test-endo-http)
-enable_clang_tidy(test-endo-http)
+
+# Unit tests
+if(ENDO_TESTING)
+    add_executable(test-endo-http
+        test_main.cpp
+        HttpClient_test.cpp
+    )
+    target_link_libraries(test-endo-http endo-http Catch2::Catch2)
+    add_test(NAME test-endo-http COMMAND test-endo-http)
+    enable_sanitizers(test-endo-http)
+    enable_clang_tidy(test-endo-http)
+endif()

--- a/src/lsp/CMakeLists.txt
+++ b/src/lsp/CMakeLists.txt
@@ -70,16 +70,18 @@ add_library(endo-lsp STATIC
 target_link_libraries(endo-lsp PUBLIC endo-editor-protocol endo nlohmann_json::nlohmann_json)
 target_include_directories(endo-lsp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-# Tests
-add_executable(test-endo-lsp
-    test_main.cpp
-    LspServer_test.cpp
-)
-target_link_libraries(test-endo-lsp endo-lsp Catch2::Catch2)
-add_test(NAME test-endo-lsp COMMAND test-endo-lsp)
-
-# Enable sanitizers and clang-tidy for all targets
+# Enable sanitizers and clang-tidy for the production library (always).
 enable_sanitizers(endo-lsp)
 enable_clang_tidy(endo-lsp)
-enable_sanitizers(test-endo-lsp)
-enable_clang_tidy(test-endo-lsp)
+
+# Tests
+if(ENDO_TESTING)
+    add_executable(test-endo-lsp
+        test_main.cpp
+        LspServer_test.cpp
+    )
+    target_link_libraries(test-endo-lsp endo-lsp Catch2::Catch2)
+    add_test(NAME test-endo-lsp COMMAND test-endo-lsp)
+    enable_sanitizers(test-endo-lsp)
+    enable_clang_tidy(test-endo-lsp)
+endif()

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -96,23 +96,25 @@ enable_sanitizers(endo-platform)
 enable_clang_tidy(endo-platform)
 
 # Tests
-add_executable(test-endo-platform
-    test_main.cpp
-    PlatformError_test.cpp
-    Process_test.cpp
-    Pipe_test.cpp
-    EnvironmentProvider_test.cpp
-    FileInfoProvider_test.cpp
-    Wakeup_test.cpp
-    MessageQueue_test.cpp
-    ProjectFileTree_test.cpp
-    WindowsPlatform_test.cpp
-    LinuxProcessProvider_test.cpp
-    DarwinProcessProvider_test.cpp
-)
+if(ENDO_TESTING)
+    add_executable(test-endo-platform
+        test_main.cpp
+        PlatformError_test.cpp
+        Process_test.cpp
+        Pipe_test.cpp
+        EnvironmentProvider_test.cpp
+        FileInfoProvider_test.cpp
+        Wakeup_test.cpp
+        MessageQueue_test.cpp
+        ProjectFileTree_test.cpp
+        WindowsPlatform_test.cpp
+        LinuxProcessProvider_test.cpp
+        DarwinProcessProvider_test.cpp
+    )
 
-target_include_directories(test-endo-platform PRIVATE ${CMAKE_SOURCE_DIR}/src)
-target_link_libraries(test-endo-platform endo-platform Catch2::Catch2)
-add_test(NAME test-endo-platform COMMAND test-endo-platform)
-enable_sanitizers(test-endo-platform)
-enable_clang_tidy(test-endo-platform)
+    target_include_directories(test-endo-platform PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_link_libraries(test-endo-platform endo-platform Catch2::Catch2)
+    add_test(NAME test-endo-platform COMMAND test-endo-platform)
+    enable_sanitizers(test-endo-platform)
+    enable_clang_tidy(test-endo-platform)
+endif()

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -259,66 +259,68 @@ set_target_properties(endo-bin PROPERTIES OUTPUT_NAME endo)
 target_link_libraries(endo-bin PUBLIC endo-shell endo-lsp endo-dap)
 enable_static_linking(endo-bin)
 
-add_executable(test-endo-shell
-    test_main.cpp
-    Shell_test.cpp
-    DirectoryConfig_test.cpp
-    builtins/InlineArgParser_test.cpp
-    commands/FindExpression_test.cpp
-    commands/GrepCommand_test.cpp
-    commands/TimeoutCommand_test.cpp
-    commands/PkillCommand_test.cpp
-    ui/PromptComponent_test.cpp
-    ui/modules/GitModule_test.cpp
-    ui/Gradient_test.cpp
-    completion/Completer_test.cpp
-    completion/FSharpCompleter_test.cpp
-    completion/CommandSpecCompleter_test.cpp
-    completion/CompleterFunctionRegistry_test.cpp
-    completion/ScriptedCompleter_test.cpp
-    history/History_test.cpp
-    history/PersistentHistory_test.cpp
-    history/RequiredPaths_test.cpp
-    output/OutputDefinitionRegistry_test.cpp
-    output/OutputParser_test.cpp
-    util/CommandResolver_test.cpp
-    util/Suggestions_test.cpp
-    ui/RichConsoleReport_test.cpp
-    ui/SyntaxHighlighter_test.cpp
-)
-
-if(NOT ENDO_BUILTIN_CRARHDUMP)
-target_sources(test-endo-shell PUBLIC
-  CrashHandler_test.cpp
-)
-endif()
-
-target_link_libraries(test-endo-shell endo-shell Catch2::Catch2)
-target_compile_definitions(test-endo-shell PRIVATE
-    ENDO_DEFINITIONS_DIR="${CMAKE_SOURCE_DIR}/data/definitions"
-    ENDO_COMPLETERS_DIR="${CMAKE_SOURCE_DIR}/data/completers"
-)
-
-add_test(NAME test-endo-shell COMMAND test-endo-shell)
-set_tests_properties(test-endo-shell PROPERTIES TIMEOUT 120)
-if(WIN32)
-    set_tests_properties(test-endo-shell PROPERTIES TIMEOUT 300)
-endif()
-
-# Documentation snippet validation test
-find_package(Python3 COMPONENTS Interpreter QUIET)
-if(Python3_FOUND)
-    add_test(
-        NAME check-doc-snippets
-        COMMAND ${Python3_EXECUTABLE}
-            ${CMAKE_SOURCE_DIR}/scripts/check-doc-snippets.py
-            --endo-path $<TARGET_FILE:endo-bin>
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+if(ENDO_TESTING)
+    add_executable(test-endo-shell
+        test_main.cpp
+        Shell_test.cpp
+        DirectoryConfig_test.cpp
+        builtins/InlineArgParser_test.cpp
+        commands/FindExpression_test.cpp
+        commands/GrepCommand_test.cpp
+        commands/TimeoutCommand_test.cpp
+        commands/PkillCommand_test.cpp
+        ui/PromptComponent_test.cpp
+        ui/modules/GitModule_test.cpp
+        ui/Gradient_test.cpp
+        completion/Completer_test.cpp
+        completion/FSharpCompleter_test.cpp
+        completion/CommandSpecCompleter_test.cpp
+        completion/CompleterFunctionRegistry_test.cpp
+        completion/ScriptedCompleter_test.cpp
+        history/History_test.cpp
+        history/PersistentHistory_test.cpp
+        history/RequiredPaths_test.cpp
+        output/OutputDefinitionRegistry_test.cpp
+        output/OutputParser_test.cpp
+        util/CommandResolver_test.cpp
+        util/Suggestions_test.cpp
+        ui/RichConsoleReport_test.cpp
+        ui/SyntaxHighlighter_test.cpp
     )
-    set_tests_properties(check-doc-snippets PROPERTIES
-        TIMEOUT 120
-        LABELS "docs"
+
+    if(NOT ENDO_BUILTIN_CRARHDUMP)
+        target_sources(test-endo-shell PUBLIC
+            CrashHandler_test.cpp
+        )
+    endif()
+
+    target_link_libraries(test-endo-shell endo-shell Catch2::Catch2)
+    target_compile_definitions(test-endo-shell PRIVATE
+        ENDO_DEFINITIONS_DIR="${CMAKE_SOURCE_DIR}/data/definitions"
+        ENDO_COMPLETERS_DIR="${CMAKE_SOURCE_DIR}/data/completers"
     )
+
+    add_test(NAME test-endo-shell COMMAND test-endo-shell)
+    set_tests_properties(test-endo-shell PROPERTIES TIMEOUT 120)
+    if(WIN32)
+        set_tests_properties(test-endo-shell PROPERTIES TIMEOUT 300)
+    endif()
+
+    # Documentation snippet validation test
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if(Python3_FOUND)
+        add_test(
+            NAME check-doc-snippets
+            COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/scripts/check-doc-snippets.py
+                --endo-path $<TARGET_FILE:endo-bin>
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        )
+        set_tests_properties(check-doc-snippets PROPERTIES
+            TIMEOUT 120
+            LABELS "docs"
+        )
+    endif()
 endif()
 
 # Installation

--- a/src/tui/CMakeLists.txt
+++ b/src/tui/CMakeLists.txt
@@ -73,32 +73,34 @@ enable_clang_tidy(tui)
 set_source_files_properties(StbImageImpl.cpp PROPERTIES COMPILE_OPTIONS "-fno-sanitize=undefined")
 
 # Tests
-add_executable(test-tui
-    test_main.cpp
-    CommandPalettePopup_test.cpp
-    CommandRegistry_test.cpp
-    GenericSyntaxHighlighter_test.cpp
-    InputField_test.cpp
-    KeyBindings_test.cpp
-    Renderer_test.cpp
-    Completer_test.cpp
-    CompletionPopup_test.cpp
-    FuzzyPickerPopup_test.cpp
-    PopupKeyDispatch_test.cpp
-    ScrollableSelection_test.cpp
-    Screen_test.cpp
-    SmartCaseMatch_test.cpp
-    FuzzyMatch_test.cpp
-    MarkdownTable_test.cpp
-    MarkdownRenderer_test.cpp
-    QuestionComponent_test.cpp
-    StyledText_test.cpp
-    Unicode_test.cpp
-    VtParser_test.cpp
-    ImageLoader_test.cpp
-    SemanticBlockClient_test.cpp
-)
-target_link_libraries(test-tui tui Catch2::Catch2)
-add_test(NAME test-tui COMMAND test-tui)
-enable_sanitizers(test-tui)
-enable_clang_tidy(test-tui)
+if(ENDO_TESTING)
+    add_executable(test-tui
+        test_main.cpp
+        CommandPalettePopup_test.cpp
+        CommandRegistry_test.cpp
+        GenericSyntaxHighlighter_test.cpp
+        InputField_test.cpp
+        KeyBindings_test.cpp
+        Renderer_test.cpp
+        Completer_test.cpp
+        CompletionPopup_test.cpp
+        FuzzyPickerPopup_test.cpp
+        PopupKeyDispatch_test.cpp
+        ScrollableSelection_test.cpp
+        Screen_test.cpp
+        SmartCaseMatch_test.cpp
+        FuzzyMatch_test.cpp
+        MarkdownTable_test.cpp
+        MarkdownRenderer_test.cpp
+        QuestionComponent_test.cpp
+        StyledText_test.cpp
+        Unicode_test.cpp
+        VtParser_test.cpp
+        ImageLoader_test.cpp
+        SemanticBlockClient_test.cpp
+    )
+    target_link_libraries(test-tui tui Catch2::Catch2)
+    add_test(NAME test-tui COMMAND test-tui)
+    enable_sanitizers(test-tui)
+    enable_clang_tidy(test-tui)
+endif()


### PR DESCRIPTION
The project already had an `ENDO_TESTING` option (default `ON`, `OFF` on
Emscripten) gating `enable_testing()` and the vendored crispy/vtparser tests,
but it was applied inconsistently: 7 component test executables, the
`check-doc-snippets` test, and the Catch2 dependency itself were built
unconditionally, so `-DENDO_TESTING=OFF` did not actually drop them. This makes
the option apply uniformly, so a no-tests build produces no test targets,
registers no ctest tests, and does not fetch Catch2 — while all production
targets still build.

## Changes

- Move the `ENDO_TESTING` definition above `include(EndoThirdParties)` so the
  Catch2 fetch can be guarded by it (the include previously ran before the
  option was defined).
- Guard the Catch2 fetch with `ENDO_TESTING`.
- Wrap the previously-unconditional test blocks (tui, platform, shell incl.
  `check-doc-snippets`, http, dap, lsp, agent) in `if(ENDO_TESTING)`.
- For http/dap/lsp/agent, keep the production-library
  `enable_sanitizers()`/`enable_clang_tidy()` calls outside the guard so
  production code stays instrumented even when tests are disabled.
- Prerequisite fix: `reportTypeError`/`reportTypeErrorWithSuggestions` were
  variadic templates defined in `IRGenerator.cpp`, so instantiations used only
  by other translation units (the single-`std::string_view` overload in
  HOFCodegen/OptionCombinatorsCodegen) were never emitted. This already broke
  Release links of `endo-bin` regardless of this change (the Debug build linked
  by luck); moving the definitions into the header fixes it and is required for
  the no-tests build to link.

Default builds (`ENDO_TESTING=ON`) are unchanged; `-DENDO_TESTING=OFF` now
cleanly excludes all test compilation.
