### PR TITLE
Add PowerShell, CMD, XML, and INI syntax highlighting

### DIFF
--- a/docs/shell/builtins.md
+++ b/docs/shell/builtins.md
@@ -355,7 +355,14 @@ cat [OPTIONS] [FILE...]
 
 **Description:** Reads files sequentially and writes their contents to standard output. If
 no files are given (or when FILE is `-`), reads from standard input. When output goes to a
-terminal, syntax highlighting is applied automatically based on the file extension.
+terminal, syntax highlighting is applied automatically based on the file name.
+
+Highlighting is supported for C/C++ (and C-family languages such as JavaScript, TypeScript,
+Rust, Go), Python, Bash, CMake, Markdown, JSON, YAML, x86 assembly, Git diffs, PowerShell
+(`.ps1`, `.psm1`, `.psd1`), Windows CMD/batch (`.cmd`, `.bat`), XML and XML-based dialects
+(`.xml`, `.props`, `.csproj`, `.targets`, `.vcxproj`, `.xaml`, `.svg`, …), INI (`.ini`), and
+Endo (`.endo`). A few well-known files are recognized by name rather than extension: `.clang-format`,
+`.clang-tidy`, and `.endo-format` are highlighted as YAML, and `.editorconfig` as INI.
 
 **Options:**
 

--- a/src/tui/GenericSyntaxHighlighter.cpp
+++ b/src/tui/GenericSyntaxHighlighter.cpp
@@ -370,6 +370,35 @@ namespace
         "size",   "skip",  "space",        "string", "text",  "type",    "weak", "word",    "zero",
     });
 
+    // PowerShell keywords (sorted, lowercase — matched case-insensitively)
+    constexpr auto powershellKeywords = std::to_array<std::string_view>({
+        "begin",        "break",   "catch",   "class",    "continue", "data",   "define",   "do",
+        "dynamicparam", "else",    "elseif",  "end",      "enum",     "exit",   "filter",   "finally",
+        "for",          "foreach", "from",    "function", "hidden",   "if",     "in",       "inlinescript",
+        "parallel",     "param",   "process", "return",   "sequence", "static", "switch",   "throw",
+        "trap",         "try",     "until",   "using",    "var",      "while",  "workflow",
+    });
+
+    // PowerShell word operators (sorted, lowercase, stored without the leading dash)
+    constexpr auto powershellOperators = std::to_array<std::string_view>({
+        "and",      "as",        "band",     "bnot",        "bor",    "bxor",    "ccontains", "ceq",
+        "cge",      "cgt",       "cle",      "clike",       "clt",    "cmatch",  "cne",       "cnotcontains",
+        "cnotlike", "cnotmatch", "contains", "creplace",    "csplit", "eq",      "f",         "ge",
+        "gt",       "in",        "is",       "isnot",       "join",   "le",      "like",      "lt",
+        "match",    "ne",        "not",      "notcontains", "notin",  "notlike", "notmatch",  "or",
+        "replace",  "shl",       "shr",      "split",       "xor",
+    });
+
+    // Windows CMD / batch keywords (sorted, lowercase — matched case-insensitively)
+    constexpr auto cmdKeywords = std::to_array<std::string_view>({
+        "assoc",    "break",  "call",  "cd",    "chdir",  "cls",      "color",  "copy",   "date",
+        "defined",  "del",    "dir",   "echo",  "else",   "endlocal", "equ",    "erase",  "errorlevel",
+        "exist",    "exit",   "for",   "ftype", "geq",    "goto",     "gtr",    "if",     "in",
+        "leq",      "lss",    "md",    "mkdir", "mklink", "move",     "neq",    "not",    "pause",
+        "popd",     "prompt", "pushd", "rd",    "rem",    "ren",      "rename", "rmdir",  "set",
+        "setlocal", "shift",  "start", "time",  "title",  "type",     "ver",    "verify", "vol",
+    });
+
     /// @brief Converts an identifier to lowercase into a stack buffer and returns a string_view.
     /// @param src The source identifier.
     /// @param buf Buffer of at least src.size() characters.
@@ -1654,32 +1683,649 @@ namespace
         return { std::move(map), state };
     }
 
