### PR TITLE
Fix Windows path casing, cd-to-home, and ~ compaction in the prompt

### DIFF
--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(endo-platform STATIC
     EnvironmentProvider.hpp
     UserPaths.hpp
     PathUtils.hpp
+    PathUtils.cpp
     ProcessProvider.hpp
     ProcessProvider.cpp
     FileSystem.hpp

--- a/src/platform/PathUtils.cpp
+++ b/src/platform/PathUtils.cpp
@@ -2,7 +2,7 @@
 #include <platform/PathUtils.hpp>
 
 #if defined(_WIN32)
-    #include <cctype>
+    #include <cwctype>
     #include <string>
     #include <string_view>
 
@@ -61,11 +61,8 @@ auto canonicalCasePath(std::filesystem::path const& p) -> std::string
         canonical = std::wstring(view);
 
     // The DOS volume name already comes back upper-cased, but normalize it defensively.
-    if (canonical.size() >= 2 && canonical[1] == L':'
-        && std::isalpha(static_cast<unsigned char>(canonical[0])))
-    {
-        canonical[0] = static_cast<wchar_t>(std::toupper(static_cast<unsigned char>(canonical[0])));
-    }
+    if (canonical.size() >= 2 && canonical[1] == L':' && std::iswalpha(static_cast<wint_t>(canonical[0])))
+        canonical[0] = static_cast<wchar_t>(std::towupper(static_cast<wint_t>(canonical[0])));
 
     return normalizePath(std::filesystem::path(canonical));
 #else

--- a/src/platform/PathUtils.cpp
+++ b/src/platform/PathUtils.cpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <platform/PathUtils.hpp>
+
+#if defined(_WIN32)
+    #include <cctype>
+    #include <string>
+    #include <string_view>
+
+    #include <windows.h>
+#endif
+
+namespace endo::platform
+{
+
+auto canonicalCasePath(std::filesystem::path const& p) -> std::string
+{
+#if defined(_WIN32)
+    auto const native = p.wstring();
+    if (native.empty())
+        return normalizePath(p);
+
+    // Open a handle to the path so its canonical, correctly-cased name can be queried.
+    // GetLongPathNameW only expands 8.3 short names — it leaves already-long components
+    // in whatever case they were passed — so it cannot fix the casing the shell needs.
+    // FILE_FLAG_BACKUP_SEMANTICS is required to obtain a handle to a directory.
+    auto* const handle = CreateFileW(native.c_str(),
+                                     0,
+                                     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                     nullptr,
+                                     OPEN_EXISTING,
+                                     FILE_FLAG_BACKUP_SEMANTICS,
+                                     nullptr);
+    if (handle == INVALID_HANDLE_VALUE)
+        return normalizePath(p); // Non-existent path or access failure: fall back.
+
+    auto const flags = FILE_NAME_NORMALIZED | VOLUME_NAME_DOS;
+    auto const needed = GetFinalPathNameByHandleW(handle, nullptr, 0, flags);
+    if (needed == 0)
+    {
+        CloseHandle(handle);
+        return normalizePath(p);
+    }
+
+    auto buffer = std::wstring(needed, L'\0');
+    auto const written = GetFinalPathNameByHandleW(handle, buffer.data(), needed, flags);
+    CloseHandle(handle);
+    if (written == 0 || written >= needed)
+        return normalizePath(p);
+    buffer.resize(written);
+
+    // GetFinalPathNameByHandleW returns an extended-length path. Strip the prefix:
+    //   \\?\C:\dir          -> C:\dir
+    //   \\?\UNC\server\share -> \\server\share
+    auto view = std::wstring_view(buffer);
+    auto canonical = std::wstring {};
+    if (view.starts_with(LR"(\\?\UNC\)"))
+        canonical = L"\\\\" + std::wstring(view.substr(8));
+    else if (view.starts_with(LR"(\\?\)"))
+        canonical = std::wstring(view.substr(4));
+    else
+        canonical = std::wstring(view);
+
+    // The DOS volume name already comes back upper-cased, but normalize it defensively.
+    if (canonical.size() >= 2 && canonical[1] == L':'
+        && std::isalpha(static_cast<unsigned char>(canonical[0])))
+    {
+        canonical[0] = static_cast<wchar_t>(std::toupper(static_cast<unsigned char>(canonical[0])));
+    }
+
+    return normalizePath(std::filesystem::path(canonical));
+#else
+    return normalizePath(p);
+#endif
+}
+
+} // namespace endo::platform

--- a/src/platform/PathUtils.cpp
+++ b/src/platform/PathUtils.cpp
@@ -3,8 +3,10 @@
 
 #if defined(_WIN32)
     #include <cwctype>
+    #include <memory>
     #include <string>
     #include <string_view>
+    #include <type_traits>
 
     #include <windows.h>
 #endif
@@ -23,27 +25,27 @@ auto canonicalCasePath(std::filesystem::path const& p) -> std::string
     // GetLongPathNameW only expands 8.3 short names — it leaves already-long components
     // in whatever case they were passed — so it cannot fix the casing the shell needs.
     // FILE_FLAG_BACKUP_SEMANTICS is required to obtain a handle to a directory.
-    auto* const handle = CreateFileW(native.c_str(),
-                                     0,
-                                     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                                     nullptr,
-                                     OPEN_EXISTING,
-                                     FILE_FLAG_BACKUP_SEMANTICS,
-                                     nullptr);
-    if (handle == INVALID_HANDLE_VALUE)
+    auto* const rawHandle = CreateFileW(native.c_str(),
+                                        0,
+                                        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                        nullptr,
+                                        OPEN_EXISTING,
+                                        FILE_FLAG_BACKUP_SEMANTICS,
+                                        nullptr);
+    if (rawHandle == INVALID_HANDLE_VALUE)
         return normalizePath(p); // Non-existent path or access failure: fall back.
 
+    // Own the handle via RAII so it is closed on every return path (including exceptions).
+    auto const handle =
+        std::unique_ptr<std::remove_pointer_t<HANDLE>, decltype(&CloseHandle)>(rawHandle, &CloseHandle);
+
     auto const flags = FILE_NAME_NORMALIZED | VOLUME_NAME_DOS;
-    auto const needed = GetFinalPathNameByHandleW(handle, nullptr, 0, flags);
+    auto const needed = GetFinalPathNameByHandleW(handle.get(), nullptr, 0, flags);
     if (needed == 0)
-    {
-        CloseHandle(handle);
         return normalizePath(p);
-    }
 
     auto buffer = std::wstring(needed, L'\0');
-    auto const written = GetFinalPathNameByHandleW(handle, buffer.data(), needed, flags);
-    CloseHandle(handle);
+    auto const written = GetFinalPathNameByHandleW(handle.get(), buffer.data(), needed, flags);
     if (written == 0 || written >= needed)
         return normalizePath(p);
     buffer.resize(written);

--- a/src/platform/PathUtils.hpp
+++ b/src/platform/PathUtils.hpp
@@ -35,6 +35,24 @@ namespace endo::platform
     return p.generic_string();
 }
 
