### PR TITLE
Add reusable TreeTableView TUI browser, lstat-backed FileInfo, and coroutine stop-token

### DIFF
--- a/src/coro/Cancellation.hpp
+++ b/src/coro/Cancellation.hpp
@@ -14,6 +14,7 @@
 /// does not, add a minimal fallback here mirroring `Generator.hpp` rather than
 /// changing call sites.
 
+#include <coroutine>
 #include <version>
 
 #if defined(__cpp_lib_jthread) && __cpp_lib_jthread >= 201911L
@@ -51,5 +52,39 @@ namespace endo::coro
 struct OperationCancelled
 {
 };
+
+/// Awaitable that yields the @c StopToken of the awaiting coroutine without
+/// suspending it. Lets a coroutine body observe its own cancellation token (e.g. to
+/// poll @c stop_requested() inside a loop) when the promise carries one; coroutines
+/// whose promise has no @c stopToken() accessor receive a default (never-stopped)
+/// token. Usage: `auto token = co_await endo::coro::thisCoroStopToken();`.
+struct ThisCoroStopToken
+{
+    StopToken token {}; ///< Filled from the awaiting promise in await_suspend.
+
+    /// Never ready: await_suspend runs to capture the token, then resumes immediately.
+    [[nodiscard]] bool await_ready() const noexcept { return false; }
+
+    /// Captures the awaiting coroutine's stop token (if its promise exposes one) and
+    /// resumes without actually suspending.
+    /// @param awaiting The coroutine performing the co_await.
+    /// @return false — do not suspend; resume @p awaiting immediately.
+    template <typename Promise>
+    bool await_suspend(std::coroutine_handle<Promise> awaiting) noexcept
+    {
+        if constexpr (requires { awaiting.promise().stopToken(); })
+            token = awaiting.promise().stopToken();
+        return false;
+    }
+
+    /// @return The captured stop token.
+    [[nodiscard]] StopToken await_resume() const noexcept { return token; }
+};
+
+/// @return An awaitable yielding the awaiting coroutine's @c StopToken.
+[[nodiscard]] inline ThisCoroStopToken thisCoroStopToken() noexcept
+{
+    return ThisCoroStopToken {};
+}
 
 } // namespace endo::coro