+    // -------------------------------------------------------------------------
+    // PowerShell highlighter
+    // -------------------------------------------------------------------------
+
+    /// @brief Highlights a line of PowerShell, tracking <# … #> block comments via state.
+    auto highlightPowerShell(std::string_view line, HighlightState state)
+        -> std::pair<HighlightMap, HighlightState>
+    {
+        auto const len = line.size();
+        auto map = HighlightMap(len, HighlightCategory::Default);
+        auto pos = std::size_t { 0 };
+
+        // Continue a <# … #> block comment carried over from the previous line.
+        if (state == HighlightState::PsBlockComment)
+        {
+            while (pos < len)
+            {
+                if (pos + 1 < len && line[pos] == '#' && line[pos + 1] == '>')
+                {
+                    map[pos] = HighlightCategory::Comment;
+                    map[pos + 1] = HighlightCategory::Comment;
+                    pos += 2;
+                    state = HighlightState::Normal;
+                    break;
+                }
+                map[pos] = HighlightCategory::Comment;
+                ++pos;
+            }
+            if (state == HighlightState::PsBlockComment)
+                return { std::move(map), state };
+        }
+
+        while (pos < len)
+        {
+            auto const ch = line[pos];
+
+            // Block comment: <# … #>
+            if (ch == '<' && pos + 1 < len && line[pos + 1] == '#')
+            {
+                auto const start = pos;
+                pos += 2;
+                state = HighlightState::PsBlockComment;
+                while (pos < len)
+                {
+                    if (pos + 1 < len && line[pos] == '#' && line[pos + 1] == '>')
+                    {
+                        pos += 2;
+                        state = HighlightState::Normal;
+                        break;
+                    }
+                    ++pos;
+                }
+                fillRange(map, start, pos - start, HighlightCategory::Comment);
+                continue;
+            }
+
+            // Line comment: #
+            if (ch == '#')
+            {
+                fillRange(map, pos, len - pos, HighlightCategory::Comment);
+                return { std::move(map), HighlightState::Normal };
+            }
+
+            // Variable: $var, ${var}, $env:NAME, $script:var, …
+            if (ch == '$')
+            {
+                auto const start = pos;
+                ++pos;
+                if (pos < len && line[pos] == '{')
+                {
+                    ++pos;
+                    while (pos < len && line[pos] != '}')
+                        ++pos;
+                    if (pos < len)
+                        ++pos; // skip '}'
+                }
+                else
+                {
+                    // identifier chars plus ':' for scope qualifiers (env:, script:, global:)
+                    while (pos < len && (isIdentChar(line[pos]) || line[pos] == ':'))
+                        ++pos;
+                }
+                fillRange(map, start, pos - start, HighlightCategory::Variable);
+                continue;
+            }
+
+            // Word operator: -eq, -match, -not, … (a dash immediately followed by letters)
+            if (ch == '-' && pos + 1 < len
+                && ((line[pos + 1] >= 'a' && line[pos + 1] <= 'z')
+                    || (line[pos + 1] >= 'A' && line[pos + 1] <= 'Z')))
+            {
+                auto const start = pos;
+                auto const wordStart = pos + 1;
+                pos = wordStart;
+                while (pos < len && isIdentChar(line[pos]))
+                    ++pos;
+                auto const word = line.substr(wordStart, pos - wordStart);
+                std::array<char, 64> buf {};
+                auto const lower = word.size() <= buf.size() ? toLowerInto(word, buf.data()) : word;
+                if (isInSortedArray(powershellOperators, lower))
+                    fillRange(map, start, pos - start, HighlightCategory::Operator);
+                // Otherwise a parameter name like -Path — left as default text.
+                continue;
+            }
+
+            // Strings (single- and double-quoted; backtick escapes inside double quotes)
+            if (ch == '"' || ch == '\'')
+            {
+                auto const quote = ch;
+                map[pos] = HighlightCategory::String;
+                ++pos;
+                while (pos < len)
+                {
+                    if (quote == '"' && line[pos] == '`' && pos + 1 < len)
+                    {
+                        map[pos] = HighlightCategory::String;
+                        map[pos + 1] = HighlightCategory::String;
+                        pos += 2;
+                        continue;
+                    }
+                    if (line[pos] == quote)
+                    {
+                        map[pos] = HighlightCategory::String;
+                        ++pos;
+                        break;
+                    }
+                    if (quote == '"' && line[pos] == '$')
+                    {
+                        auto const varStart = pos;
+                        ++pos;
+                        if (pos < len && line[pos] == '{')
+                        {
+                            ++pos;
+                            while (pos < len && line[pos] != '}')
+                                ++pos;
+                            if (pos < len)
+                                ++pos;
+                        }
+                        else
+                        {
+                            while (pos < len && (isIdentChar(line[pos]) || line[pos] == ':'))
+                                ++pos;
+                        }
+                        fillRange(map, varStart, pos - varStart, HighlightCategory::Variable);
+                        continue;
+                    }
+                    map[pos] = HighlightCategory::String;
+                    ++pos;
+                }
+                continue;
+            }
+
+            // Numbers
+            if (isDigit(ch))
+            {
+                auto const numLen = scanNumber(line, pos);
+                fillRange(map, pos, numLen, HighlightCategory::Number);
+                pos += numLen;
+                continue;
+            }
+
+            // Identifiers / keywords / Verb-Noun cmdlets
+            if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_')
+            {
+                auto const start = pos;
+                while (pos < len && (isIdentChar(line[pos]) || line[pos] == '-'))
+                    ++pos;
+                auto const word = line.substr(start, pos - start);
+                std::array<char, 64> buf {};
+                auto const lower = word.size() <= buf.size() ? toLowerInto(word, buf.data()) : word;
+                if (isInSortedArray(powershellKeywords, lower))
+                    fillRange(map, start, pos - start, HighlightCategory::Keyword);
+                else if (word.find('-') != std::string_view::npos)
+                    fillRange(map, start, pos - start, HighlightCategory::Function);
+                continue;
+            }
+
+            // Operators
+            if (isOperatorChar(ch) || ch == '@')
+            {
+                map[pos] = HighlightCategory::Operator;
+                ++pos;
+                continue;
+            }
+
+            // Punctuation
+            if (isPunctuationChar(ch))
+            {
+                map[pos] = HighlightCategory::Punctuation;
+                ++pos;
+                continue;
+            }
+
+            ++pos;
+        }
+
+        return { std::move(map), state };
+    }
+
+    // -------------------------------------------------------------------------
+    // Windows CMD / batch highlighter
+    // -------------------------------------------------------------------------
+
+    /// @brief Highlights a line of Windows CMD / batch script.
+    auto highlightBatch(std::string_view line, HighlightState /*state*/)
+        -> std::pair<HighlightMap, HighlightState>
+    {
+        auto const len = line.size();
+        auto map = HighlightMap(len, HighlightCategory::Default);
+        auto pos = std::size_t { 0 };
+
+        // Inspect the first non-blank token for line-level constructs.
+        while (pos < len && (line[pos] == ' ' || line[pos] == '\t'))
+            ++pos;
+
+        // :: comment (a label that is conventionally used as a comment)
+        if (pos + 1 < len && line[pos] == ':' && line[pos + 1] == ':')
+        {
+            fillRange(map, pos, len - pos, HighlightCategory::Comment);
+            return { std::move(map), HighlightState::Normal };
+        }
+
+        // Label definition: :label
+        if (pos < len && line[pos] == ':')
+        {
+            fillRange(map, pos, len - pos, HighlightCategory::Function);
+            return { std::move(map), HighlightState::Normal };
+        }
+
+        // REM comment line (case-insensitive, must be its own token)
+        {
+            auto wordEnd = pos;
+            while (wordEnd < len && isIdentChar(line[wordEnd]))
+                ++wordEnd;
+            auto const first = line.substr(pos, wordEnd - pos);
+            std::array<char, 4> rbuf {};
+            auto const lowerFirst = first.size() <= rbuf.size() ? toLowerInto(first, rbuf.data()) : first;
+            if (lowerFirst == "rem" && (wordEnd == len || line[wordEnd] == ' ' || line[wordEnd] == '\t'))
+            {
+                fillRange(map, pos, len - pos, HighlightCategory::Comment);
+                return { std::move(map), HighlightState::Normal };
+            }
+        }
+
+        while (pos < len)
+        {
+            auto const ch = line[pos];
+
+            // Environment / parameter variable: %VAR%, %1, %%i
+            if (ch == '%')
+            {
+                auto const start = pos;
+                ++pos;
+                if (pos < len && line[pos] == '%') // %%i loop variable
+                {
+                    ++pos;
+                    if (pos < len && isIdentChar(line[pos]))
+                        ++pos;
+                }
+                else if (pos < len && isDigit(line[pos])) // %0 … %9 positional parameter
+                {
+                    ++pos;
+                }
+                else // %VAR%
+                {
+                    while (pos < len && line[pos] != '%')
+                        ++pos;
+                    if (pos < len)
+                        ++pos; // closing '%'
+                }
+                fillRange(map, start, pos - start, HighlightCategory::Variable);
+                continue;
+            }
+
+            // Delayed-expansion variable: !VAR!
+            if (ch == '!' && pos + 1 < len && isIdentChar(line[pos + 1]))
+            {
+                auto const start = pos;
+                ++pos;
+                while (pos < len && line[pos] != '!')
+                    ++pos;
+                if (pos < len)
+                    ++pos; // closing '!'
+                fillRange(map, start, pos - start, HighlightCategory::Variable);
+                continue;
+            }
+
+            // Strings
+            if (ch == '"')
+            {
+                map[pos] = HighlightCategory::String;
+                ++pos;
+                while (pos < len)
+                {
+                    map[pos] = HighlightCategory::String;
+                    if (line[pos] == '"')
+                    {
+                        ++pos;
+                        break;
+                    }
+                    ++pos;
+                }
+                continue;
+            }
+
+            // Numbers
+            if (isDigit(ch))
+            {
+                auto const numLen = scanNumber(line, pos);
+                fillRange(map, pos, numLen, HighlightCategory::Number);
+                pos += numLen;
+                continue;
+            }
+
+            // Identifiers / keywords (case-insensitive)
+            if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_')
+            {
+                auto const start = pos;
+                while (pos < len && isIdentChar(line[pos]))
+                    ++pos;
+                auto const word = line.substr(start, pos - start);
+                std::array<char, 32> buf {};
+                auto const lower = word.size() <= buf.size() ? toLowerInto(word, buf.data()) : word;
+                if (isInSortedArray(cmdKeywords, lower))
+                    fillRange(map, start, pos - start, HighlightCategory::Keyword);
+                continue;
+            }
+
+            // Operators / redirection: | & > < ^ = etc.
+            if (isOperatorChar(ch))
+            {
+                map[pos] = HighlightCategory::Operator;
+                ++pos;
+                continue;
+            }
+
+            // Punctuation
+            if (isPunctuationChar(ch))
+            {
+                map[pos] = HighlightCategory::Punctuation;
+                ++pos;
+                continue;
+            }
+
+            ++pos;
+        }
+
+        return { std::move(map), HighlightState::Normal };
+    }
+
+    // -------------------------------------------------------------------------
+    // XML highlighter
+    // -------------------------------------------------------------------------
+
+    /// @brief Highlights a line of XML, tracking <!-- … --> comments via state.
+    auto highlightXml(std::string_view line, HighlightState state) -> std::pair<HighlightMap, HighlightState>
+    {
+        auto const len = line.size();
+        auto map = HighlightMap(len, HighlightCategory::Default);
+        auto pos = std::size_t { 0 };
+
+        // Continue a <!-- … --> comment carried over from the previous line.
+        if (state == HighlightState::XmlComment)
+        {
+            while (pos < len)
+            {
+                if (pos + 2 < len && line[pos] == '-' && line[pos + 1] == '-' && line[pos + 2] == '>')
+                {
+                    fillRange(map, pos, 3, HighlightCategory::Comment);
+                    pos += 3;
+                    state = HighlightState::Normal;
+                    break;
+                }
+                map[pos] = HighlightCategory::Comment;
+                ++pos;
+            }
+            if (state == HighlightState::XmlComment)
+                return { std::move(map), state };
+        }
+
+        while (pos < len)
+        {
+            auto const ch = line[pos];
+
+            // Comment: <!-- … -->
+            if (ch == '<' && line.substr(pos).starts_with("<!--"))
+            {
+                auto const start = pos;
+                pos += 4;
+                state = HighlightState::XmlComment;
+                while (pos < len)
+                {
+                    if (pos + 2 < len && line[pos] == '-' && line[pos + 1] == '-' && line[pos + 2] == '>')
+                    {
+                        pos += 3;
+                        state = HighlightState::Normal;
+                        break;
+                    }
+                    ++pos;
+                }
+                fillRange(map, start, pos - start, HighlightCategory::Comment);
+                continue;
+            }
+
+            // CDATA section: <![CDATA[ … ]]>
+            if (ch == '<' && line.substr(pos).starts_with("<![CDATA["))
+            {
+                auto const start = pos;
+                pos += 9;
+                while (
+                    pos < len
+                    && !(pos + 2 < len && line[pos] == ']' && line[pos + 1] == ']' && line[pos + 2] == '>'))
+                    ++pos;
+                if (pos + 2 < len)
+                    pos += 3; // closing ]]>
+                else
+                    pos = len;
+                fillRange(map, start, pos - start, HighlightCategory::String);
+                continue;
+            }
+
+            // Processing instruction: <?xml … ?>
+            if (ch == '<' && pos + 1 < len && line[pos + 1] == '?')
+            {
+                auto const start = pos;
+                pos += 2;
+                while (pos < len && !(pos + 1 < len && line[pos] == '?' && line[pos + 1] == '>'))
+                    ++pos;
+                if (pos + 1 < len)
+                    pos += 2; // closing ?>
+                else
+                    pos = len;
+                fillRange(map, start, pos - start, HighlightCategory::Preprocessor);
+                continue;
+            }
+
+            // Declaration: <!DOCTYPE …>
+            if (ch == '<' && pos + 1 < len && line[pos + 1] == '!')
+            {
+                auto const start = pos;
+                while (pos < len && line[pos] != '>')
+                    ++pos;
+                if (pos < len)
+                    ++pos;
+                fillRange(map, start, pos - start, HighlightCategory::Preprocessor);
+                continue;
+            }
+
+            // Element tag: <tag …>, </tag>, <tag/>
+            if (ch == '<')
+            {
+                map[pos] = HighlightCategory::Punctuation;
+                ++pos;
+                if (pos < len && line[pos] == '/')
+                {
+                    map[pos] = HighlightCategory::Punctuation;
+                    ++pos;
+                }
+                // Tag name
+                auto const nameStart = pos;
+                while (
+                    pos < len
+                    && (isIdentChar(line[pos]) || line[pos] == '-' || line[pos] == ':' || line[pos] == '.'))
+                    ++pos;
+                fillRange(map, nameStart, pos - nameStart, HighlightCategory::Keyword);
+                // Attributes until the closing '>'
+                while (pos < len && line[pos] != '>')
+                {
+                    auto const c = line[pos];
+                    if (c == '"' || c == '\'')
+                    {
+                        auto const quote = c;
+                        map[pos] = HighlightCategory::String;
+                        ++pos;
+                        while (pos < len)
+                        {
+                            map[pos] = HighlightCategory::String;
+                            if (line[pos] == quote)
+                            {
+                                ++pos;
+                                break;
+                            }
+                            ++pos;
+                        }
+                        continue;
+                    }
+                    if (c == '=' || c == '/')
+                    {
+                        map[pos] = c == '=' ? HighlightCategory::Operator : HighlightCategory::Punctuation;
+                        ++pos;
+                        continue;
+                    }
+                    if (isIdentChar(c) || c == '-' || c == ':')
+                    {
+                        auto const attrStart = pos;
+                        while (pos < len
+                               && (isIdentChar(line[pos]) || line[pos] == '-' || line[pos] == ':'
+                                   || line[pos] == '.'))
+                            ++pos;
+                        fillRange(map, attrStart, pos - attrStart, HighlightCategory::Variable);
+                        continue;
+                    }
+                    ++pos;
+                }
+                if (pos < len && line[pos] == '>')
+                {
+                    map[pos] = HighlightCategory::Punctuation;
+                    ++pos;
+                }
+                continue;
+            }
+
+            // Entity reference: &amp; &#10; …
+            if (ch == '&')
+            {
+                auto const start = pos;
+                ++pos;
+                while (pos < len && line[pos] != ';' && (isIdentChar(line[pos]) || line[pos] == '#'))
+                    ++pos;
+                if (pos < len && line[pos] == ';')
+                    ++pos;
+                fillRange(map, start, pos - start, HighlightCategory::Constructor);
+                continue;
+            }
+
+            ++pos;
+        }
+
+        return { std::move(map), state };
+    }
+
+    // -------------------------------------------------------------------------
+    // INI / .editorconfig highlighter
+    // -------------------------------------------------------------------------
+
+    /// @brief Highlights a line of INI / .editorconfig configuration.
+    auto highlightIni(std::string_view line, HighlightState /*state*/)
+        -> std::pair<HighlightMap, HighlightState>
+    {
+        auto const len = line.size();
+        auto map = HighlightMap(len, HighlightCategory::Default);
+        auto pos = std::size_t { 0 };
+
+        while (pos < len && (line[pos] == ' ' || line[pos] == '\t'))
+            ++pos;
+        if (pos >= len)
+            return { std::move(map), HighlightState::Normal };
+
+        // Comment: ; or #
+        if (line[pos] == ';' || line[pos] == '#')
+        {
+            fillRange(map, pos, len - pos, HighlightCategory::Comment);
+            return { std::move(map), HighlightState::Normal };
+        }
+
+        // Section header: [section] (also .editorconfig glob sections)
+        if (line[pos] == '[')
+        {
+            auto const start = pos;
+            while (pos < len && line[pos] != ']')
+                ++pos;
+            if (pos < len)
+                ++pos; // include ']'
+            fillRange(map, start, pos - start, HighlightCategory::Keyword);
+            return { std::move(map), HighlightState::Normal };
+        }
+
+        // key = value  /  key : value
+        auto sepPos = std::string_view::npos;
+        for (auto p = pos; p < len; ++p)
+        {
+            if (line[p] == '=' || line[p] == ':')
+            {
+                sepPos = p;
+                break;
+            }
+        }
+        if (sepPos == std::string_view::npos)
+        {
+            // Bare token — treat as a key.
+            fillRange(map, pos, len - pos, HighlightCategory::Variable);
+            return { std::move(map), HighlightState::Normal };
+        }
+
+        // Key (trim trailing whitespace before the separator).
+        auto keyEnd = sepPos;
+        while (keyEnd > pos && (line[keyEnd - 1] == ' ' || line[keyEnd - 1] == '\t'))
+            --keyEnd;
+        fillRange(map, pos, keyEnd - pos, HighlightCategory::Variable);
+        map[sepPos] = HighlightCategory::Operator;
+
+        // Value (skip leading whitespace) — coloured as a string for visibility.
+        auto valStart = sepPos + 1;
+        while (valStart < len && (line[valStart] == ' ' || line[valStart] == '\t'))
+            ++valStart;
+        fillRange(map, valStart, len - valStart, HighlightCategory::String);
+
+        return { std::move(map), HighlightState::Normal };
+    }
+
 } // namespace
 
 // -------------------------------------------------------------------------
 // Public API
 // -------------------------------------------------------------------------
 