+/// @brief Returns a path with its real on-disk capitalization and forward slashes.
+///
+/// On Windows the working directory and user-typed paths preserve whatever case was
+/// entered (e.g. `GetCurrentDirectoryW` echoes the case passed to `SetCurrentDirectory`),
+/// which differs from how the path is actually stored on disk. This helper resolves the
+/// path to its canonical, correctly-cased form (via `GetFinalPathNameByHandleW`) and
+/// upper-cases a leading drive letter, then normalizes separators to forward slashes.
+/// Unlike normalizePath() this is a filesystem-touching operation — the path must exist
+/// to be recased; if it does not exist or the lookup fails, it falls back to a plain
+/// normalizePath().
+///
+/// On POSIX this is equivalent to normalizePath(): the filesystem is case-sensitive, so a
+/// path's spelling is already its canonical case.
+///
+/// @param p The path to canonicalize.
+/// @return The path with on-disk capitalization and forward slashes.
+[[nodiscard]] auto canonicalCasePath(std::filesystem::path const& p) -> std::string;
+
 /// @brief Resolves POSIX-style device paths to their platform-native equivalent.
 ///
 /// Endo accepts POSIX device paths (`/dev/null`) across all platforms for portability.

--- a/src/platform/WindowsPlatform_test.cpp
+++ b/src/platform/WindowsPlatform_test.cpp
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
 #include <array>
+#include <cctype>
 #include <cstdlib>
+#include <filesystem>
+#include <string>
 #include <string_view>
