### PR TITLE
feat(tui/testing): record clipboard text in MockTerminalOutput

### DIFF
--- a/src/tui/MockTerminalOutput.cpp
+++ b/src/tui/MockTerminalOutput.cpp
@@ -238,9 +238,14 @@ void MockTerminalOutput::writeSixel([[maybe_unused]] std::string_view sixelData)
     // No-op.
 }
 
-void MockTerminalOutput::copyToClipboard([[maybe_unused]] std::string_view text)
+void MockTerminalOutput::copyToClipboard(std::string_view text)
 {
-    // No-op.
+    _clipboard.assign(text);
+}
+
+std::string const& MockTerminalOutput::clipboardText() const noexcept
+{
+    return _clipboard;
 }
 
 void MockTerminalOutput::unscroll([[maybe_unused]] int n)

--- a/src/tui/MockTerminalOutput.hpp
+++ b/src/tui/MockTerminalOutput.hpp
@@ -81,6 +81,9 @@ class MockTerminalOutput: public TerminalOutput
     /// @brief Returns the total number of flush() calls since construction.
     [[nodiscard]] int flushCount() const noexcept;
 
+    /// @brief Returns the text most recently passed to copyToClipboard (empty if never called).
+    [[nodiscard]] std::string const& clipboardText() const noexcept;
+
   private:
     int _cols;
     int _rows;
@@ -91,6 +94,7 @@ class MockTerminalOutput: public TerminalOutput
     bool _cursorVisible = true;
     int _scrollCount = 0;
     int _flushCount = 0;
+    std::string _clipboard;
 };
 
 } // namespace tui


### PR DESCRIPTION
## What

`MockTerminalOutput::copyToClipboard` was a no-op, so tests had no way to assert what a component copied to the clipboard via OSC 52.

This records the most recently copied text and exposes it through a new `clipboardText()` accessor, alongside the existing test-only accessors (`scrollCount`, `flushCount`, cursor state, …).

## Why

Enables unit testing of OSC 52 clipboard interactions (e.g. a "copy the selected path to the clipboard" command in a TUI built on this library).

## Tests

`test-tui` is green locally (818 test cases, 2481 assertions). The accessor is additive and changes no production behavior.