+namespace
+{
+    /// @brief Well-known file names (matched against the full basename) → language.
+    ///
+    /// These files carry no conventional extension yet have a well-defined format:
+    /// the *.clang-format / *.clang-tidy / .endo-format tool configs are YAML, and
+    /// .editorconfig is INI. Build files (Makefile, Dockerfile, …) are folded onto
+    /// their closest existing highlighter. Add a row to recognize a new file name.
+    constexpr auto FilenameLanguageTable = std::to_array<LanguageToken>({
+        { .token = "CMakeLists.txt", .language = LanguageId::CMake },
+        { .token = "Makefile", .language = LanguageId::Bash },
+        { .token = "makefile", .language = LanguageId::Bash },
+        { .token = "GNUmakefile", .language = LanguageId::Bash },
+        { .token = "Dockerfile", .language = LanguageId::Bash },
+        { .token = ".clang-format", .language = LanguageId::Yaml },
+        { .token = ".clang-tidy", .language = LanguageId::Yaml },
+        { .token = ".endo-format", .language = LanguageId::Yaml },
+        { .token = ".editorconfig", .language = LanguageId::Ini },
+    });
+} // namespace
+
 auto detectLanguageFromPath(std::string_view filePath) -> LanguageId
 {
-    // Handle CMakeLists.txt specially
-    if (filePath.ends_with("CMakeLists.txt"))
-        return LanguageId::CMake;
+    // Reduce to the basename so directory components can't fool the match.
+    auto const slash = filePath.find_last_of("/\\");
+    auto const fileName = slash == std::string_view::npos ? filePath : filePath.substr(slash + 1);
 
-    // Handle Makefile
-    if (filePath.ends_with("Makefile") || filePath.ends_with("makefile"))
-        return LanguageId::Bash;
+    // Well-known file names take precedence over extension detection.
+    if (auto const byName = lookupLanguage(FilenameLanguageTable, fileName); byName != LanguageId::None)
+        return byName;
 
-    // Handle Dockerfile
-    if (filePath.ends_with("Dockerfile"))
-        return LanguageId::Bash;
-
-    // Extract extension
-    auto const dotPos = filePath.rfind('.');
+    // Fall back to extension detection.
+    auto const dotPos = fileName.rfind('.');
     if (dotPos == std::string_view::npos)
         return LanguageId::None;
 
-    return detectLanguageFromExtension(filePath.substr(dotPos));
+    return detectLanguageFromExtension(fileName.substr(dotPos));
 }
 
 void registerEndoHighlighter(HighlightFunction fn)
