### PR TITLE
feat(tui): mouse click to select and double-click to activate in TreeTableView

### DIFF
--- a/src/tui/TreeTableView.cpp
+++ b/src/tui/TreeTableView.cpp
@@ -192,7 +192,73 @@ EventResult TreeTableView::onEvent(InputEvent const& event)
             default: break;
         }
     }
+    else if (auto const* mouse = std::get_if<MouseEvent>(&event))
+    {
+        // The wheel moves the selection. Most terminals translate wheel events to arrow keys in
+        // the alternate screen, but some deliver real scroll events — handle both.
+        if (mouse->type == MouseEvent::Type::ScrollUp)
+        {
+            moveCursor(-1);
+            return EventResult::Handled;
+        }
+        if (mouse->type == MouseEvent::Type::ScrollDown)
+        {
+            moveCursor(1);
+            return EventResult::Handled;
+        }
+
+        // Left-press selects the row under the pointer; a second left-press on the same row
+        // within the double-click interval activates it (descends), like a desktop double-click.
+        if (mouse->type == MouseEvent::Type::Press && mouse->button == 0)
+        {
+            auto const index = rowIndexAt(mouse->y);
+            if (!index.has_value())
+            {
+                _hadClick = false; // a click off the rows breaks any pending double-click
+                return EventResult::Ignored;
+            }
+
+            auto const now = std::chrono::steady_clock::now();
+            auto const isDoubleClick =
+                _hadClick && _lastClickRow == *index && (now - _lastClickTime) <= kDoubleClickInterval;
+
+            selectIndex(*index);
+
+            if (isDoubleClick)
+            {
+                descendCursor();
+                _hadClick = false; // reset so a third press starts a fresh click
+            }
+            else
+            {
+                _hadClick = true;
+                _lastClickRow = *index;
+                _lastClickTime = now;
+            }
+            return EventResult::Handled;
+        }
+    }
     return EventResult::Ignored;
+}
+
+std::optional<std::size_t> TreeTableView::rowIndexAt(int row) const
+{
+    auto const headerLines = _config.showHeader ? 1 : 0;
+    auto const relRow = (row - 1) - headerLines; // mouse row is 1-based; the header sits above
+    if (relRow < 0)
+        return std::nullopt; // header (or above)
+    auto const index = _scroll + static_cast<std::size_t>(relRow);
+    if (index >= _model.rows().size())
+        return std::nullopt; // empty space below the last row
+    return index;
+}
+
+void TreeTableView::selectIndex(std::size_t index)
+{
+    _cursor = index;
+    clampCursor();
+    if (_onChanged)
+        _onChanged();
 }
 
 std::vector<int> TreeTableView::computeWidths(int totalWidth) const

--- a/src/tui/TreeTableView.hpp
+++ b/src/tui/TreeTableView.hpp
@@ -15,8 +15,10 @@
 #include <tui/InputEvent.hpp>
 #include <tui/TerminalOutput.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -165,6 +167,14 @@ class TreeTableView: public Component
     /// Computes per-column widths for canvas width @p totalWidth (distributes Flex).
     [[nodiscard]] std::vector<int> computeWidths(int totalWidth) const;
 
+    /// Moves the cursor to row index @p index (clamped) and notifies listeners.
+    void selectIndex(std::size_t index);
+
+    /// Maps a component-relative, 1-based @p row coordinate to a model row index.
+    /// @param row The component-relative row (1-based, as delivered in a MouseEvent).
+    /// @return The row index, or std::nullopt if @p row is the header or below the last row.
+    [[nodiscard]] std::optional<std::size_t> rowIndexAt(int row) const;
+
     TreeTableModel& _model;           ///< Data + navigation seam.
     TreeTableConfig _config;          ///< Layout configuration.
     std::size_t _cursor = 0;          ///< Cursor index into the current rows.
@@ -174,6 +184,14 @@ class TreeTableView: public Component
     /// Remembered cursor index per current-node depth, restored on ascend. Keyed by the
     /// model's title so revisiting a node returns to where the user left off.
     std::vector<std::pair<std::string, std::size_t>> _cursorHistory;
+
+    // Double-click tracking: a left-press on the already-clicked row within the interval
+    // activates (descends into) it, like a desktop double-click.
+    bool _hadClick = false;                               ///< A prior left-press may begin a double-click.
+    std::size_t _lastClickRow = 0;                        ///< Row index of the prior left-press.
+    std::chrono::steady_clock::time_point _lastClickTime; ///< When the prior left-press happened.
+
+    static constexpr auto kDoubleClickInterval = std::chrono::milliseconds { 400 };
 };
 
 } // namespace tui