--- a/src/platform/FileInfoProvider.hpp
+++ b/src/platform/FileInfoProvider.hpp
@@ -9,13 +9,22 @@ namespace endo::platform
 {
 
 /// Platform-independent file entry returned by FileInfoProvider.
+///
+/// Fields beyond @c name carry standard `stat(2)` metadata. The block/identity
+/// fields (@c blocks, @c dev, @c ino) enable true disk-usage accounting, hardlink
+/// deduplication, and cross-filesystem detection; platforms that cannot supply
+/// them leave the documented sentinel defaults (@c blocks = -1, @c dev/@c ino = 0).
 struct FileEntry
 {
-    std::string name; ///< File name (not full path)
-    int64_t size;     ///< File size in bytes
-    int64_t mode;     ///< Permission bits (e.g. 0755)
-    int64_t mtime;    ///< Last modification time as epoch seconds
-    bool isDir;       ///< Whether this entry is a directory
+    std::string name;       ///< File name (not full path).
+    int64_t size = 0;       ///< Apparent size in bytes (st_size).
+    int64_t blocks = -1;    ///< Allocated 512-byte blocks (st_blocks); -1 if unknown.
+    int64_t mode = 0;       ///< Permission bits (e.g. 0755).
+    int64_t mtime = 0;      ///< Last modification time as epoch seconds.
+    uint64_t dev = 0;       ///< Device id (st_dev) for cross-filesystem detection; 0 if unknown.
+    uint64_t ino = 0;       ///< Inode number (st_ino) for hardlink dedup; 0 if unknown.
+    bool isDir = false;     ///< Whether this entry is a directory.
+    bool isSymlink = false; ///< Whether this entry is a symbolic link (from lstat, not followed).
 };
 
 /// Abstract interface for listing directory contents.

--- a/src/platform/FileInfoProvider_test.cpp
+++ b/src/platform/FileInfoProvider_test.cpp
@@ -216,6 +216,63 @@ TEST_CASE("LinuxFileInfoProvider.listDirectory_lists_dangling_symlink", "[platfo
     CHECK(entries[1].name == "real.txt");
 }
 
+TEST_CASE("LinuxFileInfoProvider.populates_stat_metadata", "[platform][linux]")
+{
+    // The lstat-based provider must fill the disk-usage / identity fields
+    // (blocks, dev, ino) for real files, not just apparent size.
+    TempDir tmp;
+    tmp.createFile("data.bin", std::string(8192, 'x')); // 8 KiB => several 512B blocks
+
+    LinuxFileInfoProvider provider;
+    auto entries = provider.listDirectory((tmp.path / "data.bin").string());
+
+    REQUIRE(entries.size() == 1);
+    auto const& e = entries[0];
+    CHECK(e.size == 8192);
+    CHECK(e.blocks > 0);     // allocated blocks reported (st_blocks)
+    CHECK(e.dev != 0);       // device id reported (st_dev)
+    CHECK(e.ino != 0);       // inode reported (st_ino)
+    CHECK(e.isSymlink == false);
+    CHECK(e.isDir == false);
+}
+
+TEST_CASE("LinuxFileInfoProvider.marks_symlink", "[platform][linux]")
+{
+    // A symlink must be flagged isSymlink and never reported as a directory,
+    // even when it points at one (it is not followed).
+    TempDir tmp;
+    tmp.createSubdir("realdir");
+    fs::create_symlink(tmp.path / "realdir", tmp.path / "link_to_dir");
+
+    LinuxFileInfoProvider provider;
+    auto entries = provider.listDirectory(tmp.path.string());
+
+    REQUIRE(entries.size() == 2);
+    // Sorted by name: "link_to_dir" < "realdir"
+    CHECK(entries[0].name == "link_to_dir");
+    CHECK(entries[0].isSymlink == true);
+    CHECK(entries[0].isDir == false); // not followed -> not a directory
+    CHECK(entries[1].name == "realdir");
+    CHECK(entries[1].isSymlink == false);
+    CHECK(entries[1].isDir == true);
+}
+
+TEST_CASE("LinuxFileInfoProvider.siblings_share_device", "[platform][linux]")
+{
+    // Two entries in the same directory live on the same filesystem, so their
+    // st_dev must match — the invariant cross-device detection relies on.
+    TempDir tmp;
+    tmp.createFile("a.txt", "a");
+    tmp.createFile("b.txt", "b");
+
+    LinuxFileInfoProvider provider;
+    auto entries = provider.listDirectory(tmp.path.string());
+
+    REQUIRE(entries.size() == 2);
+    CHECK(entries[0].dev == entries[1].dev);
+    CHECK(entries[0].ino != entries[1].ino); // distinct files -> distinct inodes
+}
+
 TEST_CASE("LinuxFileInfoProvider.listDirectory_nonexistent", "[platform][linux]")
 {
     LinuxFileInfoProvider provider;

--- a/src/platform/Pipe.cpp
+++ b/src/platform/Pipe.cpp
@@ -19,10 +19,15 @@ namespace endo::platform
 
 namespace
 {
-    auto inline pipeTag = logstore::category("platform.pipe", "Platform pipe operations");
-
+    /// Lazily-initialized log category for platform pipe operations.
+    ///
+    /// A function-local static (initialized on first use) is used instead of a
+    /// namespace-scope static so the potentially-throwing @c logstore::category
+    /// construction does not run during static initialization
+    /// (bugprone-throwing-static-initialization).
     auto& pipeLog()
     {
+        static auto pipeTag = logstore::category("platform.pipe", "Platform pipe operations");
         return pipeTag;
     }
 } // namespace

--- a/src/platform/linux/LinuxFileInfoProvider.cpp
+++ b/src/platform/linux/LinuxFileInfoProvider.cpp
@@ -2,8 +2,10 @@
 #include "LinuxFileInfoProvider.hpp"
 
 #include <algorithm>
-#include <chrono>
 #include <filesystem>
+#include <string>
+
+#include <sys/stat.h>
 
 #include <platform/GlobMatch.hpp>
 
@@ -15,56 +17,37 @@ namespace
 
     namespace fs = std::filesystem;
 
-    /// Populates a FileEntry from a filesystem directory_entry.
-    /// @return true on success, false if the entry could not be stat'd.
-    [[nodiscard]] bool statEntry(fs::directory_entry const& dirEntry, FileEntry& entry)
+    /// Populates a FileEntry from a filesystem path using a raw lstat(2).
+    ///
+    /// lstat() does not follow symlinks, so dangling links are reported as their own
+    /// (link) entry rather than silently dropped — matching `ls`. Using the raw stat
+    /// (instead of std::filesystem) lets us capture the allocated block count
+    /// (st_blocks), device id (st_dev), and inode (st_ino) that true disk-usage
+    /// accounting, hardlink dedup, and cross-filesystem detection require.
+    ///
+    /// @param fullPath Absolute or relative path to stat.
+    /// @param name     The entry's display name (filename component).
+    /// @param entry    Output entry to populate.
+    /// @return true on success, false if the path could not be stat'd.
+    [[nodiscard]] bool statEntry(std::string const& fullPath, std::string name, FileEntry& entry)
     {
-        std::error_code ec;
+        struct stat st {};
+        if (::lstat(fullPath.c_str(), &st) != 0)
+            return false;
 
-        entry.name = dirEntry.path().filename().string();
+        entry.name = std::move(name);
+        entry.isSymlink = S_ISLNK(st.st_mode);
+        entry.mode = static_cast<int64_t>(st.st_mode) & 0777;
+        entry.mtime = static_cast<int64_t>(st.st_mtime);
+        entry.dev = static_cast<uint64_t>(st.st_dev);
+        entry.ino = static_cast<uint64_t>(st.st_ino);
+        entry.blocks = static_cast<int64_t>(st.st_blocks);
 
-        // status() follows symlinks, so a dangling symlink (its target was removed) fails to
-        // resolve. Fall back to the non-following symlink_status() so broken links are still
-        // listed rather than silently dropped — matching `ls`.
-        auto status = dirEntry.status(ec);
-        if (ec)
-        {
-            ec.clear();
-            status = dirEntry.symlink_status(ec);
-            if (ec)
-                return false;
-        }
-
-        entry.isDir = fs::is_directory(status);
-        entry.mode = static_cast<int64_t>(status.permissions()) & 0777;
-
-        entry.size = 0;
-        if (!entry.isDir)
-        {
-            auto const fileSize = dirEntry.file_size(ec);
-            if (!ec)
-                entry.size = static_cast<int64_t>(fileSize);
-            else
-                ec.clear();
-        }
-
-        auto const lwt = dirEntry.last_write_time(ec);
-        if (!ec)
-        {
-#if defined(__APPLE__)
-            // macOS libc++ lacks std::chrono::clock_cast; file_clock uses the POSIX epoch.
-            entry.mtime = std::chrono::duration_cast<std::chrono::seconds>(lwt.time_since_epoch()).count();
-#else
-            auto const sysTime = std::chrono::clock_cast<std::chrono::system_clock>(lwt);
-            entry.mtime =
-                std::chrono::duration_cast<std::chrono::seconds>(sysTime.time_since_epoch()).count();
-#endif
-        }
-        else
-        {
-            entry.mtime = 0;
-            ec.clear();
-        }
+        // For a symlink, lstat reports the link's own metadata. Whether the target is a
+        // directory is intentionally not resolved here (the link is not followed), so a
+        // symlink is never treated as a directory for traversal purposes.
+        entry.isDir = S_ISDIR(st.st_mode);
+        entry.size = static_cast<int64_t>(st.st_size);
 
         return true;
     }
@@ -91,11 +74,11 @@ std::vector<FileEntry> LinuxFileInfoProvider::listDirectory(std::string const& p
             if (ec)
                 break;
 
-            auto const filename = dirEntry.path().filename().string();
+            auto filename = dirEntry.path().filename().string();
             if (endo::globMatchFilename(filename, filePattern))
             {
                 FileEntry entry {};
-                if (statEntry(dirEntry, entry))
+                if (statEntry(dirEntry.path().string(), std::move(filename), entry))
                     entries.push_back(std::move(entry));
             }
         }
@@ -113,7 +96,7 @@ std::vector<FileEntry> LinuxFileInfoProvider::listDirectory(std::string const& p
                 break;
 
             FileEntry entry {};
-            if (statEntry(dirEntry, entry))
+            if (statEntry(dirEntry.path().string(), dirEntry.path().filename().string(), entry))
                 entries.push_back(std::move(entry));
         }
 
@@ -122,10 +105,10 @@ std::vector<FileEntry> LinuxFileInfoProvider::listDirectory(std::string const& p
     }
 
     // Case 3: Single file path — stat and return one entry.
-    if (auto const dirEntry = fs::directory_entry(fs::path(path), ec); !ec)
     {
+        auto const single = fs::path(path);
         FileEntry entry {};
-        if (statEntry(dirEntry, entry))
+        if (statEntry(path, single.filename().string(), entry))
             entries.push_back(std::move(entry));
     }
 

--- a/src/platform/windows/WindowsFileInfoProvider.cpp
+++ b/src/platform/windows/WindowsFileInfoProvider.cpp
@@ -41,7 +41,16 @@ namespace
         }
 
         fileEntry.isDir = fs::is_directory(status);
+        fileEntry.isSymlink = fs::is_symlink(dirEntry.symlink_status(ec));
+        ec.clear();
         fileEntry.size = 0;
+
+        // Windows std::filesystem does not expose st_blocks/st_dev/st_ino. Leave the
+        // documented sentinels (blocks = -1, dev = ino = 0); disk-usage callers fall
+        // back to apparent size and disable hardlink dedup / cross-device detection.
+        fileEntry.blocks = -1;
+        fileEntry.dev = 0;
+        fileEntry.ino = 0;
 
         if (!fileEntry.isDir)
         {

--- a/src/tui/CMakeLists.txt
+++ b/src/tui/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(tui
     Text.cpp
     Theme.cpp
     Tooltip.cpp
+    TreeTableView.cpp
     Unicode.cpp
     VtParser.cpp
     completer/Completer.cpp
@@ -99,6 +100,7 @@ if(ENDO_TESTING)
         MarkdownRenderer_test.cpp
         QuestionComponent_test.cpp
         StyledText_test.cpp
+        TreeTableView_test.cpp
         Unicode_test.cpp
         VtParser_test.cpp
         ImageLoader_test.cpp

--- a/src/tui/KeyBindings.cpp
+++ b/src/tui/KeyBindings.cpp
@@ -269,8 +269,10 @@ std::optional<KeyChord> KeyChord::parse(std::string_view str)
         result.key = *specialKey;
         result.codepoint = 0;
     }
-    // Check for single letter key
-    else if (lastPart.size() == 1 && std::isalpha(static_cast<unsigned char>(lastPart[0])))
+    // Check for a single printable character key. Letters are lowercased so "g" and
+    // "G" (the latter typically written "shift+g") share one codepoint; other
+    // printable characters (digits, punctuation such as '/', '.', '?') map directly.
+    else if (lastPart.size() == 1 && std::isgraph(static_cast<unsigned char>(lastPart[0])))
     {
         result.codepoint = static_cast<char32_t>(std::tolower(static_cast<unsigned char>(lastPart[0])));
         result.key = {};

--- a/src/tui/Screen.cpp
+++ b/src/tui/Screen.cpp
@@ -77,9 +77,27 @@ Screen::Screen(Terminal& terminal, ScreenConfig config):
     });
 
     _hoverState.setOnHoverLeave([this]() { hideTooltip(); });
+
+    // Switch to the alternate screen buffer (DEC private mode 1049) so the app paints on a
+    // fresh screen and the user's scrollback is preserved; restored in the destructor.
+    if (_config.alternateScreen)
+    {
+        _terminal.output().writeRaw("\033[?1049h");
+        _terminal.output().flush();
+        _enteredAlternateScreen = true;
+    }
 }
 