@@ -1704,6 +2350,10 @@ auto highlightLine(std::string_view line, LanguageId language, HighlightState st
         case LanguageId::Yaml: return highlightYaml(line, state);
         case LanguageId::GitDiff: return highlightGitDiff(line, state);
         case LanguageId::Assembly: return highlightAssembly(line, state);
+        case LanguageId::PowerShell: return highlightPowerShell(line, state);
+        case LanguageId::Cmd: return highlightBatch(line, state);
+        case LanguageId::Xml: return highlightXml(line, state);
+        case LanguageId::Ini: return highlightIni(line, state);
         case LanguageId::Endo:
             if (endoHighlighter())
                 return endoHighlighter()(line, state);

--- a/src/tui/GenericSyntaxHighlighter.hpp
+++ b/src/tui/GenericSyntaxHighlighter.hpp
@@ -3,6 +3,8 @@
 
 #include <tui/TerminalOutput.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <string_view>
@@ -34,17 +36,21 @@ enum class HighlightCategory : std::uint8_t
 /// @brief Supported languages for syntax highlighting.
 enum class LanguageId : std::uint8_t
 {
-    None,     ///< No language — no highlighting applied.
-    Cpp,      ///< C and C++.
-    CMake,    ///< CMake build scripts.
-    Python,   ///< Python.
-    Bash,     ///< Bash/sh shell scripts.
-    Markdown, ///< Markdown.
-    Json,     ///< JSON.
-    Yaml,     ///< YAML.
-    GitDiff,  ///< Git diff output.
-    Assembly, ///< x86 assembly (Intel and AT&T syntax).
-    Endo,     ///< Endo shell language (via registered callback).
+    None,       ///< No language — no highlighting applied.
+    Cpp,        ///< C and C++.
+    CMake,      ///< CMake build scripts.
+    Python,     ///< Python.
+    Bash,       ///< Bash/sh shell scripts.
+    Markdown,   ///< Markdown.
+    Json,       ///< JSON.
+    Yaml,       ///< YAML.
+    GitDiff,    ///< Git diff output.
+    Assembly,   ///< x86 assembly (Intel and AT&T syntax).
+    PowerShell, ///< PowerShell scripts.
+    Cmd,        ///< Windows CMD / batch scripts.
+    Xml,        ///< XML and XML-based dialects (.props, .csproj, .xaml, .svg, …).
+    Ini,        ///< INI / .editorconfig configuration files.
+    Endo,       ///< Endo shell language (via registered callback).
 };
 
 /// @brief State carried across lines for multi-line constructs.
@@ -54,6 +60,8 @@ enum class HighlightState : std::uint8_t
     BlockComment,      ///< Inside a /* ... */ block comment.
     RawString,         ///< Inside a C++ R"(...)" raw string.
     TripleQuoteString, ///< Inside a Python """ or ''' triple-quoted string.
+    XmlComment,        ///< Inside an XML <!-- ... --> comment.
+    PsBlockComment,    ///< Inside a PowerShell <# ... #> block comment.
 };
 
 /// @brief Per-character highlight category for a line.