--- a/src/tui/TreeTableView_test.cpp
+++ b/src/tui/TreeTableView_test.cpp
@@ -207,15 +207,95 @@ TEST_CASE("TreeTableView: handles j/k/l/h key events", "[treetable]")
 
 namespace
 {
+/// Builds a left-button press at component-relative, 1-based row @p y.
+[[nodiscard]] InputEvent mousePress(int y)
+{
+    return InputEvent { MouseEvent { .type = MouseEvent::Type::Press, .button = 0, .x = 1, .y = y } };
+}
+} // namespace
+
+TEST_CASE("TreeTableView: left-click selects the row under the pointer", "[treetable][mouse]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    // Header occupies row 1; the first data row is row 2. Clicking row 3 selects index 1.
+    CHECK(view.onEvent(mousePress(3)) == EventResult::Handled);
+    CHECK(view.cursorIndex() == 1);
+    CHECK(view.onEvent(mousePress(2)) == EventResult::Handled);
+    CHECK(view.cursorIndex() == 0);
+}
+
+TEST_CASE("TreeTableView: double-click activates (descends into) the row", "[treetable][mouse]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    // Row 3 is index 1 = node 2 ("dir"), which is descendable. Two quick presses descend.
+    CHECK(view.onEvent(mousePress(3)) == EventResult::Handled);
+    REQUIRE(model.current() == 0); // first click only selects
+    CHECK(view.onEvent(mousePress(3)) == EventResult::Handled);
+    CHECK(model.current() == 2);    // second click activates
+    CHECK(view.cursorIndex() == 0); // descend resets the cursor
+}
+
+TEST_CASE("TreeTableView: two clicks on different rows do not activate", "[treetable][mouse]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    CHECK(view.onEvent(mousePress(3)) == EventResult::Handled); // index 1 (dir)
+    CHECK(view.onEvent(mousePress(4)) == EventResult::Handled); // index 2 (leaf) — different row
+    CHECK(model.current() == 0);                                // no descend
+    CHECK(view.cursorIndex() == 2);
+}
+
+TEST_CASE("TreeTableView: clicks on the header or below the list are ignored", "[treetable][mouse]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    view.moveCursor(1);
+    REQUIRE(view.cursorIndex() == 1);
+    CHECK(view.onEvent(mousePress(1)) == EventResult::Ignored);  // header row
+    CHECK(view.onEvent(mousePress(15)) == EventResult::Ignored); // below the 3 rows
+    CHECK(view.cursorIndex() == 1);                              // selection unchanged
+}
+
+TEST_CASE("TreeTableView: wheel scroll moves the selection", "[treetable][mouse]")
+{
+    FakeModel model;
+    TreeTableView view(model);
+    view.setArea(Rect { .x = 0, .y = 0, .width = 20, .height = 10 });
+
+    auto wheel = [](MouseEvent::Type type) {
+        return InputEvent { MouseEvent { .type = type, .button = 0, .x = 1, .y = 1 } };
+    };
+
+    CHECK(view.onEvent(wheel(MouseEvent::Type::ScrollDown)) == EventResult::Handled);
+    CHECK(view.cursorIndex() == 1);
+    CHECK(view.onEvent(wheel(MouseEvent::Type::ScrollUp)) == EventResult::Handled);
+    CHECK(view.cursorIndex() == 0);
+}
+
+namespace
+{
 /// A flat model with @p n rows and no children, to exercise paging motions.
 class FlatModel: public TreeTableModel
 {
   public:
     explicit FlatModel(int n): _n(n) {}
+
     [[nodiscard]] std::vector<TableColumn> columns() const override
     {
-        return { TableColumn { .header = "N", .width = ColumnWidth::Flex, .size = 4, .align = ColumnAlign::Left } };
+        return { TableColumn {
+            .header = "N", .width = ColumnWidth::Flex, .size = 4, .align = ColumnAlign::Left } };
     }
+
     [[nodiscard]] std::vector<RowId> rows() const override
     {
         std::vector<RowId> out;
@@ -224,12 +304,22 @@ class FlatModel: public TreeTableModel
             out.push_back(static_cast<RowId>(i));
         return out;
     }
+
     [[nodiscard]] std::string cellText(RowId row, std::size_t) const override { return std::to_string(row); }
-    [[nodiscard]] RowStyle rowStyle(RowId, bool sel) const override { return RowStyle { .style = {}, .selected = sel }; }
+
+    [[nodiscard]] RowStyle rowStyle(RowId, bool sel) const override
+    {
+        return RowStyle { .style = {}, .selected = sel };
+    }
+
     [[nodiscard]] bool canDescend(RowId) const override { return false; }
+
     bool descend(RowId) override { return false; }
+
     bool ascend() override { return false; }
+
     [[nodiscard]] std::string currentTitle() const override { return "/"; }
+
     void sortBy(int) override {}
 
   private:


### PR DESCRIPTION
## What

`TreeTableView` only handled keyboard input, so mouse clicks did nothing. This adds mouse support to `onEvent`:

- **Left-press** selects the row under the pointer.
- A **second left-press on the same row within 400ms** activates it (descends), like a desktop double-click.
- Real **wheel** `ScrollUp`/`ScrollDown` events move the selection (terminals using alternate-scroll already send arrow keys, which keep working).

A clicked coordinate is mapped to a row index via a new `rowIndexAt()` helper (accounting for the header row and scroll offset); clicks on the header or below the last row are ignored.

## Tests

New `[treetable][mouse]` cases: click-selects, double-click-descends, two-clicks-on-different-rows don't activate, header/below-list clicks ignored, and wheel scroll moves the selection. Full `test-tui` green locally (823 test cases, 2502 assertions).