-Screen::~Screen() = default;
+Screen::~Screen()
+{
+    if (_enteredAlternateScreen)
+    {
+        auto& out = _terminal.output();
+        out.showCursor();
+        out.writeRaw("\033[?1049l"); // leave the alternate screen, restoring the primary buffer
+        out.flush();
+    }
+}
 
 Component& Screen::root() noexcept
 {

--- a/src/tui/Screen.hpp
+++ b/src/tui/Screen.hpp
@@ -52,6 +52,11 @@ struct ScreenConfig
     int inlineMaxHeight = 0;                        ///< For Viewport::Inline (0 = no limit).
     UnscrollMode unscrollMode = UnscrollMode::Auto; ///< Unscroll behavior for inline mode.
     bool inhibitReflow = false;                     ///< Disable text reflow (DEC 2028) on rendered lines.
+
+    /// Switch to the terminal's alternate screen buffer (DEC private mode 1049) for the
+    /// lifetime of the Screen, restoring the primary buffer (and the user's scrollback) on
+    /// destruction. Intended for full-screen apps with @c Viewport::Fullscreen.
+    bool alternateScreen = false;
 };
 
 /// Cursor movement calculations for inline rendering.
@@ -297,6 +302,7 @@ class Screen // NOLINT(clang-analyzer-optin.performance.Padding)
     Buffer _previous;
 
     bool _needsFullRedraw = true;
+    bool _enteredAlternateScreen = false; ///< Whether we switched to the alternate screen buffer.
     std::unordered_set<Component*> _dirtyComponents;
     int _previousContentHeight = 0;
     int _previousCursorRow = 0;         ///< Cursor row at end of last inline render (for positioning)

--- a/src/tui/TerminalOutput.hpp
+++ b/src/tui/TerminalOutput.hpp
@@ -18,6 +18,9 @@ struct RgbColor
     std::uint8_t r = 0;
     std::uint8_t g = 0;
     std::uint8_t b = 0;
+
+    /// Componentwise equality.
+    [[nodiscard]] constexpr bool operator==(RgbColor const&) const noexcept = default;
 };
 
 /// @brief User-defined literal for creating RgbColor from a hex value.

--- a/src/tui/TreeTableView.cpp
+++ b/src/tui/TreeTableView.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <tui/Canvas.hpp>
 #include <tui/KeyCode.hpp>
+#include <tui/Modifier.hpp>
 #include <tui/Theme.hpp>
 #include <tui/TreeTableView.hpp>
 
@@ -70,6 +71,13 @@ void TreeTableView::pageBy(int direction)
     auto const headerLines = _config.showHeader ? 1 : 0;
     auto const viewport = std::max(1, area().height - headerLines);
     moveCursor(direction * viewport);