@@ -137,74 +145,188 @@ using HighlightFunction =
 /// @param fn The highlighting function to call for LanguageId::Endo.
 void registerEndoHighlighter(HighlightFunction fn);
 
+// --- Data-driven language detection tables ---
+
+/// @brief Associates a textual token (file extension or fence tag) with a language.
+struct LanguageToken
+{
+    std::string_view token; ///< The extension (with leading dot) or fence tag to match.
+    LanguageId language;    ///< The language this token maps to.
+};
+
+/// @brief File extension → language table (extensions include the leading dot).
+///
+/// Each row maps one extension to one language; add a row to teach the highlighter a
+/// new extension. Several distinct languages are intentionally folded onto a shared
+/// highlighter (e.g. JS/TS/Rust/Go reuse the C-family highlighter, TOML reuses YAML).
+inline constexpr auto ExtensionLanguageTable = std::to_array<LanguageToken>({
+    // C / C++ and C-family languages sharing the C++ highlighter.
+    { .token = ".cpp", .language = LanguageId::Cpp },
+    { .token = ".cxx", .language = LanguageId::Cpp },
+    { .token = ".cc", .language = LanguageId::Cpp },
+    { .token = ".c", .language = LanguageId::Cpp },
+    { .token = ".hpp", .language = LanguageId::Cpp },
+    { .token = ".hxx", .language = LanguageId::Cpp },
+    { .token = ".hh", .language = LanguageId::Cpp },
+    { .token = ".h", .language = LanguageId::Cpp },
+    { .token = ".ipp", .language = LanguageId::Cpp },
+    { .token = ".js", .language = LanguageId::Cpp },
+    { .token = ".jsx", .language = LanguageId::Cpp },
+    { .token = ".ts", .language = LanguageId::Cpp },
+    { .token = ".tsx", .language = LanguageId::Cpp },
+    { .token = ".rs", .language = LanguageId::Cpp },
+    { .token = ".go", .language = LanguageId::Cpp },
+    { .token = ".java", .language = LanguageId::Cpp },
+    { .token = ".kt", .language = LanguageId::Cpp },
+    { .token = ".cs", .language = LanguageId::Cpp },
+    // Python and Python-like languages.
+    { .token = ".py", .language = LanguageId::Python },
+    { .token = ".pyw", .language = LanguageId::Python },
+    { .token = ".pyi", .language = LanguageId::Python },
+    { .token = ".rb", .language = LanguageId::Python },
+    { .token = ".lua", .language = LanguageId::Python },
+    // Shell.
+    { .token = ".sh", .language = LanguageId::Bash },
+    { .token = ".bash", .language = LanguageId::Bash },
+    { .token = ".zsh", .language = LanguageId::Bash },
+    // Data / config.
+    { .token = ".json", .language = LanguageId::Json },
+    { .token = ".jsonl", .language = LanguageId::Json },
+    { .token = ".yml", .language = LanguageId::Yaml },
+    { .token = ".yaml", .language = LanguageId::Yaml },
+    { .token = ".toml", .language = LanguageId::Yaml },
+    { .token = ".ini", .language = LanguageId::Ini },
+    // Markup / build / diff.
+    { .token = ".md", .language = LanguageId::Markdown },
+    { .token = ".markdown", .language = LanguageId::Markdown },
+    { .token = ".cmake", .language = LanguageId::CMake },
+    { .token = ".diff", .language = LanguageId::GitDiff },
+    { .token = ".patch", .language = LanguageId::GitDiff },
+    { .token = ".asm", .language = LanguageId::Assembly },
+    { .token = ".s", .language = LanguageId::Assembly },
+    { .token = ".S", .language = LanguageId::Assembly },
+    { .token = ".nasm", .language = LanguageId::Assembly },
+    // PowerShell.
+    { .token = ".ps1", .language = LanguageId::PowerShell },
+    { .token = ".psm1", .language = LanguageId::PowerShell },
+    { .token = ".psd1", .language = LanguageId::PowerShell },
+    { .token = ".ps1xml", .language = LanguageId::PowerShell },
+    // Windows CMD / batch.
+    { .token = ".cmd", .language = LanguageId::Cmd },
+    { .token = ".bat", .language = LanguageId::Cmd },
+    // XML and XML-based dialects.
+    { .token = ".xml", .language = LanguageId::Xml },
+    { .token = ".props", .language = LanguageId::Xml },
+    { .token = ".csproj", .language = LanguageId::Xml },
+    { .token = ".targets", .language = LanguageId::Xml },
+    { .token = ".vcxproj", .language = LanguageId::Xml },
+    { .token = ".nuspec", .language = LanguageId::Xml },
+    { .token = ".resx", .language = LanguageId::Xml },
+    { .token = ".xaml", .language = LanguageId::Xml },
+    { .token = ".svg", .language = LanguageId::Xml },
+    { .token = ".plist", .language = LanguageId::Xml },
+    { .token = ".xsd", .language = LanguageId::Xml },
+    { .token = ".wxs", .language = LanguageId::Xml },
+    // Endo.
+    { .token = ".endo", .language = LanguageId::Endo },
+});
+
+/// @brief Markdown fence tag → language table (lowercase tags, without backticks).
+inline constexpr auto FenceTagLanguageTable = std::to_array<LanguageToken>({
+    { .token = "cpp", .language = LanguageId::Cpp },
+    { .token = "c++", .language = LanguageId::Cpp },
+    { .token = "cxx", .language = LanguageId::Cpp },
+    { .token = "c", .language = LanguageId::Cpp },
+    { .token = "h", .language = LanguageId::Cpp },
+    { .token = "hpp", .language = LanguageId::Cpp },
+    { .token = "javascript", .language = LanguageId::Cpp },
+    { .token = "js", .language = LanguageId::Cpp },
+    { .token = "jsx", .language = LanguageId::Cpp },
+    { .token = "typescript", .language = LanguageId::Cpp },
+    { .token = "ts", .language = LanguageId::Cpp },
+    { .token = "tsx", .language = LanguageId::Cpp },
+    { .token = "rust", .language = LanguageId::Cpp },
+    { .token = "rs", .language = LanguageId::Cpp },
+    { .token = "go", .language = LanguageId::Cpp },
+    { .token = "golang", .language = LanguageId::Cpp },
+    { .token = "java", .language = LanguageId::Cpp },
+    { .token = "kotlin", .language = LanguageId::Cpp },
+    { .token = "kt", .language = LanguageId::Cpp },
+    { .token = "csharp", .language = LanguageId::Cpp },
+    { .token = "cs", .language = LanguageId::Cpp },
+    { .token = "c#", .language = LanguageId::Cpp },
+    { .token = "python", .language = LanguageId::Python },
+    { .token = "py", .language = LanguageId::Python },
+    { .token = "ruby", .language = LanguageId::Python },
+    { .token = "rb", .language = LanguageId::Python },
+    { .token = "lua", .language = LanguageId::Python },
+    { .token = "bash", .language = LanguageId::Bash },
+    { .token = "sh", .language = LanguageId::Bash },
+    { .token = "shell", .language = LanguageId::Bash },
+    { .token = "zsh", .language = LanguageId::Bash },
+    { .token = "dockerfile", .language = LanguageId::Bash },
+    { .token = "docker", .language = LanguageId::Bash },
+    { .token = "json", .language = LanguageId::Json },
+    { .token = "jsonl", .language = LanguageId::Json },
+    { .token = "yaml", .language = LanguageId::Yaml },
+    { .token = "yml", .language = LanguageId::Yaml },
+    { .token = "toml", .language = LanguageId::Yaml },
+    { .token = "markdown", .language = LanguageId::Markdown },
+    { .token = "md", .language = LanguageId::Markdown },
+    { .token = "cmake", .language = LanguageId::CMake },
+    { .token = "diff", .language = LanguageId::GitDiff },
+    { .token = "patch", .language = LanguageId::GitDiff },
+    { .token = "asm", .language = LanguageId::Assembly },
+    { .token = "assembly", .language = LanguageId::Assembly },
+    { .token = "nasm", .language = LanguageId::Assembly },
+    { .token = "x86", .language = LanguageId::Assembly },
+    { .token = "x86asm", .language = LanguageId::Assembly },
+    { .token = "intel", .language = LanguageId::Assembly },
+    { .token = "att", .language = LanguageId::Assembly },
+    { .token = "gas", .language = LanguageId::Assembly },
+    { .token = "powershell", .language = LanguageId::PowerShell },
+    { .token = "pwsh", .language = LanguageId::PowerShell },
+    { .token = "ps", .language = LanguageId::PowerShell },
+    { .token = "ps1", .language = LanguageId::PowerShell },
+    { .token = "posh", .language = LanguageId::PowerShell },
+    { .token = "bat", .language = LanguageId::Cmd },
+    { .token = "batch", .language = LanguageId::Cmd },
+    { .token = "cmd", .language = LanguageId::Cmd },
+    { .token = "dosbatch", .language = LanguageId::Cmd },
+    { .token = "dos", .language = LanguageId::Cmd },
+    { .token = "xml", .language = LanguageId::Xml },
+    { .token = "xaml", .language = LanguageId::Xml },
+    { .token = "svg", .language = LanguageId::Xml },
+    { .token = "html", .language = LanguageId::Xml },
+    { .token = "xhtml", .language = LanguageId::Xml },
+    { .token = "ini", .language = LanguageId::Ini },
+    { .token = "editorconfig", .language = LanguageId::Ini },
+    { .token = "dosini", .language = LanguageId::Ini },
+    { .token = "endo", .language = LanguageId::Endo },
+});
+
+/// @brief Looks up a token in a language table, returning the mapped language or None.
+/// @param table The token→language table to search.
+/// @param token The token to look up (exact match).
+/// @return The mapped language, or LanguageId::None if the token is not present.
+template <std::size_t N>
+[[nodiscard]] constexpr auto lookupLanguage(std::array<LanguageToken, N> const& table, std::string_view token)
+    -> LanguageId
+{
+    auto const it = std::ranges::find(table, token, &LanguageToken::token);
+    return it != table.end() ? it->language : LanguageId::None;
+}
+
 // --- Inline constexpr implementations ---
 
 constexpr auto detectLanguageFromExtension(std::string_view ext) -> LanguageId
 {
-    if (ext == ".cpp" || ext == ".cxx" || ext == ".cc" || ext == ".c" || ext == ".hpp" || ext == ".hxx"
-        || ext == ".hh" || ext == ".h" || ext == ".ipp")
-        return LanguageId::Cpp;
-    if (ext == ".js" || ext == ".jsx" || ext == ".ts" || ext == ".tsx" || ext == ".rs" || ext == ".go"
-        || ext == ".java" || ext == ".kt" || ext == ".cs")
-        return LanguageId::Cpp;
-    if (ext == ".py" || ext == ".pyw" || ext == ".pyi" || ext == ".rb" || ext == ".lua")
-        return LanguageId::Python;
-    if (ext == ".sh" || ext == ".bash" || ext == ".zsh")
-        return LanguageId::Bash;
-    if (ext == ".json" || ext == ".jsonl")
-        return LanguageId::Json;
-    if (ext == ".yml" || ext == ".yaml" || ext == ".toml")
-        return LanguageId::Yaml;
-    if (ext == ".md" || ext == ".markdown")
-        return LanguageId::Markdown;
-    if (ext == ".cmake")
-        return LanguageId::CMake;
-    if (ext == ".diff" || ext == ".patch")
-        return LanguageId::GitDiff;
-    if (ext == ".asm" || ext == ".s" || ext == ".S" || ext == ".nasm")
-        return LanguageId::Assembly;
-    if (ext == ".endo")
-        return LanguageId::Endo;
-    return LanguageId::None;
+    return lookupLanguage(ExtensionLanguageTable, ext);
 }
 
 constexpr auto detectLanguageFromFenceTag(std::string_view tag) -> LanguageId
 {
-    if (tag == "cpp" || tag == "c++" || tag == "cxx" || tag == "c" || tag == "h" || tag == "hpp")
-        return LanguageId::Cpp;
-    if (tag == "javascript" || tag == "js" || tag == "jsx" || tag == "typescript" || tag == "ts"
-        || tag == "tsx")
-        return LanguageId::Cpp;
-    if (tag == "rust" || tag == "rs" || tag == "go" || tag == "golang")
-        return LanguageId::Cpp;
-    if (tag == "java" || tag == "kotlin" || tag == "kt" || tag == "csharp" || tag == "cs" || tag == "c#")
-        return LanguageId::Cpp;
-    if (tag == "python" || tag == "py")
-        return LanguageId::Python;
-    if (tag == "ruby" || tag == "rb" || tag == "lua")
-        return LanguageId::Python;
-    if (tag == "bash" || tag == "sh" || tag == "shell" || tag == "zsh")
-        return LanguageId::Bash;
-    if (tag == "dockerfile" || tag == "docker")
-        return LanguageId::Bash;
-    if (tag == "json" || tag == "jsonl")
-        return LanguageId::Json;
-    if (tag == "yaml" || tag == "yml")
-        return LanguageId::Yaml;
-    if (tag == "toml")
-        return LanguageId::Yaml;
-    if (tag == "markdown" || tag == "md")
-        return LanguageId::Markdown;
-    if (tag == "cmake")
-        return LanguageId::CMake;
-    if (tag == "diff" || tag == "patch")
-        return LanguageId::GitDiff;
-    if (tag == "asm" || tag == "assembly" || tag == "nasm" || tag == "x86" || tag == "x86asm"
-        || tag == "intel" || tag == "att" || tag == "gas")
-        return LanguageId::Assembly;
-    if (tag == "endo")
-        return LanguageId::Endo;
-    return LanguageId::None;
+    return lookupLanguage(FenceTagLanguageTable, tag);
 }
 
 } // namespace tui

