### PR TITLE
Fix Windows App Execution Aliases (winget) in endo

### DIFF
--- a/src/platform/FileInfoProvider_test.cpp
+++ b/src/platform/FileInfoProvider_test.cpp
@@ -198,6 +198,24 @@ TEST_CASE("LinuxFileInfoProvider.listDirectory_glob_no_match", "[platform][linux
     CHECK(entries.empty());
 }
 
+TEST_CASE("LinuxFileInfoProvider.listDirectory_lists_dangling_symlink", "[platform][linux]")
+{
+    // A dangling symlink fails to resolve via status() (which follows). It must still be
+    // listed via the symlink_status() fallback — mirroring how the Windows provider keeps
+    // App Execution Aliases (winget) visible despite their reparse points being unfollowable.
+    TempDir tmp;
+    tmp.createFile("real.txt", "data");
+    fs::create_symlink(tmp.path / "missing_target", tmp.path / "broken.lnk");
+
+    LinuxFileInfoProvider provider;
+    auto entries = provider.listDirectory(tmp.path.string());
+
+    REQUIRE(entries.size() == 2);
+    CHECK(entries[0].name == "broken.lnk");
+    CHECK(entries[0].isDir == false);
+    CHECK(entries[1].name == "real.txt");
+}
+
 TEST_CASE("LinuxFileInfoProvider.listDirectory_nonexistent", "[platform][linux]")
 {
     LinuxFileInfoProvider provider;

--- a/src/platform/FileSystem.hpp
+++ b/src/platform/FileSystem.hpp
@@ -31,6 +31,20 @@ class FileSystem
     [[nodiscard]] virtual bool isDirectory(std::filesystem::path const& path) const = 0;
     [[nodiscard]] virtual bool isRegularFile(std::filesystem::path const& path) const = 0;
     [[nodiscard]] virtual bool isSymlink(std::filesystem::path const& path) const = 0;
+
+    /// Tests whether @p path names a file the shell can execute.
+    ///
+    /// Returns true for regular files and symlinks to them, and — on Windows — also for
+    /// App Execution Alias reparse points (e.g. `winget`, Microsoft Store `python`). These
+    /// are zero-byte `IO_REPARSE_TAG_APPEXECLINK` reparse points that are neither regular
+    /// files nor symlinks and cannot be opened or followed through normal filesystem APIs,
+    /// yet they must stay discoverable on `PATH` so that `CreateProcessW` can launch them —
+    /// matching how `cmd.exe` and PowerShell resolve such commands. On POSIX the file must
+    /// additionally carry an execute permission bit. Directories always return false.
+    ///
+    /// @param path The path to test.
+    /// @return True if @p path is a runnable executable file, false otherwise.
+    [[nodiscard]] virtual bool isExecutableFile(std::filesystem::path const& path) const = 0;
     [[nodiscard]] virtual std::filesystem::path weaklyCanonical(std::filesystem::path const& path) const = 0;
     [[nodiscard]] virtual std::filesystem::path currentPath() const = 0;
 

--- a/src/platform/FileSystem_test.cpp
+++ b/src/platform/FileSystem_test.cpp
@@ -95,3 +95,41 @@ TEST_CASE("walkDirectoryRecursive yields nothing for a non-directory and reports
     // "could not enumerate", so they don't act on a partial/empty walk.
     REQUIRE(ec);
 }
+
+TEST_CASE("isExecutableFile accepts a file carrying an execute bit", "[FileSystem]")
+{
+    auto fs = InMemoryFileSystem {};
+    fs.addExecutable("/usr/bin/tool");
+
+    CHECK(fs.isExecutableFile("/usr/bin/tool"));
+}
+
+TEST_CASE("isExecutableFile rejects a regular file without an execute bit", "[FileSystem]")
+{
+    // Mirrors the POSIX rule the shell relies on: a readable/writable but non-executable
+    // file on PATH must not be treated as a runnable command.
+    auto fs = InMemoryFileSystem {};
+    fs.addFile("/usr/bin/data", "contents");
+
+    CHECK_FALSE(fs.isExecutableFile("/usr/bin/data"));
+}
+
+TEST_CASE("isExecutableFile rejects directories and missing paths", "[FileSystem]")
+{
+    auto fs = InMemoryFileSystem {};
+    fs.addDirectory("/usr/bin");
+
+    CHECK_FALSE(fs.isExecutableFile("/usr/bin"));
+    CHECK_FALSE(fs.isExecutableFile("/usr/bin/nope"));
+}
+
+TEST_CASE("isExecutableFile follows the execute bit of a symlink entry", "[FileSystem]")
+{
+    auto fs = InMemoryFileSystem {};
+    fs.addSymlink("/usr/bin/link", "/opt/real");
+    REQUIRE(fs.setPermissions("/usr/bin/link",
+                              std::filesystem::perms::owner_read | std::filesystem::perms::owner_exec)
+                .has_value());
+
+    CHECK(fs.isExecutableFile("/usr/bin/link"));
+}

--- a/src/platform/NativeFileSystem.cpp
+++ b/src/platform/NativeFileSystem.cpp
@@ -51,6 +51,31 @@ bool NativeFileSystem::isSymlink(fs::path const& path) const
     return fs::is_symlink(path, ec);
 }
 