+}
+
+void TreeTableView::halfPageBy(int direction)
+{
+    auto const headerLines = _config.showHeader ? 1 : 0;
+    auto const viewport = std::max(1, area().height - headerLines);
+    moveCursor(direction * std::max(1, viewport / 2));
 }
 
 void TreeTableView::descendCursor()
@@ -152,6 +160,17 @@ EventResult TreeTableView::onEvent(InputEvent const& event)
     // accept a few intrinsic keys so the component is usable standalone.
     if (auto const* key = std::get_if<KeyEvent>(&event))
     {
+        // Ctrl-D / Ctrl-U: half-page down / up (vim).
+        if (hasModifier(key->modifiers, Modifier::Ctrl))
+        {
+            switch (key->codepoint)
+            {
+                case U'd': halfPageBy(1); return EventResult::Handled;
+                case U'u': halfPageBy(-1); return EventResult::Handled;
+                default: break;
+            }
+        }
+
         switch (key->key)
         {
             case KeyCode::Up: moveCursor(-1); return EventResult::Handled;
@@ -168,6 +187,8 @@ EventResult TreeTableView::onEvent(InputEvent const& event)
             case U'k': moveCursor(-1); return EventResult::Handled;
             case U'l': descendCursor(); return EventResult::Handled;
             case U'h': ascendCursor(); return EventResult::Handled;
+            case U'g': moveToTop(); return EventResult::Handled;
+            case U'G': moveToBottom(); return EventResult::Handled;
             default: break;
         }
     }

--- a/src/tui/TreeTableView.cpp
+++ b/src/tui/TreeTableView.cpp
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <tui/Canvas.hpp>
+#include <tui/KeyCode.hpp>
+#include <tui/Theme.hpp>
+#include <tui/TreeTableView.hpp>
+
+#include <algorithm>
+#include <utility>
+
+namespace tui
+{
+
+TreeTableView::TreeTableView(TreeTableModel& model, TreeTableConfig config) noexcept:
+    _model(model), _config(config)
+{
+}
+
+void TreeTableView::clampCursor()
+{
+    auto const count = _model.rows().size();
+    if (count == 0)
+    {
+        _cursor = 0;
+        _scroll = 0;
+        return;
+    }
+    _cursor = std::min(_cursor, count - 1);
+
+    // Keep the cursor within the visible window (header takes one line when shown).
+    auto const headerLines = _config.showHeader ? 1u : 0u;
+    auto const areaHeight = static_cast<unsigned>(std::max(0, area().height));
+    auto const viewport = (areaHeight > headerLines) ? areaHeight - headerLines : 1u;
+    if (_cursor < _scroll)
+        _scroll = _cursor;
+    else if (_cursor >= _scroll + viewport)
+        _scroll = _cursor - viewport + 1;
+}
+
+void TreeTableView::moveCursor(int delta)
+{
+    auto const count = _model.rows().size();
+    if (count == 0)
+        return;
+    auto const target = static_cast<long long>(_cursor) + delta;
+    _cursor = static_cast<std::size_t>(std::clamp<long long>(target, 0, static_cast<long long>(count) - 1));
+    clampCursor();
+    if (_onChanged)
+        _onChanged();
+}
+
+void TreeTableView::moveToTop()
+{
+    _cursor = 0;
+    clampCursor();
+    if (_onChanged)
+        _onChanged();
+}
+
+void TreeTableView::moveToBottom()
+{
+    auto const count = _model.rows().size();
+    _cursor = (count == 0) ? 0 : count - 1;
+    clampCursor();
+    if (_onChanged)
+        _onChanged();
+}
+
+void TreeTableView::pageBy(int direction)
+{
+    auto const headerLines = _config.showHeader ? 1 : 0;
+    auto const viewport = std::max(1, area().height - headerLines);
+    moveCursor(direction * viewport);
+}
+
+void TreeTableView::descendCursor()
+{
+    bool valid = false;
+    auto const row = cursorRow(valid);
+    if (!valid || !_model.canDescend(row))
+        return;
+
+    // Remember where we were so ascending restores the cursor.
+    _cursorHistory.emplace_back(_model.currentTitle(), _cursor);
+    if (_model.descend(row))
+    {
+        _cursor = 0;
+        _scroll = 0;
+        clampCursor();
+        if (_onChanged)
+            _onChanged();
+    }
+    else
+    {
+        _cursorHistory.pop_back();
+    }
+}
+
+void TreeTableView::ascendCursor()
+{
+    if (!_model.ascend())
+        return;
+
+    // Restore the remembered cursor for the node we just returned to.
+    _cursor = 0;
+    if (!_cursorHistory.empty())
+    {
+        auto const& [title, idx] = _cursorHistory.back();
+        if (title == _model.currentTitle())
+        {
+            _cursor = idx;
+            _cursorHistory.pop_back();
+        }
+    }
+    _scroll = 0;
+    clampCursor();
+    if (_onChanged)
+        _onChanged();
+}
+
+void TreeTableView::sortBy(int sortKey)
+{
+    // Keep the cursor on the same row across the re-sort when possible.
+    bool valid = false;
+    auto const current = cursorRow(valid);
+    _model.sortBy(sortKey);
+    if (valid)
+    {
+        auto const rows = _model.rows();
+        if (auto const it = std::ranges::find(rows, current); it != rows.end())
+            _cursor = static_cast<std::size_t>(std::distance(rows.begin(), it));
+    }
+    clampCursor();
+    if (_onChanged)
+        _onChanged();
+}
+
+RowId TreeTableView::cursorRow(bool& valid) const
+{
+    auto const rows = _model.rows();
+    if (_cursor >= rows.size())
+    {
+        valid = false;
+        return 0;
+    }
+    valid = true;
+    return rows[_cursor];
+}
+
+EventResult TreeTableView::onEvent(InputEvent const& event)
+{
+    // The view handles only generic motions; the host maps keys to these calls. We still
+    // accept a few intrinsic keys so the component is usable standalone.
+    if (auto const* key = std::get_if<KeyEvent>(&event))
+    {
+        switch (key->key)
+        {
+            case KeyCode::Up: moveCursor(-1); return EventResult::Handled;
+            case KeyCode::Down: moveCursor(1); return EventResult::Handled;
+            case KeyCode::PageUp: pageBy(-1); return EventResult::Handled;
+            case KeyCode::PageDown: pageBy(1); return EventResult::Handled;
+            case KeyCode::Enter: descendCursor(); return EventResult::Handled;
+            case KeyCode::Backspace: ascendCursor(); return EventResult::Handled;
+            default: break;
+        }
+        switch (key->codepoint)
+        {
+            case U'j': moveCursor(1); return EventResult::Handled;
+            case U'k': moveCursor(-1); return EventResult::Handled;
+            case U'l': descendCursor(); return EventResult::Handled;
+            case U'h': ascendCursor(); return EventResult::Handled;
+            default: break;
+        }
+    }
+    return EventResult::Ignored;
+}
+
+std::vector<int> TreeTableView::computeWidths(int totalWidth) const
+{
+    auto const cols = _model.columns();
+    std::vector<int> widths(cols.size(), 0);
+
+    auto fixedTotal = 0;
+    auto flexIndex = std::size_t { cols.size() };
+    for (auto i = std::size_t { 0 }; i < cols.size(); ++i)
+    {
+        if (cols[i].width == ColumnWidth::Flex && flexIndex == cols.size())
+            flexIndex = i;
+        widths[i] = cols[i].size;
+        if (cols[i].width == ColumnWidth::Fixed)
+            fixedTotal += cols[i].size + 1; // +1 inter-column space
+    }
+
+    if (flexIndex != cols.size())
+    {
+        auto const leftover = totalWidth - fixedTotal - 1;
+        widths[flexIndex] = std::max(cols[flexIndex].size, leftover);
+    }
+    return widths;
+}
+
+namespace
+{
+    /// Pads/truncates @p text to exactly @p width cells with @p align.
+    [[nodiscard]] std::string fit(std::string text, int width, ColumnAlign align)
+    {
+        auto const w = static_cast<std::size_t>(std::max(width, 0));
+        if (text.size() > w)
+            text.resize(w);
+        if (text.size() < w)
+        {
+            auto const pad = std::string(w - text.size(), ' ');
+            text = (align == ColumnAlign::Right) ? pad + text : text + pad;
+        }
+        return text;
+    }
+} // namespace
+
+void TreeTableView::renderRow(
+    Canvas& canvas, int line, RowId row, bool selected, std::vector<int> const& widths)
+{
+    auto const cols = _model.columns();
+    auto const rowStyle = _model.rowStyle(row, selected);
+    auto style = rowStyle.style;
+    if (selected)
+        style.inverse = true;
+
+    auto col = 0;
+    for (auto i = std::size_t { 0 }; i < cols.size(); ++i)
+    {
+        auto cell = _model.cellText(row, i);
+
+        // A designated bar column is filled proportionally by the model's text already
+        // (the host formats the bar); the view only lays it out. No special-casing here
+        // keeps the view domain-agnostic.
+        auto const fitted = fit(std::move(cell), widths[i], cols[i].align);
+        col += canvas.putString(line, col, fitted, style);
+        col += 1; // inter-column space
+    }
+}
+
+void TreeTableView::render(Canvas& canvas)
+{
+    clampCursor();
+    auto const cols = _model.columns();
+    auto const widths = computeWidths(canvas.width());
+
+    auto line = 0;
+    if (_config.showHeader)
+    {
+        auto headerStyle = canvas.theme().textBold;
+        auto col = 0;
+        for (auto i = std::size_t { 0 }; i < cols.size(); ++i)
+        {
+            auto const header = fit(std::string { cols[i].header }, widths[i], cols[i].align);
+            col += canvas.putString(0, col, header, headerStyle);
+            col += 1;
+        }
+        line = 1;
+    }
+
+    auto const rows = _model.rows();
+    auto const headerLines = _config.showHeader ? 1 : 0;
+    auto const viewport = static_cast<std::size_t>(std::max(0, canvas.height() - headerLines));
+    for (auto i = std::size_t { 0 }; i < viewport; ++i)
+    {
+        auto const rowIndex = _scroll + i;
+        if (rowIndex >= rows.size())
+            break;
+        renderRow(canvas, line + static_cast<int>(i), rows[rowIndex], rowIndex == _cursor, widths);
+    }
+}
+
+} // namespace tui