--- a/src/tui/GenericSyntaxHighlighter_test.cpp
+++ b/src/tui/GenericSyntaxHighlighter_test.cpp
@@ -60,6 +60,21 @@ TEST_CASE("GenericSyntaxHighlighter.detectLanguageFromExtension", "[tui][highlig
     CHECK(detectLanguageFromExtension(".lua") == LanguageId::Python);
     // TOML maps to YAML
     CHECK(detectLanguageFromExtension(".toml") == LanguageId::Yaml);
+    // PowerShell
+    CHECK(detectLanguageFromExtension(".ps1") == LanguageId::PowerShell);
+    CHECK(detectLanguageFromExtension(".psm1") == LanguageId::PowerShell);
+    CHECK(detectLanguageFromExtension(".psd1") == LanguageId::PowerShell);
+    // Windows CMD / batch
+    CHECK(detectLanguageFromExtension(".cmd") == LanguageId::Cmd);
+    CHECK(detectLanguageFromExtension(".bat") == LanguageId::Cmd);
+    // XML and XML-based dialects
+    CHECK(detectLanguageFromExtension(".xml") == LanguageId::Xml);
+    CHECK(detectLanguageFromExtension(".props") == LanguageId::Xml);
+    CHECK(detectLanguageFromExtension(".csproj") == LanguageId::Xml);
+    CHECK(detectLanguageFromExtension(".xaml") == LanguageId::Xml);
+    CHECK(detectLanguageFromExtension(".svg") == LanguageId::Xml);
+    // INI
+    CHECK(detectLanguageFromExtension(".ini") == LanguageId::Ini);
 }
 
 TEST_CASE("GenericSyntaxHighlighter.detectLanguageFromFenceTag", "[tui][highlight]")
