### PR TITLE
Embed build version in binary and clean up legacy PATH on MSI upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,9 @@ endif()
 
 if(ENDO_TESTING)
     enable_testing()
+    # Unit test for the git-describe version parser (pure CMake, no git needed).
+    add_test(NAME version-parse
+             COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/tests/TestVersionParse.cmake")
 endif()
 
 include(EnableCcache)

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -67,17 +67,22 @@ if(WIN32)
     # The PATH component GUID is derived deterministically from the version so
     # that each installed version owns a distinct PATH component. This lets an
     # upgrade cleanly add the new version's bin directory and remove the previous
-    # one (Environment edits are registry-only and never locked), leaving the
-    # newest version's bin first/only on PATH — so "endo" always resolves to the
-    # latest install. Reusing one GUID across versions would violate MSI's
-    # component rules (same GUID, differing keypath value) and break migration.
+    # one (Environment edits are registry-only and never locked). The new entry is
+    # prepended (Part="first" in wix-env-path.wxs.in), so "endo" resolves to the
+    # latest install first even if a stray earlier endo entry survives on PATH.
+    # Reusing one GUID across versions would violate MSI's component rules (same
+    # GUID, differing keypath value) and break migration.
     string(UUID ENDO_PATH_COMPONENT_GUID
         NAMESPACE "${CPACK_WIX_UPGRADE_GUID}"
         NAME "endo-path-${PROJECT_VERSION}"
         TYPE SHA1 UPPER)
     configure_file("${CMAKE_SOURCE_DIR}/cmake/wix-env-path.wxs.in"
                    "${CMAKE_BINARY_DIR}/wix-env-path.wxs" @ONLY)
-    set(CPACK_WIX_EXTRA_SOURCES "${CMAKE_BINARY_DIR}/wix-env-path.wxs")
+    # wix-legacy-path-cleanup.wxs is static (frozen GUID, version-independent) and
+    # is used verbatim — it must not go through configure_file.
+    set(CPACK_WIX_EXTRA_SOURCES
+        "${CMAKE_BINARY_DIR}/wix-env-path.wxs"
+        "${CMAKE_SOURCE_DIR}/cmake/wix-legacy-path-cleanup.wxs")
     set(CPACK_WIX_PATCH_FILE "${CMAKE_SOURCE_DIR}/cmake/wix-path-env.xml")
 
 elseif(APPLE)

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -6,6 +6,8 @@
 # 2.) Git tags matching pattern v* (e.g., v1.2.34)
 # 3.) .git directory with branch and SHA info as fallback
 #
+include("${CMAKE_CURRENT_LIST_DIR}/VersionParse.cmake")
+
 function(GetVersionInformation VersionTripleVar VersionStringVar)
     find_package(Git QUIET)
 
@@ -19,8 +21,12 @@ function(GetVersionInformation VersionTripleVar VersionStringVar)
         set(THE_SOURCE "${CMAKE_SOURCE_DIR}/version.txt")
     elseif(GIT_FOUND)
         # Use a long describe so untagged (development / CI) builds still get a
-        # unique, monotonically increasing version. Format: v<maj>.<min>.<patch>-<n>-g<sha>
-        # where <n> is the number of commits since the most recent v* tag.
+        # version that increases per commit within a release line. Format:
+        # v<maj>.<min>.<patch>[-<pre>]-<n>-g<sha>[-dirty], where <n> is the number
+        # of commits since the most recent v* tag. Releases use the clean tag
+        # version (what users install); the folded development version is only for
+        # CI artifacts, which are not distributed. Parsing lives in
+        # endo_parse_git_describe() (cmake/VersionParse.cmake) so it can be tested.
         execute_process(
             COMMAND ${GIT_EXECUTABLE} describe --tags --long --match "v*" --dirty
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -29,37 +35,19 @@ function(GetVersionInformation VersionTripleVar VersionStringVar)
             ERROR_QUIET
             RESULT_VARIABLE GIT_RESULT
         )
-        if(GIT_RESULT EQUAL 0 AND
-           GIT_DESCRIBE MATCHES "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)-([0-9]+)-g([0-9a-f]+)(-dirty)?$")
-            set(_ver_major "${CMAKE_MATCH_1}")
-            set(_ver_minor "${CMAKE_MATCH_2}")
-            set(_ver_patch "${CMAKE_MATCH_3}")
-            set(_ver_commits "${CMAKE_MATCH_4}")
-            set(_ver_sha "${CMAKE_MATCH_5}")
-            set(_ver_dirty "${CMAKE_MATCH_6}")
-            if(_ver_commits EQUAL 0 AND _ver_dirty STREQUAL "")
-                # Exactly on a release tag.
-                set(THE_VERSION "${_ver_major}.${_ver_minor}.${_ver_patch}")
-                set(THE_VERSION_STRING "${_ver_major}.${_ver_minor}.${_ver_patch}")
-                set(THE_SOURCE "git tag")
-                message(STATUS "Successfully retrieved version '${THE_VERSION}' from Git tag.")
-            else()
-                # Development build N commits past the tag. Fold the commit distance
-                # into the patch component so the numeric version is unique and
-                # monotonically increasing per commit. This is required so the MSI
-                # installer treats each CI build as an upgrade and so per-version
-                # install directories are distinct. The human-readable string keeps
-                # the short SHA so an installed build maps back to a commit.
-                math(EXPR _ver_build "${_ver_patch} + ${_ver_commits}")
-                set(THE_VERSION "${_ver_major}.${_ver_minor}.${_ver_build}")
-                set(THE_VERSION_STRING
-                    "${_ver_major}.${_ver_minor}.${_ver_patch}-${_ver_commits}-g${_ver_sha}${_ver_dirty}")
-                set(THE_SOURCE "git describe (development build)")
-                message(STATUS "Derived development version '${THE_VERSION}' (${THE_VERSION_STRING}).")
-            endif()
+        set(_parsed_ok FALSE)
+        if(GIT_RESULT EQUAL 0)
+            endo_parse_git_describe("${GIT_DESCRIBE}"
+                _parsed_ok THE_VERSION THE_VERSION_STRING THE_SOURCE)
+        endif()
+        if(_parsed_ok)
+            message(STATUS "Derived version '${THE_VERSION}' (${THE_VERSION_STRING}) from ${THE_SOURCE}.")
         else()
-            # No matching v* tag reachable (e.g. shallow clone without tags). Fall
-            # back to the total commit count so CI builds remain unique and ordered.
+            # No parseable v* tag reachable (e.g. shallow clone without tags, or a
+            # tag that is not v<MAJOR>.<MINOR>.<PATCH>-shaped). Fall back to the
+            # total commit count so CI builds remain unique and ordered. This is a
+            # degraded, non-semver version, so warn loudly rather than degrade
+            # silently.
             execute_process(
                 COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -76,12 +64,18 @@ function(GetVersionInformation VersionTripleVar VersionStringVar)
                 ERROR_QUIET
             )
             if(GIT_COUNT_RESULT EQUAL 0 AND NOT "${GIT_COMMIT_COUNT}" STREQUAL "")
-                set(THE_VERSION "0.0.${GIT_COMMIT_COUNT}")
+                endo_clamp_msi_build("${GIT_COMMIT_COUNT}" _count_build)
+                set(THE_VERSION "0.0.${_count_build}")
                 set(THE_VERSION_STRING "0.0.0-${GIT_COMMIT_COUNT}-g${GIT_SHORT_SHA}")
                 set(THE_SOURCE "git commit count (no v* tag found)")
-                message(STATUS "No v* tag found; derived version '${THE_VERSION}' from commit count.")
+                message(WARNING
+                    "Endo: no parseable v* tag reachable; derived degraded version "
+                    "'${THE_VERSION}' from commit count. Tag a release "
+                    "(v<MAJOR>.<MINOR>.<PATCH>) or fetch tags "
+                    "(git fetch --tags / actions/checkout fetch-depth: 0).")
             else()
-                message(STATUS "Info: No suitable Git tag (e.g., 'v1.2.34') found.")
+                message(WARNING
+                    "Endo: no suitable Git tag (e.g. 'v1.2.34') found and commit count unavailable.")
             endif()
         endif()
     endif()

--- a/cmake/VersionParse.cmake
+++ b/cmake/VersionParse.cmake
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pure, side-effect-free parsing of `git describe` output into an Endo version.
+#
+# Kept separate from Version.cmake (which performs the actual git invocations) so
+# the parsing logic can be unit-tested in isolation via `cmake -P` with mock
+# inputs and no git dependency. See cmake/tests/TestVersionParse.cmake.
+
+# Maximum value of an MSI ProductVersion build field. The Windows Installer
+# compares only major.minor.build (each capped); a larger value is rejected by
+# the WiX toolset or silently wraps, breaking upgrade detection.
+set(ENDO_MSI_BUILD_FIELD_MAX 65535)
+
+# Clamp a numeric build component to the MSI build-field limit, warning if it
+# overflows.
+# @param value     The candidate build number.
+# @param out_var   Name of the variable to receive the clamped value.
+function(endo_clamp_msi_build value out_var)
+    if(value GREATER ${ENDO_MSI_BUILD_FIELD_MAX})
+        message(WARNING
+            "Endo: derived MSI build number ${value} exceeds ${ENDO_MSI_BUILD_FIELD_MAX}; "
+            "clamping (Windows Installer ProductVersion build-field limit).")
+        set(${out_var} "${ENDO_MSI_BUILD_FIELD_MAX}" PARENT_SCOPE)
+    else()
+        set(${out_var} "${value}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Parse the output of `git describe --tags --long --match "v*" --dirty` into a
+# numeric version triple and a human-readable string.
+#
+# Accepted shape: v<major>.<minor>.<patch>[<suffix>]-<commits>-g<sha>[-dirty]
+# where <suffix> is any optional pre-release/build metadata (e.g. "-rc1"); it is
+# preserved in the human string but ignored for the numeric triple. The two-step
+# match (peel the "-<commits>-g<sha>" trailer first, then parse the tag core)
+# makes pre-release tags parse correctly instead of being silently dropped.
+#
+# Numbering:
+#   * Exactly on a clean tag (commits == 0, not dirty) -> the clean tag version.
+#   * Otherwise (development build, or dirty on a tag)  -> patch + commits folded
+#     into the build field, so each commit yields a unique, increasing version
+#     within the release line. (Releases always use the clean tag version and are
+#     what users install; CI/dev MSIs are not distributed, so cross-tag ordering
+#     is intentionally not guaranteed.)
+#
+# @param describe      The git-describe string to parse.
+# @param out_ok        Receives TRUE if parsing succeeded, FALSE otherwise.
+# @param out_numeric   Receives the numeric triple "major.minor.build".
+# @param out_human     Receives the human-readable version string.
+# @param out_source    Receives a short description of the version source.
+function(endo_parse_git_describe describe out_ok out_numeric out_human out_source)
+    # Step 1: peel the "-<commits>-g<sha>[-dirty]" describe trailer. Anchored at
+    # the end so the greedy tag capture backtracks deterministically.
+    if(NOT describe MATCHES "^(.+)-([0-9]+)-g([0-9a-f]+)(-dirty)?$")
+        set(${out_ok} FALSE PARENT_SCOPE)
+        return()
+    endif()
+    # Save the captures immediately: the next MATCHES clobbers CMAKE_MATCH_*.
+    set(_tag "${CMAKE_MATCH_1}")
+    set(_commits "${CMAKE_MATCH_2}")
+    set(_sha "${CMAKE_MATCH_3}")
+    set(_dirty "${CMAKE_MATCH_4}")
+
+    # Step 2: parse the numeric core from the tag; anything after the patch is
+    # optional pre-release/build metadata kept only in the human string.
+    if(NOT _tag MATCHES "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$")
+        set(${out_ok} FALSE PARENT_SCOPE)
+        return()
+    endif()
+    set(_major "${CMAKE_MATCH_1}")
+    set(_minor "${CMAKE_MATCH_2}")
+    set(_patch "${CMAKE_MATCH_3}")
+    set(_suffix "${CMAKE_MATCH_4}")
+
+    if(_commits EQUAL 0 AND _dirty STREQUAL "")
+        # Exactly on a clean release tag.
+        set(${out_numeric} "${_major}.${_minor}.${_patch}" PARENT_SCOPE)
+        set(${out_human} "${_major}.${_minor}.${_patch}${_suffix}" PARENT_SCOPE)
+        set(${out_source} "git tag" PARENT_SCOPE)
+    else()
+        # Development build N commits past the tag (or a dirty checkout exactly on
+        # a tag, which folds to patch+0 == patch and so aliases the clean release
+        # numerically — acceptable because a dirty build is local-only, never
+        # released, and the "-dirty" marker is preserved in the human string).
+        math(EXPR _build "${_patch} + ${_commits}")
+        endo_clamp_msi_build("${_build}" _build)
+        set(${out_numeric} "${_major}.${_minor}.${_build}" PARENT_SCOPE)
+        set(${out_human}
+            "${_major}.${_minor}.${_patch}${_suffix}-${_commits}-g${_sha}${_dirty}" PARENT_SCOPE)
+        set(${out_source} "git describe (development build)" PARENT_SCOPE)
+    endif()
+    set(${out_ok} TRUE PARENT_SCOPE)
+endfunction()

--- a/cmake/tests/TestVersionParse.cmake
+++ b/cmake/tests/TestVersionParse.cmake
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unit test for endo_parse_git_describe() in cmake/VersionParse.cmake.
+# Pure CMake, no git required. Run via:
+#   cmake -P cmake/tests/TestVersionParse.cmake
+#
+# Data-driven: each row is "<describe>|<expected-numeric>". The sentinel value
+# "FAIL" means parsing is expected to be rejected (out_ok == FALSE).
+
+include("${CMAKE_CURRENT_LIST_DIR}/../VersionParse.cmake")
+
+set(_cases
+    "v0.1.0-0-gabc1234|0.1.0"             # clean release tag
+    "v1.2.3-5-gabc1234|1.2.8"             # development build: patch + commits
+    "v1.2.3-0-gabc1234-dirty|1.2.3"       # dirty on a tag: folds to patch+0 (documented alias)
+    "v1.2.3-rc1-5-gabc1234|1.2.8"         # pre-release suffix tolerated (kept only in human string)
+    "v10.20.30-rc.2-7-gdeadbee|10.20.37"  # dotted pre-release, multi-digit components
+    "v1.2.0-70000-gabc1234|1.2.65535"     # MSI build-field overflow clamped
+    "v0.0.0-0-g0000000|0.0.0"             # zero version
+    "garbage|FAIL"                        # not a describe string
+    "v1.2-5-gabc1234|FAIL"                # tag missing the patch component
+    "|FAIL"                               # empty input
+)
+
+set(_failures 0)
+foreach(_case IN LISTS _cases)
+    string(REPLACE "|" ";" _parts "${_case}")
+    list(GET _parts 0 _describe)
+    list(GET _parts 1 _expected)
+
+    endo_parse_git_describe("${_describe}" _ok _numeric _human _source)
+
+    if(_expected STREQUAL "FAIL")
+        if(_ok)
+            message(SEND_ERROR "FAIL: '${_describe}' expected rejection but parsed to '${_numeric}'.")
+            math(EXPR _failures "${_failures} + 1")
+        endif()
+    elseif(NOT _ok)
+        message(SEND_ERROR "FAIL: '${_describe}' expected '${_expected}' but was rejected.")
+        math(EXPR _failures "${_failures} + 1")
+    elseif(NOT _numeric STREQUAL _expected)
+        message(SEND_ERROR "FAIL: '${_describe}' expected '${_expected}' but got '${_numeric}'.")
+        math(EXPR _failures "${_failures} + 1")
+    endif()
+endforeach()
+
+list(LENGTH _cases _total)
+if(_failures GREATER 0)
+    message(FATAL_ERROR "version-parse: ${_failures}/${_total} case(s) failed.")
+endif()
+message(STATUS "version-parse: all ${_total} cases passed.")

--- a/cmake/wix-env-path.wxs.in
+++ b/cmake/wix-env-path.wxs.in
@@ -7,7 +7,8 @@
   Configured by CMake (configure_file, @ONLY) into the build tree so that the
   component GUID is unique per version. Each installed version owns its own
   PATH component, so an upgrade cleanly adds the new version's bin directory and
-  removes the previous one — leaving the newest version first/only on PATH.
+  removes the previous one. The entry is prepended (Part="first") so the newest
+  version's bin resolves first even if a stray earlier endo entry survives.
 
   Compiled as an extra source via CPACK_WIX_EXTRA_SOURCES.
   The ComponentRef is injected into the product feature via wix-path-env.xml.
@@ -17,7 +18,7 @@
         <DirectoryRef Id="INSTALL_ROOT">
             <Component Id="Env_PATH" Guid="@ENDO_PATH_COMPONENT_GUID@" Win64="yes" KeyPath="yes">
                 <Environment Id="ENV_PATH" Name="PATH" Value="[INSTALL_ROOT]bin"
-                             Permanent="no" Part="last" Action="set" System="yes" />
+                             Permanent="no" Part="first" Action="set" System="yes" />
             </Component>
         </DirectoryRef>
     </Fragment>

--- a/cmake/wix-legacy-path-cleanup.wxs
+++ b/cmake/wix-legacy-path-cleanup.wxs
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SPDX-License-Identifier: Apache-2.0
+
+  WIX source fragment: one-time cleanup of the legacy *unversioned* system PATH
+  entry "C:\Program Files\Endo\bin" left behind by the old (now-removed) NSIS
+  installer. An MSI MajorUpgrade is keyed on the UpgradeCode and cannot detect or
+  uninstall the NSIS product, so that segment can persist and shadow the new
+  versioned bin directory on PATH.
+
+  This removes ONLY that single PATH segment (Action="remove"). It does NOT delete
+  any legacy files — an MSI must not remove files it does not own; leftover NSIS
+  files are handled by a documentation note instead.
+
+  Version-INDEPENDENT: the Name, Value and keypath are identical in every release,
+  so this uses ONE STABLE, frozen GUID (NOT the per-version derived GUID used by
+  Env_PATH in wix-env-path.wxs.in). Permanent="yes" so uninstalling Endo never
+  re-adds the legacy entry. The remove is idempotent — a no-op on machines that
+  never had the NSIS installer.
+
+  Static source (never run through configure_file). Compiled via
+  CPACK_WIX_EXTRA_SOURCES; its ComponentRef is injected into the product feature
+  via wix-path-env.xml.
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <DirectoryRef Id="INSTALL_ROOT">
+            <Component Id="Env_PATH_LegacyCleanup"
+                       Guid="8F7E33BD-5B6D-4222-A924-283D857C1200" Win64="yes" KeyPath="yes">
+                <Environment Id="ENV_PATH_LEGACY_REMOVE" Name="PATH"
+                             Value="[ProgramFiles64Folder]Endo\bin"
+                             Action="remove" Part="all" System="yes" Permanent="yes" />
+            </Component>
+        </DirectoryRef>
+    </Fragment>
+</Wix>

--- a/cmake/wix-path-env.xml
+++ b/cmake/wix-path-env.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   SPDX-License-Identifier: Apache-2.0
-  WIX patch fragment: includes the PATH environment component (defined in
-  wix-env-path.wxs.in, configured per-version into the build tree) in the main
-  product feature so it gets installed.
+  WIX patch fragment: includes in the main product feature so they get installed:
+    1. Env_PATH — the per-version PATH component (wix-env-path.wxs.in, configured
+       per-version into the build tree).
+    2. Env_PATH_LegacyCleanup — the static component that removes the legacy
+       unversioned NSIS PATH entry (wix-legacy-path-cleanup.wxs).
 -->
 <CPackWiXPatch>
     <CPackWiXFragment Id="#PRODUCTFEATURE">
         <ComponentRef Id="Env_PATH" />
+        <ComponentRef Id="Env_PATH_LegacyCleanup" />
     </CPackWiXFragment>
 </CPackWiXPatch>

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -81,9 +81,16 @@ Because each version installs side by side in its own directory, **you can upgra
 reinstall while Endo is still running** -- the installer never replaces the locked,
 in-use binary, so it does not ask you to close running `endo.exe` processes or force a
 reboot. Running sessions keep working; you decide when to restart them. After an upgrade,
-`PATH` resolves `endo` to the newest version, and the previous version's files are removed
-automatically (on the next reboot if it was still in use). See
+the new version's `bin` is placed first on `PATH`, so `endo` resolves to the newest
+version, and the previous version's files are removed automatically (on the next reboot if
+it was still in use). See
 [Platform Differences](shell/platform-differences.md#windows) for setup details.
+
+If you are upgrading from a pre-`.msi` Endo that was installed with the old `.exe`
+(NSIS) installer, the `.msi` automatically removes that installer's leftover
+`C:\Program Files\Endo\bin` entry from `PATH`. Its files (directly under
+`C:\Program Files\Endo\`) are not touched by the `.msi`; remove them with the old
+uninstaller or by hand if you no longer need them.
 
 ### GitHub Repository
 

--- a/docs/shell/platform-differences.md
+++ b/docs/shell/platform-differences.md
@@ -333,10 +333,17 @@ puts that version's `bin` directory on the system `PATH`.
 Because each version lives in its own directory, you can **upgrade or reinstall while
 Endo is still running** -- the installer never has to replace the locked, in-use
 `endo.exe`. Already-running Endo sessions keep working unchanged; you choose when to
-restart them. After an upgrade, `PATH` points at the new version, so a bare `endo` (or a
-freshly launched shell) always resolves to the latest installed version. Files from a
-previous version that was still running during the upgrade are cleaned up automatically
-on the next reboot.
+restart them. After an upgrade, the new version's `bin` is placed first on `PATH`, so a
+bare `endo` (or a freshly launched shell) always resolves to the latest installed version.
+Files from a previous version that was still running during the upgrade are cleaned up
+automatically on the next reboot.
+
+!!! note "Upgrading from the old `.exe` installer"
+    Older Endo builds were distributed with an NSIS `.exe` installer that put an
+    unversioned `C:\Program Files\Endo\bin` on `PATH`. The `.msi` removes that stale
+    entry on install so it can no longer shadow the new versioned `bin`. The old
+    installer's *files* (directly under `C:\Program Files\Endo\`) are left untouched --
+    remove them with its uninstaller or manually if you no longer need them.
 
 !!! tip
     Prefer referring to Endo as just `endo` (resolved via `PATH`) rather than hard-coding

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -2,6 +2,13 @@
 # This library contains the shell execution runtime, builtins, job control, etc.
 # It depends on the endo language library for parsing and IR generation.
 
+# Generate the build-derived version header (build/src/shell/EndoVersion.hpp),
+# includable as <shell/EndoVersion.hpp>. ENDO_VERSION_STRING / ENDO_VERSION are
+# set at top scope by GetVersionInformation() and are visible here via the
+# add_subdirectory() scope. (Re-runs at configure time, not on every commit.)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/EndoVersion.hpp.in
+               ${CMAKE_CURRENT_BINARY_DIR}/EndoVersion.hpp @ONLY)
+
 add_library(endo-shell STATIC
     # Core
     Shell.hpp
@@ -240,6 +247,12 @@ if(NOT ENDO_STACKTRACE_NATIVE AND NOT MSVC)
         target_link_libraries(endo-shell PRIVATE stdc++exp)
     endif()
 endif()
+
+# Expose the generated EndoVersion.hpp (build/src/shell/EndoVersion.hpp) as
+# <shell/EndoVersion.hpp> to this target and its dependents (e.g. endo-bin). The
+# binary-tree src dir is already inherited transitively from CoreVM; this makes
+# the dependency explicit rather than relying on that.
+target_include_directories(endo-shell PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>)
 
 target_compile_definitions(endo-shell PRIVATE
     ENDO_DEFINITIONS_DIR="${CMAKE_SOURCE_DIR}/data/definitions"

--- a/src/shell/EndoVersion.hpp.in
+++ b/src/shell/EndoVersion.hpp.in
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <string_view>
+
+namespace endo
+{
+
+/// Human-readable build version string (e.g. "0.1.128-gabc1234").
+/// Derived at configure time from a git tag / describe / version.txt by
+/// GetVersionInformation() in cmake/Version.cmake (ENDO_VERSION_STRING).
+inline constexpr std::string_view EndoVersionString = "@ENDO_VERSION_STRING@";
+
+/// Numeric version triple (major.minor.patch), e.g. "0.1.128".
+/// Matches the CMake project() version and the Windows MSI ProductVersion
+/// (ENDO_VERSION).
+inline constexpr std::string_view EndoVersionNumber = "@ENDO_VERSION@";
+
+} // namespace endo

--- a/src/shell/HelpPrinter.cpp
+++ b/src/shell/HelpPrinter.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "HelpPrinter.hpp"
+#include <shell/EndoVersion.hpp>
 #include <shell/output/FileTypeStyle.hpp>
 #include <shell/ui/SyntaxHighlighter.hpp>
 
@@ -19,7 +20,6 @@ using namespace std::string_view_literals;
 namespace
 {
 
-constexpr std::string_view Version = "0.1.0";
 constexpr std::string_view DocsUrl = "https://endo-lang.org/";
 constexpr std::string_view GitHubUrl = "https://github.com/contour-terminal/endo";
 
@@ -364,12 +364,16 @@ void printVersion()
         auto const nameStyle =
             tui::Style { .fg = tui::RgbColor { .r = 0x50, .g = 0x78, .b = 0xFF }, .bold = true };
         auto const versionStyle = tui::Style { .fg = theme.colors.success };
-        std::print(
-            "{}endo{} {}{}{}", sgrSequence(nameStyle), Reset, sgrSequence(versionStyle), Version, Reset);
+        std::print("{}endo{} {}{}{}",
+                   sgrSequence(nameStyle),
+                   Reset,
+                   sgrSequence(versionStyle),
+                   endo::EndoVersionString,
+                   Reset);
     }
     else
     {
-        std::print("endo version {}", Version);
+        std::print("endo version {}", endo::EndoVersionString);
     }
     std::print("\n");
 }

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -24,8 +24,10 @@
 #endif
 
 #if defined(ENDO_BUILTIN_CRARHDUMP)
-#include "CrashHandler.hpp"
+    #include "CrashHandler.hpp"
 #endif
+#include <shell/EndoVersion.hpp>
+
 #include "FormatCommand.hpp"
 #include "HelpPrinter.hpp"
 #include "Shell.hpp"
@@ -40,8 +42,6 @@ using namespace std::string_view_literals;
 
 namespace
 {
-
-constexpr std::string_view Version = "0.1.0";
 
 void printLogCategories()
 {
@@ -279,7 +279,7 @@ int main(int argc, char const* argv[])
 #endif
 
 #if defined(ENDO_BUILTIN_CRARHDUMP)
-    endo::CrashHandler::initialize(std::string(Version).c_str());
+    endo::CrashHandler::initialize(std::string(endo::EndoVersionString).c_str());
 #endif
 
     auto const args = std::span(argv, static_cast<size_t>(argc));


### PR DESCRIPTION
Follow-up to the side-by-side Windows MSI installer work (#134). It makes the installed binary report its real version, hardens the CMake version derivation with a unit test, and cleans up the legacy NSIS `PATH` entry that could otherwise shadow the new versioned `bin`.

## Changes

- **Embed the build-derived version into the binary.** A generated `<shell/EndoVersion.hpp>` replaces the hardcoded `"0.1.0"` literals in `endo --version`, the help banner, and the crash handler, so the binary reports the actual git-tag or development-build version.
- **Extract git-describe parsing into a testable CMake module.** `endo_parse_git_describe()` (in `cmake/VersionParse.cmake`) is now exercised by a pure-CMake unit test (no git required), and the no-tag fallback warns loudly instead of silently degrading.
- **Remove the legacy NSIS `PATH` entry on MSI upgrade.** A static WIX component (frozen GUID) removes the old unversioned `C:\Program Files\Endo\bin` entry, and the new version's `bin` is prepended (`Part="first"`) so `endo` always resolves to the latest install even if a stray earlier entry survives. The migration is documented in the release notes and platform-differences page.