--- a/src/tui/TreeTableView.hpp
+++ b/src/tui/TreeTableView.hpp
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file TreeTableView.hpp
+/// @brief Generic, data-driven tree/table browser component with vim-style navigation.
+///
+/// `TreeTableView` renders a scrollable, column-oriented table of the children of a
+/// "current node" and lets the user move a cursor, descend into a child, ascend to the
+/// parent, and re-sort — the classic ncdu / file-manager interaction, made reusable.
+/// It owns no domain data: everything it shows and every action it takes is delegated
+/// to an injected @ref TreeTableModel. A disk-usage browser, a process tree, a JSON
+/// explorer, etc. all reuse this component by implementing the model.
+
+#include <tui/Component.hpp>
+#include <tui/InputEvent.hpp>
+#include <tui/TerminalOutput.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace tui
+{
+
+/// Opaque handle identifying a row in the model's current view. The view never
+/// interprets it; it only passes it back to the model.
+using RowId = std::uint64_t;
+
+/// How a column claims horizontal space.
+enum class ColumnWidth : std::uint8_t
+{
+    Fixed, ///< Exactly @c width cells.
+    Flex,  ///< At least @c width cells; absorbs leftover width (one Flex column).
+};
+
+/// Text alignment within a column.
+enum class ColumnAlign : std::uint8_t
+{
+    Left,
+    Right,
+};
+
+/// A column the view lays out. The cell text is produced by the model per row, so the
+/// view stays domain-agnostic; the spec here is pure layout data.
+struct TableColumn
+{
+    std::string_view header; ///< Header label.
+    ColumnWidth width;       ///< Fixed or flex sizing.
+    int size;                ///< Fixed width, or minimum width for Flex.
+    ColumnAlign align;       ///< Cell alignment.
+};
+
+/// The styling the model wants applied to one row's text.
+struct RowStyle
+{
+    Style style;   ///< Foreground/attributes for the row.
+    bool selected; ///< Whether the row is the cursor row (the view may invert it).
+};
+
+/// The data + navigation seam a @ref TreeTableView renders and drives.
+///
+/// Implementations adapt any hierarchical, column-describable data to the view. The
+/// view calls these to paint and to act; it holds no domain state itself (only the
+/// cursor/scroll position).
+class TreeTableModel
+{
+  public:
+    virtual ~TreeTableModel() = default;
+
+    /// @return The columns to lay out, left to right (layout data only).
+    [[nodiscard]] virtual std::vector<TableColumn> columns() const = 0;
+
+    /// @return The rows of the current node, in display (sorted) order.
+    [[nodiscard]] virtual std::vector<RowId> rows() const = 0;
+
+    /// @return The text for @p row in column index @p column.
+    [[nodiscard]] virtual std::string cellText(RowId row, std::size_t column) const = 0;
+
+    /// @return The style to render @p row with (color rules, etc.).
+    [[nodiscard]] virtual RowStyle rowStyle(RowId row, bool selected) const = 0;
+
+    /// @return true if @p row can be descended into (e.g. a non-empty directory).
+    [[nodiscard]] virtual bool canDescend(RowId row) const = 0;
+
+    /// Descends into @p row, making it the current node. No-op if not descendable.
+    /// @return true if the current node changed.
+    virtual bool descend(RowId row) = 0;
+
+    /// Ascends to the parent of the current node. No-op at the top.
+    /// @return true if the current node changed.
+    virtual bool ascend() = 0;
+
+    /// @return A one-line title for the current node (e.g. its path), for the header.
+    [[nodiscard]] virtual std::string currentTitle() const = 0;
+
+    /// Applies the sort the model associates with @p sortKey to the current rows.
+    /// The view forwards a small integer chosen by the host's key bindings; the model
+    /// decides what each key means (data-driven on the model side).
+    /// @param sortKey Host-defined sort selector.
+    virtual void sortBy(int sortKey) = 0;
+};
+
+/// Configuration knobs for a @ref TreeTableView (all data, no behavior).
+struct TreeTableConfig
+{
+    bool showHeader = true; ///< Draw the column header row.
+    int barColumn = -1;     ///< Index of a column the view fills as a proportional bar (-1 = none).
+};
+
+/// A generic, reusable tree/table browser. Owns only cursor + scroll state; all data
+/// and navigation come from an injected @ref TreeTableModel.
+class TreeTableView: public Component
+{
+  public:
+    /// @param model The data/navigation seam (not owned; must outlive the view).
+    /// @param config Layout configuration.
+    explicit TreeTableView(TreeTableModel& model, TreeTableConfig config = {}) noexcept;
+
+    void render(Canvas& canvas) override;
+    [[nodiscard]] EventResult onEvent(InputEvent const& event) override;
+
+    [[nodiscard]] bool focusable() const override { return true; }
+
+    /// Moves the cursor by @p delta rows, clamped to the row range.
+    void moveCursor(int delta);
+
+    /// Moves the cursor to the first / last row.
+    void moveToTop();
+    void moveToBottom();
+
+    /// Scrolls by a page (viewport height) in @p direction (-1 up, +1 down).
+    void pageBy(int direction);
+
+    /// Descends into the cursor row (if descendable), resetting the cursor.
+    void descendCursor();
+
+    /// Ascends to the parent of the current node, restoring the remembered cursor.
+    void ascendCursor();
+
+    /// Forwards @p sortKey to the model and keeps the cursor on the same row when possible.
+    void sortBy(int sortKey);
+
+    /// @return The row currently under the cursor, or 0 with @p valid=false if empty.
+    [[nodiscard]] RowId cursorRow(bool& valid) const;
+
+    /// @return The cursor's index within the current rows (0-based).
+    [[nodiscard]] std::size_t cursorIndex() const noexcept { return _cursor; }
+
+    /// Callback invoked when the cursor row changes or the current node changes.
+    void onSelectionChanged(std::function<void()> callback) { _onChanged = std::move(callback); }
+
+  private:
+    /// Clamps the cursor and scroll offset to the current row count and viewport.
+    void clampCursor();
+
+    /// Renders one row at canvas line @p line for model row @p row.
+    void renderRow(Canvas& canvas, int line, RowId row, bool selected, std::vector<int> const& widths);
+
+    /// Computes per-column widths for canvas width @p totalWidth (distributes Flex).
+    [[nodiscard]] std::vector<int> computeWidths(int totalWidth) const;
+
+    TreeTableModel& _model;           ///< Data + navigation seam.
+    TreeTableConfig _config;          ///< Layout configuration.
+    std::size_t _cursor = 0;          ///< Cursor index into the current rows.
+    std::size_t _scroll = 0;          ///< Index of the first visible row.
+    std::function<void()> _onChanged; ///< Selection/navigation change callback.
+
+    /// Remembered cursor index per current-node depth, restored on ascend. Keyed by the
+    /// model's title so revisiting a node returns to where the user left off.
+    std::vector<std::pair<std::string, std::size_t>> _cursorHistory;
+};
+
+} // namespace tui