+bool NativeFileSystem::isExecutableFile(fs::path const& path) const
+{
+#if defined(_WIN32)
+    // GetFileAttributesW does not follow reparse points, so it succeeds for App Execution
+    // Alias entries (winget, Store python, …) that CreateFileW/std::filesystem cannot open.
+    // Any existing non-directory entry is a runnable candidate; PATHEXT already restricts
+    // bare-name search to executable extensions, matching cmd.exe / PowerShell semantics.
+    auto const attrs = GetFileAttributesW(path.wstring().c_str());
+    return attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY) == 0;
+#else
+    std::error_code ec;
+    if (!fs::is_regular_file(path, ec) && !fs::is_symlink(path, ec))
+        return false;
+
+    auto const status = fs::status(path, ec);
+    if (ec)
+        return false;
+
+    auto const perms = status.permissions();
+    return (perms & fs::perms::owner_exec) != fs::perms::none
+           || (perms & fs::perms::group_exec) != fs::perms::none
+           || (perms & fs::perms::others_exec) != fs::perms::none;
+#endif
+}
+
 fs::path NativeFileSystem::weaklyCanonical(fs::path const& path) const
 {
     std::error_code ec;

--- a/src/platform/NativeFileSystem.hpp
+++ b/src/platform/NativeFileSystem.hpp
@@ -16,6 +16,7 @@ class NativeFileSystem final: public FileSystem
     [[nodiscard]] bool isDirectory(std::filesystem::path const& path) const override;
     [[nodiscard]] bool isRegularFile(std::filesystem::path const& path) const override;
     [[nodiscard]] bool isSymlink(std::filesystem::path const& path) const override;
+    [[nodiscard]] bool isExecutableFile(std::filesystem::path const& path) const override;
     [[nodiscard]] std::filesystem::path weaklyCanonical(std::filesystem::path const& path) const override;
     [[nodiscard]] std::filesystem::path currentPath() const override;
 

--- a/src/platform/linux/LinuxFileInfoProvider.cpp
+++ b/src/platform/linux/LinuxFileInfoProvider.cpp
@@ -23,9 +23,17 @@ namespace
 
         entry.name = dirEntry.path().filename().string();
 
-        auto const status = dirEntry.status(ec);
+        // status() follows symlinks, so a dangling symlink (its target was removed) fails to
+        // resolve. Fall back to the non-following symlink_status() so broken links are still
+        // listed rather than silently dropped — matching `ls`.
+        auto status = dirEntry.status(ec);
         if (ec)
-            return false;
+        {
+            ec.clear();
+            status = dirEntry.symlink_status(ec);
+            if (ec)
+                return false;
+        }
 
         entry.isDir = fs::is_directory(status);
         entry.mode = static_cast<int64_t>(status.permissions()) & 0777;
@@ -45,8 +53,7 @@ namespace
         {
 #if defined(__APPLE__)
             // macOS libc++ lacks std::chrono::clock_cast; file_clock uses the POSIX epoch.
-            entry.mtime =
-                std::chrono::duration_cast<std::chrono::seconds>(lwt.time_since_epoch()).count();
+            entry.mtime = std::chrono::duration_cast<std::chrono::seconds>(lwt.time_since_epoch()).count();
 #else
             auto const sysTime = std::chrono::clock_cast<std::chrono::system_clock>(lwt);
             entry.mtime =

--- a/src/platform/testing/InMemoryFileSystem.cpp
+++ b/src/platform/testing/InMemoryFileSystem.cpp
@@ -180,6 +180,21 @@ bool InMemoryFileSystem::isSymlink(std::filesystem::path const& path) const
     return _symlinks.contains(normalize(path));
 }
 
+bool InMemoryFileSystem::isExecutableFile(std::filesystem::path const& path) const
+{
+    auto const key = normalize(path);
+    if (!_files.contains(key) && !_symlinks.contains(key))
+        return false;
+
+    auto const it = _permissions.find(key);
+    auto const perms = it != _permissions.end()
+                           ? it->second
+                           : std::filesystem::perms::owner_read | std::filesystem::perms::owner_write;
+    return (perms & std::filesystem::perms::owner_exec) != std::filesystem::perms::none
+           || (perms & std::filesystem::perms::group_exec) != std::filesystem::perms::none
+           || (perms & std::filesystem::perms::others_exec) != std::filesystem::perms::none;
+}
+
 std::filesystem::path InMemoryFileSystem::weaklyCanonical(std::filesystem::path const& path) const
 {
     return std::filesystem::path(normalize(path));

--- a/src/platform/testing/InMemoryFileSystem.hpp
+++ b/src/platform/testing/InMemoryFileSystem.hpp
@@ -48,6 +48,7 @@ class InMemoryFileSystem final: public FileSystem
     [[nodiscard]] bool isDirectory(std::filesystem::path const& path) const override;
     [[nodiscard]] bool isRegularFile(std::filesystem::path const& path) const override;
     [[nodiscard]] bool isSymlink(std::filesystem::path const& path) const override;
+    [[nodiscard]] bool isExecutableFile(std::filesystem::path const& path) const override;
     [[nodiscard]] std::filesystem::path weaklyCanonical(std::filesystem::path const& path) const override;
     [[nodiscard]] std::filesystem::path currentPath() const override;
 

--- a/src/platform/windows/WindowsFileInfoProvider.cpp
+++ b/src/platform/windows/WindowsFileInfoProvider.cpp
@@ -27,9 +27,18 @@ namespace
 
         fileEntry.name = dirEntry.path().filename().string();
 
-        auto const status = dirEntry.status(ec);
+        // status() follows reparse points. App Execution Aliases (winget, Microsoft Store
+        // python, …) are reparse points that cannot be opened or followed through normal
+        // filesystem APIs, so the follow fails. Fall back to the non-following
+        // symlink_status() so such entries are still listed — matching `cmd.exe` / `dir`.
+        auto status = dirEntry.status(ec);
         if (ec)
-            return false;
+        {
+            ec.clear();
+            status = dirEntry.symlink_status(ec);
+            if (ec)
+                return false;
+        }
 
         fileEntry.isDir = fs::is_directory(status);
         fileEntry.size = 0;

--- a/src/shell/builtins/CommandBuilder.cpp
+++ b/src/shell/builtins/CommandBuilder.cpp
@@ -491,7 +491,15 @@ std::expected<std::filesystem::path, ShellError> Shell::resolveProgram(std::stri
 #endif
     )
     {
-        if (_fs.exists(programPath) && (_fs.isRegularFile(programPath) || _fs.isSymlink(programPath)))
+        // Native programs must be executable. Endo scripts are run in-process
+        // (see ProcessExecution.cpp) and therefore carry no execute bit, so accept
+        // an existing .endo regular file or symlink even when it is not executable.
+        if (_fs.isExecutableFile(programPath))
+        {
+            return programPath;
+        }
+        if (programPath.extension() == ".endo" && _fs.exists(programPath)
+            && (_fs.isRegularFile(programPath) || _fs.isSymlink(programPath)))
         {
             return programPath;
         }
@@ -502,7 +510,7 @@ std::expected<std::filesystem::path, ShellError> Shell::resolveProgram(std::stri
     if (!_env.get("PATH").has_value())
         return std::unexpected(ShellError::VariableNotFound);
 
-    auto const resolver = CommandResolver(_env);
+    auto const resolver = CommandResolver(_env, _fs);
     auto const found = resolver.findInPath(program);
     if (found.empty())
         return std::unexpected(ShellError::ProgramNotFound);

--- a/src/shell/builtins/Registration.cpp
+++ b/src/shell/builtins/Registration.cpp
@@ -478,7 +478,7 @@ void Shell::registerUserCommandBuiltins()
         .returnType(CoreVM::LiteralType::Number)
         .bind([this](CoreVM::Params& args) {
             auto const& program = args.getString(1);
-            CommandResolver resolver(_env);
+            CommandResolver resolver(_env, _fs);
             auto const info = resolver.resolve(program);
             if (info.type == CommandType::External)
             {

--- a/src/shell/builtins/UserCommands.cpp
+++ b/src/shell/builtins/UserCommands.cpp
@@ -292,7 +292,7 @@ void Shell::builtinWhich(CoreVM::Params& context)
     }
 
     // Use CommandResolver for PATH search (handles PATH separator and PATHEXT correctly)
-    auto const resolver = CommandResolver(_env);
+    auto const resolver = CommandResolver(_env, _fs);
     bool allFound = true;
 
     // Search for each program

--- a/src/shell/ui/Prompt.cpp
+++ b/src/shell/ui/Prompt.cpp
@@ -20,6 +20,7 @@
 #include <shell/util/CommandResolver.hpp>
 
 #include "PromptComponent.hpp"
+#include <platform/NativeFileSystem.hpp>
 #if defined(_WIN32)
     #include <platform/windows/WindowsEnvironmentProvider.hpp>
 #else
@@ -69,11 +70,13 @@ void Prompt::initialize()
     // Ensure any protocol enable sequences are flushed
     _terminal.output().flush();
 
-    // Create CommandResolver for tooltip support
+    // Create CommandResolver for tooltip support. It shares the filesystem the Shell
+    // injected via setFileSystem(); fall back to the native filesystem if none was set.
+    auto const& fs = _historyFs ? *_historyFs : NativeFileSystem::instance();
 #if defined(_WIN32)
-    _commandResolver = std::make_unique<CommandResolver>(WindowsEnvironmentProvider::instance());
+    _commandResolver = std::make_unique<CommandResolver>(WindowsEnvironmentProvider::instance(), fs);
 #else
-    _commandResolver = std::make_unique<CommandResolver>(PosixEnvironmentProvider::instance());
+    _commandResolver = std::make_unique<CommandResolver>(PosixEnvironmentProvider::instance(), fs);
 #endif
 
     // Create PromptComponent

--- a/src/shell/util/CommandResolver.cpp
+++ b/src/shell/util/CommandResolver.cpp
@@ -13,7 +13,7 @@
 namespace endo
 {
 
-CommandResolver::CommandResolver(EnvironmentProvider const& env): _env(env)
+CommandResolver::CommandResolver(EnvironmentProvider const& env, FileSystem const& fs): _env(env), _fs(fs)
 {
 }
 
@@ -99,16 +99,15 @@ std::vector<std::string> CommandResolver::findAllInPath(std::string_view command
         if (pathStr.empty())
             continue;
 
-        std::error_code ec;
         std::filesystem::path dir(pathStr);
 
-        if (!std::filesystem::exists(dir, ec) || !std::filesystem::is_directory(dir, ec))
+        if (!_fs.exists(dir) || !_fs.isDirectory(dir))
             continue;
 
         auto const candidate = dir / std::string(command);
 
 #if defined(_WIN32)
-        // On Windows, check the exact name first, then try each PATHEXT extension
+        // On Windows, check the exact name first, then try each PATHEXT extension.
         auto const candidates = [&]() {
             auto result = std::vector<std::filesystem::path> {};
             result.push_back(candidate);
@@ -119,31 +118,13 @@ std::vector<std::string> CommandResolver::findAllInPath(std::string_view command
 
         for (auto const& cand: candidates)
         {
-            if (!std::filesystem::exists(cand, ec))
-                continue;
-            if (!std::filesystem::is_regular_file(cand, ec) && !std::filesystem::is_symlink(cand, ec))
+            if (!_fs.isExecutableFile(cand))
                 continue;
             results.push_back(platform::normalizePath(cand));
             break; // At most one match per PATH directory
         }
 #else
-        if (!std::filesystem::exists(candidate, ec))
-            continue;
-
-        if (!std::filesystem::is_regular_file(candidate, ec) && !std::filesystem::is_symlink(candidate, ec))
-            continue;
-
-        // Check if executable
-        auto status = std::filesystem::status(candidate, ec);
-        if (ec)
-            continue;
-
-        auto perms = status.permissions();
-        bool isExecutable = (perms & std::filesystem::perms::owner_exec) != std::filesystem::perms::none
-                            || (perms & std::filesystem::perms::group_exec) != std::filesystem::perms::none
-                            || (perms & std::filesystem::perms::others_exec) != std::filesystem::perms::none;
-
-        if (isExecutable)
+        if (_fs.isExecutableFile(candidate))
             results.push_back(candidate.string());
 #endif
     }

--- a/src/shell/util/CommandResolver.hpp
+++ b/src/shell/util/CommandResolver.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <platform/EnvironmentProvider.hpp>
+#include <platform/FileSystem.hpp>
 
 namespace endo
 {
@@ -40,8 +41,10 @@ struct CommandInfo
 class CommandResolver
 {
   public:
-    /// @brief Constructs a resolver with access to the environment.
-    explicit CommandResolver(EnvironmentProvider const& env);
+    /// @brief Constructs a resolver with access to the environment and filesystem.
+    /// @param env Environment provider, used to read PATH and PATHEXT.
+    /// @param fs  Filesystem abstraction, used to test candidate executables.
+    CommandResolver(EnvironmentProvider const& env, FileSystem const& fs);
 
     /// @brief Resolves a command and returns its info.
     /// @param command The command name to resolve.
@@ -75,6 +78,7 @@ class CommandResolver
 
   private:
     EnvironmentProvider const& _env;
+    FileSystem const& _fs;
 
     // Cache for efficiency
     mutable std::string _cachedPath;

--- a/src/shell/util/CommandResolver_test.cpp
+++ b/src/shell/util/CommandResolver_test.cpp
@@ -8,6 +8,8 @@
 #include <fstream>
 #include <string>
 
+#include <platform/NativeFileSystem.hpp>
+#include <platform/testing/InMemoryFileSystem.hpp>
 #include <platform/testing/TestEnvironmentProvider.hpp>
 
 using namespace endo;
@@ -67,7 +69,7 @@ TEST_CASE("CommandResolver.findInPath.bare_name_found")
     env.set("PATHEXT", ".exe;.cmd;.bat");
 #endif
 
-    auto const resolver = CommandResolver(env);
+    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
     auto const result = resolver.findInPath("testcmd");
     REQUIRE(!result.empty());
     CHECK(std::filesystem::path(result).filename().string().starts_with("testcmd"));
@@ -83,7 +85,7 @@ TEST_CASE("CommandResolver.findInPath.not_found")
     env.set("PATHEXT", ".exe");
 #endif
 
-    auto const resolver = CommandResolver(env);
+    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
     auto const result = resolver.findInPath("nonexistent");
     CHECK(result.empty());
 }
@@ -93,7 +95,7 @@ TEST_CASE("CommandResolver.findInPath.missing_PATH")
     platform::TestEnvironmentProvider env;
     // No PATH set at all.
 
-    auto const resolver = CommandResolver(env);
+    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
     auto const result = resolver.findInPath("anything");
     CHECK(result.empty());
 }
@@ -114,7 +116,7 @@ TEST_CASE("CommandResolver.findInPath.skips_nonexistent_directory")
     env.set("PATH", pathValue);
 #endif
 
-    auto const resolver = CommandResolver(env);
+    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
     auto const result = resolver.findInPath("mycmd");
     REQUIRE(!result.empty());
     CHECK(std::filesystem::path(result).filename().string().starts_with("mycmd"));
@@ -131,7 +133,7 @@ TEST_CASE("CommandResolver.findInPath.PATHEXT_resolution")
     env.set("PATH", dir.path.string());
     env.set("PATHEXT", ".exe;.cmd;.bat");
 
-    auto const resolver = CommandResolver(env);
+    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
     auto const result = resolver.findInPath("testapp");
     REQUIRE(!result.empty());
     CHECK(result.ends_with(".cmd"));
@@ -148,8 +150,30 @@ TEST_CASE("CommandResolver.findInPath.skips_non_executable")
     platform::TestEnvironmentProvider env;
     env.set("PATH", dir.path.string());
 
-    auto const resolver = CommandResolver(env);
+    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
     auto const result = resolver.findInPath("noexec");
     CHECK(result.empty());
 }
 #endif
+
+TEST_CASE("CommandResolver.findInPath.resolves_through_injected_filesystem")
+{
+    // Drives PATH search entirely through an injected InMemoryFileSystem — no disk access —
+    // proving the resolver now relies on the FileSystem abstraction rather than std::filesystem.
+    platform::testing::InMemoryFileSystem fs;
+    fs.addDirectory("/bin");
+    platform::TestEnvironmentProvider env;
+#if defined(_WIN32)
+    fs.addExecutable("/bin/tool.exe");
+    env.set("PATH", "/bin");
+    env.set("PATHEXT", ".exe;.cmd");
+#else
+    fs.addExecutable("/bin/tool");
+    env.set("PATH", "/bin");
+#endif
+
+    auto const resolver = CommandResolver(env, fs);
+    auto const result = resolver.findInPath("tool");
+    REQUIRE(!result.empty());
+    CHECK(std::filesystem::path(result).filename().string().starts_with("tool"));
+}


### PR DESCRIPTION
On Windows, commands installed as App Execution Aliases — winget, the Microsoft Store `python`, and others living in `%LOCALAPPDATA%\Microsoft\WindowsApps` — did not work in endo: they were reported "program not found" when run, and were missing from `ls` output even though the directory itself was on `PATH`. These aliases are zero-byte `IO_REPARSE_TAG_APPEXECLINK` reparse points that are neither regular files nor symlinks and cannot be opened or followed through normal filesystem APIs, yet Windows resolves them during process creation. endo's filesystem checks all followed the reparse and discarded the entry on failure, so the aliases fell through every code path. This PR makes endo treat them the way `cmd.exe` and PowerShell do.

## Changes

- Add `FileSystem::isExecutableFile()` as the single source of truth for "is this path a runnable executable file". On Windows it queries `GetFileAttributesW` (which does not follow the reparse) and accepts any existing non-directory entry; on POSIX it keeps the regular-file/symlink + execute-bit rule.
- Route both the `PATH` search in `CommandResolver` and the explicit-path branch of `resolveProgram` through it, collapsing the previously duplicated `is_regular_file || is_symlink` checks.
- Inject the `FileSystem` abstraction into `CommandResolver` so its `PATH` resolution no longer touches `std::filesystem` directly and is unit-testable via `InMemoryFileSystem`.
- Fix `ls` dropping such entries: `FileInfoProvider::statEntry` now falls back to the non-following `symlink_status()` when `status()` fails, in both the Windows and Linux providers. On Linux this symmetrically restores listing of dangling symlinks.