@@ -104,6 +119,20 @@ TEST_CASE("GenericSyntaxHighlighter.detectLanguageFromFenceTag", "[tui][highligh
     CHECK(detectLanguageFromFenceTag("docker") == LanguageId::Bash);
     // TOML maps to YAML
     CHECK(detectLanguageFromFenceTag("toml") == LanguageId::Yaml);
+    // PowerShell
+    CHECK(detectLanguageFromFenceTag("powershell") == LanguageId::PowerShell);
+    CHECK(detectLanguageFromFenceTag("pwsh") == LanguageId::PowerShell);
+    CHECK(detectLanguageFromFenceTag("ps1") == LanguageId::PowerShell);
+    // Windows CMD / batch
+    CHECK(detectLanguageFromFenceTag("bat") == LanguageId::Cmd);
+    CHECK(detectLanguageFromFenceTag("batch") == LanguageId::Cmd);
+    CHECK(detectLanguageFromFenceTag("cmd") == LanguageId::Cmd);
+    // XML
+    CHECK(detectLanguageFromFenceTag("xml") == LanguageId::Xml);
+    CHECK(detectLanguageFromFenceTag("xaml") == LanguageId::Xml);
+    // INI
+    CHECK(detectLanguageFromFenceTag("ini") == LanguageId::Ini);
+    CHECK(detectLanguageFromFenceTag("editorconfig") == LanguageId::Ini);
 }
 
 TEST_CASE("GenericSyntaxHighlighter.detectLanguageFromPath", "[tui][highlight]")
@@ -116,6 +145,22 @@ TEST_CASE("GenericSyntaxHighlighter.detectLanguageFromPath", "[tui][highlight]")
     CHECK(detectLanguageFromPath("config.yml") == LanguageId::Yaml);
     CHECK(detectLanguageFromPath("README.md") == LanguageId::Markdown);
     CHECK(detectLanguageFromPath("noext") == LanguageId::None);
+
+    // Well-known config file names are detected by name (not extension).
+    CHECK(detectLanguageFromPath(".clang-format") == LanguageId::Yaml);
+    CHECK(detectLanguageFromPath(".clang-tidy") == LanguageId::Yaml);
+    CHECK(detectLanguageFromPath(".endo-format") == LanguageId::Yaml);
+    CHECK(detectLanguageFromPath(".editorconfig") == LanguageId::Ini);
+    // Filename detection works with leading directories too.
+    CHECK(detectLanguageFromPath("/home/user/project/.clang-format") == LanguageId::Yaml);
+    CHECK(detectLanguageFromPath(R"(C:\proj\.editorconfig)") == LanguageId::Ini);
+    // .endo-format must not be mistaken for the .endo extension.
+    CHECK(detectLanguageFromPath("main.endo") == LanguageId::Endo);
+    // New extensions resolve through the path entry point as well.
+    CHECK(detectLanguageFromPath("Build.props") == LanguageId::Xml);
+    CHECK(detectLanguageFromPath("deploy.ps1") == LanguageId::PowerShell);
+    CHECK(detectLanguageFromPath("setup.bat") == LanguageId::Cmd);
+    CHECK(detectLanguageFromPath("settings.ini") == LanguageId::Ini);
 }
 
 // =============================================================================
@@ -544,6 +589,166 @@ TEST_CASE("GenericSyntaxHighlighter.asm_block_comment", "[tui][highlight]")
     auto const [map2, state2] = highlightLine("end */", LanguageId::Assembly, state1);
     CHECK(hasCategory(map2, 0, 5, Cat::Comment));
     CHECK(state2 == HighlightState::Normal);