--- a/src/tui/TreeTableView.hpp
+++ b/src/tui/TreeTableView.hpp
@@ -133,6 +133,10 @@ class TreeTableView: public Component
     /// Scrolls by a page (viewport height) in @p direction (-1 up, +1 down).
     void pageBy(int direction);
 
+    /// Scrolls by half a page (viewport height / 2) in @p direction (-1 up, +1 down),
+    /// like vim's Ctrl+U / Ctrl+D.
+    void halfPageBy(int direction);
+
     /// Descends into the cursor row (if descendable), resetting the cursor.
     void descendCursor();
 

--- a/src/tui/TreeTableView_test.cpp
+++ b/src/tui/TreeTableView_test.cpp
@@ -204,3 +204,94 @@ TEST_CASE("TreeTableView: handles j/k/l/h key events", "[treetable]")
     CHECK(view.cursorIndex() == 0);
     CHECK(view.onEvent(keyChar(U'z')) == EventResult::Ignored);
 }
+
+namespace
+{
+/// A flat model with @p n rows and no children, to exercise paging motions.
+class FlatModel: public TreeTableModel
+{
+  public:
+    explicit FlatModel(int n): _n(n) {}
+    [[nodiscard]] std::vector<TableColumn> columns() const override
+    {
+        return { TableColumn { .header = "N", .width = ColumnWidth::Flex, .size = 4, .align = ColumnAlign::Left } };
+    }
+    [[nodiscard]] std::vector<RowId> rows() const override
+    {
+        std::vector<RowId> out;
+        out.reserve(static_cast<std::size_t>(_n));
+        for (int i = 0; i < _n; ++i)
+            out.push_back(static_cast<RowId>(i));
+        return out;
+    }
+    [[nodiscard]] std::string cellText(RowId row, std::size_t) const override { return std::to_string(row); }
+    [[nodiscard]] RowStyle rowStyle(RowId, bool sel) const override { return RowStyle { .style = {}, .selected = sel }; }
+    [[nodiscard]] bool canDescend(RowId) const override { return false; }
+    bool descend(RowId) override { return false; }
+    bool ascend() override { return false; }
+    [[nodiscard]] std::string currentTitle() const override { return "/"; }
+    void sortBy(int) override {}
+
+  private:
+    int _n;
+};
+} // namespace
+
+TEST_CASE("TreeTableView: halfPageBy moves half the viewport", "[treetable]")
+{
+    FlatModel model(100);
+    TreeTableView view(model);
+    // Header takes 1 line; viewport = height - 1 = 20; half = 10.
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 21 });
+
+    view.halfPageBy(1);
+    CHECK(view.cursorIndex() == 10);
+    view.halfPageBy(1);
+    CHECK(view.cursorIndex() == 20);
+    view.halfPageBy(-1);
+    CHECK(view.cursorIndex() == 10);
+}
+
+TEST_CASE("TreeTableView: pageBy moves a full viewport", "[treetable]")
+{
+    FlatModel model(100);
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 21 }); // viewport 20
+
+    view.pageBy(1);
+    CHECK(view.cursorIndex() == 20);
+    view.pageBy(-1);
+    CHECK(view.cursorIndex() == 0);
+}
+
+TEST_CASE("TreeTableView: Ctrl-D / Ctrl-U handled in onEvent", "[treetable]")
+{
+    FlatModel model(100);
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 21 }); // half-page = 10
+
+    auto ctrlKey = [](char32_t c) {
+        return InputEvent { KeyEvent { .key = {}, .modifiers = Modifier::Ctrl, .codepoint = c } };
+    };
+
+    CHECK(view.onEvent(ctrlKey(U'd')) == EventResult::Handled);
+    CHECK(view.cursorIndex() == 10);
+    CHECK(view.onEvent(ctrlKey(U'u')) == EventResult::Handled);
+    CHECK(view.cursorIndex() == 0);
+}
+
+TEST_CASE("TreeTableView: g / G jump to top / bottom in onEvent", "[treetable]")
+{
+    FlatModel model(50);
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 21 });
+
+    auto key = [](char32_t c, Modifier m = Modifier::None) {
+        return InputEvent { KeyEvent { .key = {}, .modifiers = m, .codepoint = c } };
+    };
+
+    CHECK(view.onEvent(key(U'G')) == EventResult::Handled);
+    CHECK(view.cursorIndex() == 49);
+    CHECK(view.onEvent(key(U'g')) == EventResult::Handled);
+    CHECK(view.cursorIndex() == 0);
+}