+#include <system_error>
 
 #include <platform/PathUtils.hpp>
 #include <platform/Types.hpp>
@@ -83,6 +88,48 @@ TEST_CASE("resolveDevicePath.similar_but_not_null_device", "[platform]")
     CHECK(resolveDevicePath("/dev/zero") == "/dev/zero");
     CHECK(resolveDevicePath("null") == "null");
 }
+
+TEST_CASE("canonicalCasePath.nonexistent_path_falls_back_to_normalize", "[platform]")
+{
+    // A path that does not exist on disk cannot be recased, so the helper must fall
+    // back to a plain separator normalization rather than failing.
+#if defined(_WIN32)
+    CHECK(canonicalCasePath(std::filesystem::path("C:\\does\\not\\exist_endo_xyz"))
+          == "C:/does/not/exist_endo_xyz");
+#else
+    CHECK(canonicalCasePath(std::filesystem::path("/does/not/exist_endo_xyz")) == "/does/not/exist_endo_xyz");
+#endif
+}
+
+#if defined(_WIN32)
+TEST_CASE("canonicalCasePath.corrects_case_and_uppercases_drive", "[platform]")
+{
+    namespace fs = std::filesystem;
+    auto const dirName = std::string("EndoCanonCaseTEST_dir");
+    auto const dir = fs::temp_directory_path() / dirName;
+
+    std::error_code ec;
+    fs::create_directory(dir, ec);
+    REQUIRE_FALSE(ec);
+
+    // Spell the existing directory entirely in lower case (including its drive letter)
+    // to simulate a user-typed path that disagrees with the on-disk capitalization.
+    auto wrongCase = canonicalCasePath(dir);
+    std::ranges::transform(
+        wrongCase, wrongCase.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    auto const result = canonicalCasePath(fs::path(wrongCase));
+    auto const lastComponent = result.substr(result.rfind('/') + 1);
+
+    REQUIRE(result.size() >= 2);
+    CHECK(result[1] == ':');
+    CHECK(std::isupper(static_cast<unsigned char>(result[0])) != 0); // Drive letter upper-cased.
+    CHECK(result.find('\\') == std::string::npos);                   // Forward slashes only.
+    CHECK(lastComponent == dirName);                                 // Real on-disk component case.
+
+    fs::remove(dir, ec);
+}
+#endif
 
 TEST_CASE("homeDirectory.returns_value_when_HOME_set", "[platform]")
 {

--- a/src/platform/windows/WindowsEnvironmentProvider.cpp
+++ b/src/platform/windows/WindowsEnvironmentProvider.cpp
@@ -3,13 +3,13 @@
 
 #if defined(_WIN32)
 
-    #include <platform/PathUtils.hpp>
-
     #include <algorithm>
     #include <cctype>
     #include <filesystem>
 
     #include <windows.h>
+
+    #include <platform/PathUtils.hpp>
 
 namespace endo::platform
 {
@@ -117,7 +117,10 @@ std::expected<void, PlatformError> WindowsEnvironmentProvider::changeDirectory(
 
 std::string WindowsEnvironmentProvider::currentDirectory() const
 {
-    return normalizePath(std::filesystem::current_path());
+    // Report the real on-disk capitalization (and an upper-case drive letter) so that
+    // PWD and the prompt agree with how the directory is actually stored, rather than
+    // echoing whatever case was passed to SetCurrentDirectory.
+    return canonicalCasePath(std::filesystem::current_path());
 }
 
 } // namespace endo::platform

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -272,6 +272,7 @@ if(ENDO_TESTING)
         commands/PkillCommand_test.cpp
         ui/PromptComponent_test.cpp
         ui/modules/GitModule_test.cpp
+        ui/modules/PathModule_test.cpp
         ui/Gradient_test.cpp
         completion/Completer_test.cpp
         completion/FSharpCompleter_test.cpp

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -1283,6 +1283,43 @@ namespace
     }
 } // namespace
 
+void Shell::updatePromptContext()
+{
+    auto ctx = PromptContext {};
+    // Canonicalize on-disk capitalization so the prompt shows the real path case
+    // (e.g. "D:/Lastrada" after `cd d:/lastrada`) rather than the typed case.
+    ctx.cwd = platform::canonicalCasePath(_fs.currentPath());
+    emitWindowTitle(ctx.cwd);
+    // Resolve home via the environment abstraction (HOME, then USERPROFILE on Windows)
+    // and canonicalize it the same way as cwd, so the tilde-contraction prefix match in
+    // PathModule compares matching separators and case.
+    if (auto const home = _env.homeDirectory())
+        ctx.homePath = platform::canonicalCasePath(*home);
+    ctx.lastExitCode = _exitCode;
+    ctx.lastDuration = _lastCommandDuration;
+    ctx.terminalWidth = prompt.terminal().columns();
+    ctx.isSSH = std::getenv("SSH_CONNECTION") != nullptr;
+    if (ctx.isSSH)
+    {
+        auto buf = std::array<char, 256> {};
+#if defined(_WIN32)
+        DWORD bufLen = static_cast<DWORD>(buf.size());
+        if (GetComputerNameA(buf.data(), &bufLen))
+            ctx.hostname = buf.data();
+#else
+        if (gethostname(buf.data(), buf.size()) == 0)
+            ctx.hostname = buf.data();
+#endif
+    }
+    ctx.theme = &tui::currentTheme();
+    ctx.fsharpState = &_fsharpState;
+    ctx.outputDefs = &_outputDefinitions;
+    ctx.shellLevel = _shellLevel;
+    ctx.cellPixelWidth = prompt.terminal().cellPixelWidth();
+    ctx.cellPixelHeight = prompt.terminal().cellPixelHeight();
+    prompt.setPromptContext(std::move(ctx));
+}
+
 int Shell::run()
 {
     if (_interactive && !_tty.isTerminal())
@@ -1376,40 +1413,7 @@ int Shell::run()
         emitPromptStart();
 
         // Populate prompt context for module evaluation
-        {
-            auto ctx = PromptContext {};
-            ctx.cwd = platform::normalizePath(_fs.currentPath());
-            emitWindowTitle(ctx.cwd);
-            if (auto const* home = std::getenv("HOME"))
-                ctx.homePath = home;
-    #if defined(_WIN32)
-            else if (auto const* userProfile = std::getenv("USERPROFILE"))
-                ctx.homePath = userProfile;
-    #endif
-            ctx.lastExitCode = _exitCode;
-            ctx.lastDuration = _lastCommandDuration;
-            ctx.terminalWidth = prompt.terminal().columns();
-            ctx.isSSH = std::getenv("SSH_CONNECTION") != nullptr;
-            if (ctx.isSSH)
-            {
-                auto buf = std::array<char, 256> {};
-    #if defined(_WIN32)
-                DWORD bufLen = static_cast<DWORD>(buf.size());
-                if (GetComputerNameA(buf.data(), &bufLen))
-                    ctx.hostname = buf.data();
-    #else
-                if (gethostname(buf.data(), buf.size()) == 0)
-                    ctx.hostname = buf.data();
-    #endif
-            }
-            ctx.theme = &tui::currentTheme();
-            ctx.fsharpState = &_fsharpState;
-            ctx.outputDefs = &_outputDefinitions;
-            ctx.shellLevel = _shellLevel;
-            ctx.cellPixelWidth = prompt.terminal().cellPixelWidth();
-            ctx.cellPixelHeight = prompt.terminal().cellPixelHeight();
-            prompt.setPromptContext(std::move(ctx));
-        }
+        updatePromptContext();
 
         // Display the prompt before waiting for input
         prompt.display();
@@ -1510,33 +1514,7 @@ int Shell::run()
         emitPromptStart();
 
         // Populate prompt context for module evaluation
-        {
-            auto ctx = PromptContext {};
-            ctx.cwd = platform::normalizePath(_fs.currentPath());
-            emitWindowTitle(ctx.cwd);
-            if (auto const* home = std::getenv("HOME"))
-                ctx.homePath = home;
-            else if (auto const* userProfile = std::getenv("USERPROFILE"))
-                ctx.homePath = userProfile;
-            ctx.lastExitCode = _exitCode;
-            ctx.lastDuration = _lastCommandDuration;
-            ctx.terminalWidth = prompt.terminal().columns();
-            ctx.isSSH = std::getenv("SSH_CONNECTION") != nullptr;
-            if (ctx.isSSH)
-            {
-                auto buf = std::array<char, 256> {};
-                DWORD bufLen = static_cast<DWORD>(buf.size());
-                if (GetComputerNameA(buf.data(), &bufLen))
-                    ctx.hostname = buf.data();
-            }
-            ctx.theme = &tui::currentTheme();
-            ctx.fsharpState = &_fsharpState;
-            ctx.outputDefs = &_outputDefinitions;
-            ctx.shellLevel = _shellLevel;
-            ctx.cellPixelWidth = prompt.terminal().cellPixelWidth();
-            ctx.cellPixelHeight = prompt.terminal().cellPixelHeight();
-            prompt.setPromptContext(std::move(ctx));
-        }
+        updatePromptContext();
 
         // Display the prompt before waiting for input
         prompt.display();

--- a/src/shell/Shell.hpp
+++ b/src/shell/Shell.hpp
@@ -548,6 +548,14 @@ class Shell final: public SignalCallback
     /// Control characters (C0, DEL, C1) are stripped to prevent escape injection.
     void emitWindowTitle(std::string_view title);
 
+    /// @brief Builds the prompt rendering context and hands it to the prompt component.
+    ///
+    /// Populates a PromptContext with the canonical-cased working directory, the
+    /// tilde-contraction home path, exit/timing state, terminal geometry and theme,
+    /// then calls prompt.setPromptContext(). Shared by the POSIX and Windows REPL
+    /// loops so both render identical context.
+    void updatePromptContext();
+
     template <typename... Args>
     void error(std::format_string<Args...> const& message, Args&&... args)
     {

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -101,6 +101,35 @@ TEST_CASE("shell.cd.home")
     CHECK(shell.env.get("PWD").value_or("") == "/home/testuser");
 }
 
+TEST_CASE("shell.cd.home_falls_back_to_USERPROFILE")
+{
+    // Regression: on Windows HOME is unset and USERPROFILE names the home directory.
+    // Bare `cd` must resolve through homeDirectory() (HOME, then USERPROFILE) rather
+    // than falling back to the drive root.
+    TestShell shell;
+    // TestShell seeds HOME from the real environment so external commands resolve;
+    // clear it here so USERPROFILE is the only home source under test.
+    shell.env.unset("HOME");
+    shell.env.set("USERPROFILE", "/home/winuser");
+    shell.env.addValidPath("/home/winuser");
+    shell("cd");
+    CHECK(shell.exitCode == 0);
+    CHECK(shell.env.get("PWD").value_or("") == "/home/winuser");
+}
+
+TEST_CASE("shell.cd.home_errors_when_no_home_set")
+{
+    // Neither HOME nor USERPROFILE set: bare `cd` reports an error instead of
+    // silently changing to the filesystem root.
+    TestShell shell;
+    // TestShell seeds HOME from the real environment; clear both home sources so
+    // bare `cd` has nothing to resolve and must report an error.
+    shell.env.unset("HOME");
+    shell.env.unset("USERPROFILE");
+    shell("cd");
+    CHECK(shell.exitCode == 1);
+}
+
 TEST_CASE("shell.cd.minus")
 {
     TestShell shell;
@@ -3041,7 +3070,8 @@ TEST_CASE("FileCompleter.prefix_match_scores_higher_than_fuzzy")
     auto originalDir = std::filesystem::current_path();
     std::filesystem::current_path(tempDir);
 
-    endo::FileCompleter completer;
+    endo::TestEnvironment env;
+    endo::FileCompleter completer(env);
 
     // Complete "sr" - should match both "src" (prefix) and "scripts" (fuzzy)
     endo::CompletionContext context {

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -3105,6 +3105,38 @@ TEST_CASE("FileCompleter.prefix_match_scores_higher_than_fuzzy")
     CHECK_FALSE(results[1].matchPositions.empty());
 }
 
+TEST_CASE("FileCompleter.relative_prefix_stays_relative")
+{
+    // Regression: a relative nested prefix (e.g. "sub/it") must keep its relative
+    // form in the completion. On Windows, canonicalizing the parent directory would
+    // resolve it to an absolute path and rewrite the user's typed relative prefix.
+    auto const tempDir = std::filesystem::temp_directory_path() / "endo_rel_completion";
+    std::filesystem::create_directories(tempDir / "sub");
+    {
+        std::ofstream(tempDir / "sub" / "item.txt");
+    }
+
+    auto const originalDir = std::filesystem::current_path();
+    std::filesystem::current_path(tempDir);
+
+    endo::TestEnvironment env;
+    endo::FileCompleter completer(env);
+
+    endo::CompletionContext context {
+        .type = endo::CompletionContextType::FilePath,
+        .prefix = "sub/it",
+        .cursorPosition = 6,
+        .fullInput = "cd sub/it",
+    };
+    auto const results = completer.complete(context);
+
+    std::filesystem::current_path(originalDir);
+    std::filesystem::remove_all(tempDir);
+
+    REQUIRE(results.size() == 1);
+    CHECK(results[0].text == "sub/item.txt"); // Relative, not an absolute path.
+}
+
 // ========================================================================
 // String Interpolation Tests
 // ========================================================================

--- a/src/shell/builtins/Environment.cpp
+++ b/src/shell/builtins/Environment.cpp
@@ -57,7 +57,19 @@ void Shell::builtinChDir(CoreVM::Params& context)
 
 void Shell::builtinChDirHome(CoreVM::Params& context)
 {
-    applyDirectoryChange(_env.get("HOME").value_or("/"), context);
+    // Resolve the home directory through the environment abstraction, which tries HOME
+    // first (Unix) and then USERPROFILE (Windows). Falling back to "/" here would send
+    // Windows users to the drive root instead of their home directory.
+    auto const home = _env.homeDirectory();
+    if (!home.has_value())
+    {
+        error("cd: HOME not set");
+        _exitCode = 1;
+        context.setResult(false);
+        return;
+    }
+
+    applyDirectoryChange(*home, context);
 }
 
 void Shell::applyDirectoryChange(std::filesystem::path const& path, CoreVM::Params& context)

--- a/src/shell/completion/Completer.cpp
+++ b/src/shell/completion/Completer.cpp
@@ -55,7 +55,7 @@ Completer::Completer(EnvironmentProvider const& env,
 
     _providers.push_back(std::make_unique<LetBindingCompleter>(fsharpState));
     _providers.push_back(std::make_unique<VariableCompleter>(env));
-    _providers.push_back(std::make_unique<FileCompleter>());
+    _providers.push_back(std::make_unique<FileCompleter>(env));
     _providers.push_back(std::make_unique<HistoryCompleter>(history, env, fs));
 
     // Sort by priority (highest first)

--- a/src/shell/completion/FileCompleter.cpp
+++ b/src/shell/completion/FileCompleter.cpp
@@ -7,17 +7,19 @@
 #include <tui/completer/SmartCaseMatch.hpp>
 
 #include <algorithm>
-#include <cstdlib>
 
 #include <platform/PathUtils.hpp>
 
 #if !defined(_WIN32)
     #include <pwd.h>
-    #include <unistd.h>
 #endif
 
 namespace endo
 {
+
+FileCompleter::FileCompleter(EnvironmentProvider const& env): _env(env)
+{
+}
 
 std::vector<CompletionItem> FileCompleter::complete(CompletionContext const& context)
 {
@@ -108,7 +110,9 @@ std::vector<CompletionItem> FileCompleter::complete(CompletionContext const& con
             }
             else
             {
-                pathPrefix = platform::normalizePath(dir);
+                // Use the on-disk capitalization (and upper-case drive letter on Windows)
+                // so the completed prefix matches the real path, not the user's typed case.
+                pathPrefix = platform::canonicalCasePath(dir);
                 if (!pathPrefix.empty() && pathPrefix.back() != '/')
                     pathPrefix += '/';
             }
@@ -128,7 +132,7 @@ bool FileCompleter::canHandle(CompletionContextType type) const
            || type == CompletionContextType::Redirect;
 }
 
-std::filesystem::path FileCompleter::expandTilde(std::string_view path)
+std::filesystem::path FileCompleter::expandTilde(std::string_view path) const
 {
     if (path.empty() || path[0] != '~')
         return std::filesystem::path(path);
@@ -137,27 +141,14 @@ std::filesystem::path FileCompleter::expandTilde(std::string_view path)
 
     if (path.size() == 1 || path[1] == '/')
     {
-        // ~ or ~/... - current user's home
-#if defined(_WIN32)
-        if (char const* home = std::getenv("HOME"))
-        {
-            result = home;
-        }
-        else if (char const* userProfile = std::getenv("USERPROFILE"))
-        {
-            result = userProfile;
-        }
-#else
-        if (char const* home = std::getenv("HOME"))
-        {
-            result = home;
-        }
-        else if (struct passwd* pw = getpwuid(getuid()))
-        {
-            result = pw->pw_dir;
-        }
-#endif
+        // ~ or ~/... - current user's home, resolved through the environment
+        // abstraction (HOME, then USERPROFILE on Windows) so home resolution is
+        // centralized and matches the rest of the shell.
+        auto const home = _env.homeDirectory();
+        if (!home.has_value())
+            return std::filesystem::path(path); // No home set: leave the path unchanged.
 
+        result = home->string();
         if (path.size() > 1)
             result += std::string(path.substr(1));
     }

--- a/src/shell/completion/FileCompleter.cpp
+++ b/src/shell/completion/FileCompleter.cpp
@@ -112,7 +112,11 @@ std::vector<CompletionItem> FileCompleter::complete(CompletionContext const& con
             {
                 // Use the on-disk capitalization (and upper-case drive letter on Windows)
                 // so the completed prefix matches the real path, not the user's typed case.
-                pathPrefix = platform::canonicalCasePath(dir);
+                // Only canonicalize absolute paths: canonicalCasePath() resolves to an
+                // absolute path, which would otherwise rewrite a relative prefix the user
+                // typed (e.g. "foo/") into an absolute one.
+                pathPrefix =
+                    dir.is_absolute() ? platform::canonicalCasePath(dir) : platform::normalizePath(dir);
                 if (!pathPrefix.empty() && pathPrefix.back() != '/')
                     pathPrefix += '/';
             }
@@ -148,7 +152,7 @@ std::filesystem::path FileCompleter::expandTilde(std::string_view path) const
         if (!home.has_value())
             return std::filesystem::path(path); // No home set: leave the path unchanged.
 
-        result = home->string();
+        result = platform::normalizePath(*home); // Forward slashes, matching the rest.
         if (path.size() > 1)
             result += std::string(path.substr(1));
     }

--- a/src/shell/completion/FileCompleter.hpp
+++ b/src/shell/completion/FileCompleter.hpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include <platform/EnvironmentProvider.hpp>
+
 namespace endo
 {
 
@@ -14,6 +16,11 @@ namespace endo
 class FileCompleter: public CompletionProvider
 {
   public:
+    /// @brief Constructs a file completer.
+    /// @param env Environment abstraction used to resolve the user's home directory
+    ///            for tilde (`~`) expansion.
+    explicit FileCompleter(EnvironmentProvider const& env);
+
     [[nodiscard]] std::vector<CompletionItem> complete(CompletionContext const& context) override;
     [[nodiscard]] bool canHandle(CompletionContextType type) const override;
 
@@ -23,8 +30,10 @@ class FileCompleter: public CompletionProvider
     [[nodiscard]] static std::string escapeForShell(std::string_view path);
 
   private:
+    EnvironmentProvider const& _env;
+
     /// @brief Expands tilde to home directory.
-    [[nodiscard]] static std::filesystem::path expandTilde(std::string_view path);
+    [[nodiscard]] std::filesystem::path expandTilde(std::string_view path) const;
 
     /// @brief Checks if a filename is hidden (starts with dot).
     [[nodiscard]] static bool isHidden(std::string_view name);

--- a/src/shell/ui/modules/PathModule.cpp
+++ b/src/shell/ui/modules/PathModule.cpp
@@ -4,15 +4,44 @@
 
 #include <tui/Theme.hpp>
 
+#include <algorithm>
+#include <cctype>
+#include <string_view>
+
 namespace endo
 {
+
+namespace
+{
+    /// @brief Tests whether @p path begins with @p prefix.
+    ///
+    /// On Windows the comparison is case-insensitive, matching the case-insensitive
+    /// filesystem (the home directory and cwd may differ in case despite being equal).
+    /// On POSIX it is an exact prefix test.
+    ///
+    /// @param path   The full path to test.
+    /// @param prefix The candidate prefix.
+    /// @return True if @p path starts with @p prefix.
+    [[nodiscard]] bool startsWithPath(std::string_view path, std::string_view prefix)
+    {
+        if (prefix.size() > path.size())
+            return false;
+#if defined(_WIN32)
+        return std::ranges::equal(path.substr(0, prefix.size()), prefix, [](char a, char b) {
+            return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b));
+        });
+#else
+        return path.starts_with(prefix);
+#endif
+    }
+} // namespace
 
 PromptSegments PathModule::evaluate(PromptContext const& ctx) const
 {
     auto path = ctx.cwd;
 
     // Tilde-contract home directory
-    if (!ctx.homePath.empty() && path.starts_with(ctx.homePath))
+    if (!ctx.homePath.empty() && startsWithPath(path, ctx.homePath))
     {
         path = "~" + path.substr(ctx.homePath.size());
         if (path.size() > 1 && path[1] != '/')

--- a/src/shell/ui/modules/PathModule_test.cpp
+++ b/src/shell/ui/modules/PathModule_test.cpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <utility>
+
+#include "PathModule.hpp"
+
+using namespace endo;
+
+namespace
+{
+
+/// @brief Renders a PathModule for the given cwd/home and returns the resulting text.
+[[nodiscard]] std::string renderPath(std::string cwd, std::string homePath)
+{
+    auto ctx = PromptContext {};
+    ctx.cwd = std::move(cwd);
+    ctx.homePath = std::move(homePath);
+    auto const segments = PathModule {}.evaluate(ctx);
+    REQUIRE(segments.size() == 1);
+    return segments.front().text;
+}
+
+} // namespace
+
+TEST_CASE("PathModule.contracts_home_to_tilde")
+{
+    CHECK(renderPath("/home/alice/projects", "/home/alice") == "~/projects");
+    CHECK(renderPath("/home/alice", "/home/alice") == "~");
+}
+
+TEST_CASE("PathModule.leaves_non_home_paths_unchanged")
+{
+    CHECK(renderPath("/usr/local/bin", "/home/alice") == "/usr/local/bin");
+}
+
+TEST_CASE("PathModule.does_not_contract_partial_component_match")
+{
+    // "/home/alice2" shares a textual prefix with home "/home/alice" but is a
+    // different directory, so it must be left intact (not rendered as "~2").
+    CHECK(renderPath("/home/alice2", "/home/alice") == "/home/alice2");
+}
+
+TEST_CASE("PathModule.no_home_path_leaves_cwd_unchanged")
+{
+    CHECK(renderPath("/home/alice", "") == "/home/alice");
+}
+
+#if defined(_WIN32)
+TEST_CASE("PathModule.contracts_home_case_insensitively_on_windows")
+{
+    // On Windows the filesystem is case-insensitive, so cwd and home may differ in
+    // case while naming the same directory; contraction must still apply.
+    CHECK(renderPath("C:/Users/Alice/Documents", "c:/users/alice") == "~/Documents");
+}
+#endif


### PR DESCRIPTION
On Windows the shell mishandled paths in three visible ways: the prompt and `$PWD` showed whatever case the user typed (e.g. `d:/lastrada`) instead of the real on-disk `D:/Lastrada`; bare `cd` changed to the drive root `C:/` instead of the user's home directory; and the home directory was never contracted to `~` in the prompt the way it is on Unix. The root causes were that `GetCurrentDirectoryW` echoes the case passed to `SetCurrentDirectory` rather than the on-disk case, that `cd` with no argument fell back to `"/"` when `HOME` was unset (the normal Windows case, where `USERPROFILE` holds the home path), and that the prompt's home-prefix comparison used mismatched separators and case.

## Changes

- Add `platform::canonicalCasePath()`, which resolves a path to its real on-disk capitalization via `GetFinalPathNameByHandleW`, upper-cases a leading drive letter, and normalizes separators (a no-op normalize on POSIX, where the filesystem is case-sensitive).
- Use it for the prompt's working directory, `WindowsEnvironmentProvider::currentDirectory()` (so `$PWD` agrees), and the completed path prefix in `FileCompleter` — so completion offers the canonical case too.
- Resolve bare `cd` through `EnvironmentProvider::homeDirectory()` (HOME, then USERPROFILE), erroring if neither is set, instead of defaulting to the drive root.
- Derive the prompt's home path the same way and make `PathModule`'s tilde-contraction prefix test case-insensitive on Windows, so `~` compaction works.
- Extract the prompt-context block, which was duplicated across the POSIX and Windows REPL loops, into `Shell::updatePromptContext()` so both share one path — the duplication was why the casing fix initially failed to reach Windows.
- Centralize `FileCompleter`'s tilde expansion through the injected `EnvironmentProvider` instead of raw `getenv`.