+}
+
+// =============================================================================
+// PowerShell highlighting
+// =============================================================================
+
+TEST_CASE("GenericSyntaxHighlighter.powershell_variable_and_cmdlet", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine("$result = Get-ChildItem", LanguageId::PowerShell);
+    CHECK(hasCategory(map, 0, 7, Cat::Variable));   // $result
+    CHECK(hasCategory(map, 10, 13, Cat::Function)); // Get-ChildItem (Verb-Noun)
+    CHECK(state == HighlightState::Normal);
+}
+
+TEST_CASE("GenericSyntaxHighlighter.powershell_keyword_operator_comment", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine("if ($x -eq 1) { } # done", LanguageId::PowerShell);
+    CHECK(hasCategory(map, 0, 2, Cat::Keyword));  // if
+    CHECK(hasCategory(map, 4, 2, Cat::Variable)); // $x
+    CHECK(hasCategory(map, 7, 3, Cat::Operator)); // -eq
+    CHECK(categoryAt(map, 11, Cat::Number));      // 1
+    CHECK(hasCategory(map, 18, 6, Cat::Comment)); // # done
+}
+
+TEST_CASE("GenericSyntaxHighlighter.powershell_string_interpolation", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine(R"("Hello $name")", LanguageId::PowerShell);
+    CHECK(hasCategory(map, 0, 7, Cat::String));   // "Hello
+    CHECK(hasCategory(map, 7, 5, Cat::Variable)); // $name
+    CHECK(categoryAt(map, 12, Cat::String));      // closing quote
+}
+
+TEST_CASE("GenericSyntaxHighlighter.powershell_block_comment_multi_line", "[tui][highlight]")
+{
+    auto const [map1, state1] = highlightLine("<# start", LanguageId::PowerShell);
+    CHECK(hasCategory(map1, 0, 8, Cat::Comment));
+    CHECK(state1 == HighlightState::PsBlockComment);
+
+    auto const [map2, state2] = highlightLine("middle", LanguageId::PowerShell, state1);
+    CHECK(hasCategory(map2, 0, 6, Cat::Comment));
+    CHECK(state2 == HighlightState::PsBlockComment);
+
+    auto const [map3, state3] = highlightLine("end #> code", LanguageId::PowerShell, state2);
+    CHECK(hasCategory(map3, 0, 6, Cat::Comment));
+    CHECK(state3 == HighlightState::Normal);
+}
+
+// =============================================================================
+// Windows CMD / batch highlighting
+// =============================================================================
+
+TEST_CASE("GenericSyntaxHighlighter.batch_keyword_and_variable", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine(R"(set PATH=%PATH%;C:\bin)", LanguageId::Cmd);
+    CHECK(hasCategory(map, 0, 3, Cat::Keyword));  // set
+    CHECK(hasCategory(map, 9, 6, Cat::Variable)); // %PATH%
+    CHECK(state == HighlightState::Normal);
+}
+
+TEST_CASE("GenericSyntaxHighlighter.batch_rem_comment", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine("REM this is a comment", LanguageId::Cmd);
+    CHECK(hasCategory(map, 0, 21, Cat::Comment));
+}
+
+TEST_CASE("GenericSyntaxHighlighter.batch_label", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine(":start", LanguageId::Cmd);
+    CHECK(hasCategory(map, 0, 6, Cat::Function));
+}
+
+TEST_CASE("GenericSyntaxHighlighter.batch_loop_variable", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine("echo %%i", LanguageId::Cmd);
+    CHECK(hasCategory(map, 0, 4, Cat::Keyword));  // echo
+    CHECK(hasCategory(map, 5, 3, Cat::Variable)); // %%i
+}
+
+// =============================================================================
+// XML highlighting
+// =============================================================================
+
+TEST_CASE("GenericSyntaxHighlighter.xml_tag_attribute_value", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine(R"(<tag attr="val">)", LanguageId::Xml);
+    CHECK(categoryAt(map, 0, Cat::Punctuation));  // <
+    CHECK(hasCategory(map, 1, 3, Cat::Keyword));  // tag
+    CHECK(hasCategory(map, 5, 4, Cat::Variable)); // attr
+    CHECK(categoryAt(map, 9, Cat::Operator));     // =
+    CHECK(hasCategory(map, 10, 5, Cat::String));  // "val"
+    CHECK(categoryAt(map, 15, Cat::Punctuation)); // >
+    CHECK(state == HighlightState::Normal);
+}
+
+TEST_CASE("GenericSyntaxHighlighter.xml_comment_multi_line", "[tui][highlight]")
+{
+    auto const [map1, state1] = highlightLine("<!-- start", LanguageId::Xml);
+    CHECK(hasCategory(map1, 0, 10, Cat::Comment));
+    CHECK(state1 == HighlightState::XmlComment);
+
+    auto const [map2, state2] = highlightLine("still comment", LanguageId::Xml, state1);
+    CHECK(hasCategory(map2, 0, 13, Cat::Comment));
+    CHECK(state2 == HighlightState::XmlComment);
+
+    auto const [map3, state3] = highlightLine("end -->", LanguageId::Xml, state2);
+    CHECK(hasCategory(map3, 0, 7, Cat::Comment));
+    CHECK(state3 == HighlightState::Normal);
+}
+
+TEST_CASE("GenericSyntaxHighlighter.xml_processing_instruction", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine(R"(<?xml version="1.0"?>)", LanguageId::Xml);
+    CHECK(hasCategory(map, 0, 21, Cat::Preprocessor));
+}
+
+TEST_CASE("GenericSyntaxHighlighter.xml_entity", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine("<p>&amp;</p>", LanguageId::Xml);
+    CHECK(categoryAt(map, 1, Cat::Keyword));         // p
+    CHECK(hasCategory(map, 3, 5, Cat::Constructor)); // &amp;
+    CHECK(categoryAt(map, 10, Cat::Keyword));        // p (closing tag)
+}
+
+// =============================================================================
+// INI / .editorconfig highlighting
+// =============================================================================
+
+TEST_CASE("GenericSyntaxHighlighter.ini_section", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine("[section]", LanguageId::Ini);
+    CHECK(hasCategory(map, 0, 9, Cat::Keyword));
+    CHECK(state == HighlightState::Normal);
+}
+
+TEST_CASE("GenericSyntaxHighlighter.ini_key_value", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine("key = value", LanguageId::Ini);
+    CHECK(hasCategory(map, 0, 3, Cat::Variable)); // key
+    CHECK(categoryAt(map, 4, Cat::Operator));     // =
+    CHECK(hasCategory(map, 6, 5, Cat::String));   // value
+}
+
+TEST_CASE("GenericSyntaxHighlighter.ini_comment", "[tui][highlight]")
+{
+    {
+        auto const [map, state] = highlightLine("; comment", LanguageId::Ini);
+        CHECK(hasCategory(map, 0, 9, Cat::Comment));
+    }
+    {
+        auto const [map, state] = highlightLine("# comment", LanguageId::Ini);
+        CHECK(hasCategory(map, 0, 9, Cat::Comment));
+    }
+}
+
+TEST_CASE("GenericSyntaxHighlighter.ini_editorconfig_glob", "[tui][highlight]")
+{
+    auto const [map, state] = highlightLine("indent_size = 4", LanguageId::Ini);
+    CHECK(hasCategory(map, 0, 11, Cat::Variable)); // indent_size
+    CHECK(categoryAt(map, 12, Cat::Operator));     // =
+    CHECK(categoryAt(map, 14, Cat::String));       // 4
 }
 
 // =============================================================================


### PR DESCRIPTION
Adds syntax highlighting for four new file formats and teaches the highlighter to recognize well-known configuration files by name. Previously `cat` (and the pager, file/history/completion previews, and agent-mode code blocks) only highlighted a fixed set of languages and missed common Windows and config-file formats.

## Changes

- **PowerShell** (`.ps1`, `.psm1`, `.psd1`, `.ps1xml`): variables and scope qualifiers, `Verb-Noun` cmdlets, word operators (`-eq`, `-match`, …), and `<# … #>` block comments tracked across lines.
- **Windows CMD / batch** (`.cmd`, `.bat`): `REM`/`::` comments, `:labels`, `%VAR%` / `!VAR!` / `%%i` variables, and case-insensitive keywords.
- **XML and XML dialects** (`.xml`, `.props`, `.csproj`, `.targets`, `.vcxproj`, `.nuspec`, `.resx`, `.xaml`, `.svg`, `.plist`, `.xsd`, `.wxs`): tags, attributes, values, entities, processing instructions, `<!DOCTYPE>`, CDATA, and `<!-- … -->` comments tracked across lines.
- **INI** (`.ini`): sections, key/value pairs, and `;` / `#` comments.
- **Filename-based detection**: `.clang-format`, `.clang-tidy`, and `.endo-format` are highlighted as YAML, and `.editorconfig` as INI. This also fixes `.endo-format` being mistaken for the `.endo` extension.
- **Data-driven detection**: the hand-written `if`-ladders in `detectLanguageFromExtension` / `detectLanguageFromFenceTag` / `detectLanguageFromPath` are replaced with `LanguageToken` tables consumed by a single `lookupLanguage()` helper, so adding an extension, fence tag, or filename is now a one-row change. Path detection matches on the basename to avoid directory-component false positives.

No new highlight categories or theme colours are required — all four formats reuse existing categories, leaving the theme and the `TokenCategory`↔`HighlightCategory` invariant untouched. Detection and per-language highlighting tests (including multi-line comment carry-over for XML and PowerShell) are added.