--- a/src/tui/TreeTableView_test.cpp
+++ b/src/tui/TreeTableView_test.cpp
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <tui/TreeTableView.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace tui;
+
+namespace
+{
+/// A tiny in-memory tree model for exercising the generic view without any domain code.
+///
+/// Nodes are ints; children are stored in a map. The "current node" plus a parent stack
+/// model navigation. Sorting just reverses the child order so re-sorts are observable.
+class FakeModel: public TreeTableModel
+{
+  public:
+    FakeModel()
+    {
+        _children[0] = { 1, 2, 3 }; // root's children
+        _children[2] = { 4, 5 };    // node 2 is a directory
+        _names = { { 0, "root" }, { 1, "alpha" }, { 2, "dir" }, { 3, "beta" }, { 4, "x" }, { 5, "y" } };
+    }
+
+    [[nodiscard]] std::vector<TableColumn> columns() const override
+    {
+        return { TableColumn {
+                     .header = "Name", .width = ColumnWidth::Flex, .size = 4, .align = ColumnAlign::Left },
+                 TableColumn {
+                     .header = "Id", .width = ColumnWidth::Fixed, .size = 3, .align = ColumnAlign::Right } };
+    }
+
+    [[nodiscard]] std::vector<RowId> rows() const override
+    {
+        std::vector<RowId> out;
+        for (auto const id: _children.at(_current))
+            out.push_back(static_cast<RowId>(id));
+        return out;
+    }
+
+    [[nodiscard]] std::string cellText(RowId row, std::size_t column) const override
+    {
+        if (column == 0)
+            return _names.at(static_cast<int>(row));
+        return std::to_string(row);
+    }
+
+    [[nodiscard]] RowStyle rowStyle(RowId, bool selected) const override
+    {
+        return RowStyle { .style = {}, .selected = selected };
+    }
+
+    [[nodiscard]] bool canDescend(RowId row) const override
+    {
+        return _children.contains(static_cast<int>(row));
+    }
+
+    bool descend(RowId row) override
+    {
+        if (!canDescend(row))
+            return false;
+        _stack.push_back(_current);
+        _current = static_cast<int>(row);
+        return true;
+    }
+
+    bool ascend() override
+    {
+        if (_stack.empty())
+            return false;
+        _current = _stack.back();
+        _stack.pop_back();
+        return true;
+    }
+
+    [[nodiscard]] std::string currentTitle() const override { return _names.at(_current); }
+
+    void sortBy(int) override
+    {
+        auto& kids = _children[_current];
+        std::ranges::reverse(kids);
+    }
+
+    [[nodiscard]] int current() const { return _current; }
+
+  private:
+    std::map<int, std::vector<int>> _children;
+    std::map<int, std::string> _names;
+    std::vector<int> _stack;
+    int _current = 0;
+};
+} // namespace
+
+TEST_CASE("TreeTableView: cursor moves within row bounds", "[treetable]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    CHECK(view.cursorIndex() == 0);
+    view.moveCursor(1);
+    CHECK(view.cursorIndex() == 1);
+    view.moveCursor(100); // clamps to last (3 rows -> index 2)
+    CHECK(view.cursorIndex() == 2);
+    view.moveCursor(-100); // clamps to first
+    CHECK(view.cursorIndex() == 0);
+}
+
+TEST_CASE("TreeTableView: moveToTop/Bottom", "[treetable]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    view.moveToBottom();
+    CHECK(view.cursorIndex() == 2);
+    view.moveToTop();
+    CHECK(view.cursorIndex() == 0);
+}
+
+TEST_CASE("TreeTableView: descend into a directory row resets cursor", "[treetable]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    // Move to node 2 ("dir", index 1) and descend.
+    view.moveCursor(1);
+    bool valid = false;
+    CHECK(view.cursorRow(valid) == 2);
+    view.descendCursor();
+    CHECK(model.current() == 2);
+    CHECK(view.cursorIndex() == 0); // reset on descend
+}
+
+TEST_CASE("TreeTableView: descend is a no-op on a leaf row", "[treetable]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    // Row 0 is node 1 ("alpha"), a leaf.
+    view.descendCursor();
+    CHECK(model.current() == 0); // unchanged
+}
+
+TEST_CASE("TreeTableView: ascend restores the remembered cursor", "[treetable]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    view.moveCursor(1); // cursor on "dir" (index 1)
+    view.descendCursor();
+    REQUIRE(model.current() == 2);
+    view.ascendCursor();
+    CHECK(model.current() == 0);
+    CHECK(view.cursorIndex() == 1); // restored to where we descended from
+}
+
+TEST_CASE("TreeTableView: sortBy keeps the cursor on the same row", "[treetable]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    // Cursor on row index 0 = node 1. After reverse-sort, node 1 is last.
+    bool valid = false;
+    REQUIRE(view.cursorRow(valid) == 1);
+    view.sortBy(0);
+    CHECK(view.cursorRow(valid) == 1); // same row id
+    CHECK(view.cursorIndex() == 2);    // now at the end
+}
+
+TEST_CASE("TreeTableView: selection-changed callback fires on navigation", "[treetable]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    int changes = 0;
+    view.onSelectionChanged([&] { ++changes; });
+    view.moveCursor(1);
+    view.descendCursor();
+    CHECK(changes >= 2);
+}
+
+TEST_CASE("TreeTableView: handles j/k/l/h key events", "[treetable]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    auto keyChar = [](char32_t c) {
+        return InputEvent { KeyEvent { .key = {}, .modifiers = Modifier::None, .codepoint = c } };
+    };
+
+    CHECK(view.onEvent(keyChar(U'j')) == EventResult::Handled);
+    CHECK(view.cursorIndex() == 1);
+    CHECK(view.onEvent(keyChar(U'k')) == EventResult::Handled);
+    CHECK(view.cursorIndex() == 0);
+    CHECK(view.onEvent(keyChar(U'z')) == EventResult::Ignored);
+}

--- a/src/tui/runtime/platform/TerminalEventSourcePosix.cpp
+++ b/src/tui/runtime/platform/TerminalEventSourcePosix.cpp
@@ -71,6 +71,17 @@ WaitOutcome TerminalEventSource::wait(int timeoutMs)
         return finalize(std::move(outcome));
     }
 
+    // The input terminal closed (EOF / not a TTY / detached): poll reports POLLHUP or
+    // POLLERR with no POLLIN, and none of the readers below would consume it — leaving the
+    // pump to re-poll instantly and busy-loop. Treat it as an interrupt so the runtime
+    // unwinds the root flow cleanly instead of spinning at 100% CPU.
+    if ((fds[inputIndex].revents & (POLLHUP | POLLERR | POLLNVAL)) != 0
+        && (fds[inputIndex].revents & POLLIN) == 0)
+    {
+        outcome.interrupted = true;
+        return finalize(std::move(outcome));
+    }
+
     auto const ready = [&](int index) {
         return index >= 0 && (fds[static_cast<std::size_t>(index)].revents & POLLIN) != 0;
     };


### PR DESCRIPTION
This branch lands a set of generic, broadly-useful improvements to the shared `tui`, `platform`, and `coro` libraries. They were extracted while building a disk-usage browser, but carry no app-specific concepts — each piece is reusable on its own. The headline addition is `TreeTableView`, a data-driven tree/table browser component that any tree-of-rows application can drive through an injected model, plus the `stat(2)` metadata and cooperative-cancellation primitives such a component needs.

## Changes

**tui**
- Add `TreeTableView` + `TreeTableModel`: a reusable, data-driven tree/table browser with vim-style navigation (move, descend/ascend, sort, paging), driven entirely by an injected model.
- Add half-page scrolling (`Ctrl+D` / `Ctrl+U`) and `g` / `G` (jump to top/bottom) motions to `TreeTableView`.
- Add `ScreenConfig::alternateScreen`: when set, `Screen` switches to the terminal's alternate screen buffer (DEC private mode 1049) on construction and restores the primary buffer and the user's scrollback on destruction — intended for full-screen apps using `Viewport::Fullscreen`.
- `KeyChord::parse` now accepts any single printable character (digits, `/`, `.`, `?`, …), not just letters, so punctuation keys can be bound.
- `RgbColor` gains a defaulted `operator==`.

**platform**
- Extend `FileEntry` with `blocks` (`st_blocks`), `dev` (`st_dev`), `ino` (`st_ino`) and `isSymlink` — standard `stat(2)` metadata enabling true disk-usage accounting, hardlink dedup, and cross-filesystem detection.
- Rewrite the POSIX (Linux/Darwin) `FileInfoProvider` to use raw `lstat()` so those fields are captured; the Windows provider fills documented sentinels.
- `Pipe.cpp`: make the log-category a function-local static to avoid `bugprone-throwing-static-initialization` under newer clang-tidy.

**coro**
- Add `thisCoroStopToken()`: an awaitable that yields the awaiting coroutine's `StopToken` without suspending, for cooperative cancellation inside loops.

**runtime**
- Treat input `POLLHUP` / `POLLERR` (closed, detached, or non-TTY input) as an interrupt instead of busy-looping at 100% CPU. The runtime now unwinds the root flow cleanly when the input fd is closed.

New unit tests cover `TreeTableView`, the lstat-backed `FileInfoProvider`, and the new motions; all `coro`/`platform`/`tui` suites pass under ASAN + UBSAN + clang-tidy.