### PR TITLE
style: clang-format vendored platform/tui sources

### DIFF
--- a/src/platform/DarwinProcessProvider_test.cpp
+++ b/src/platform/DarwinProcessProvider_test.cpp
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 #if defined(__APPLE__)
 
-    #include "darwin/DarwinProcessProvider.hpp"
-
     #include <catch2/catch_test_macros.hpp>
 
     #include <algorithm>
     #include <ranges>
 
     #include <unistd.h>
+
+    #include "darwin/DarwinProcessProvider.hpp"
 
 using namespace endo::platform;
 

--- a/src/platform/FileInfoProvider_test.cpp
+++ b/src/platform/FileInfoProvider_test.cpp
@@ -229,9 +229,9 @@ TEST_CASE("LinuxFileInfoProvider.populates_stat_metadata", "[platform][linux]")
     REQUIRE(entries.size() == 1);
     auto const& e = entries[0];
     CHECK(e.size == 8192);
-    CHECK(e.blocks > 0);     // allocated blocks reported (st_blocks)
-    CHECK(e.dev != 0);       // device id reported (st_dev)
-    CHECK(e.ino != 0);       // inode reported (st_ino)
+    CHECK(e.blocks > 0); // allocated blocks reported (st_blocks)
+    CHECK(e.dev != 0);   // device id reported (st_dev)
+    CHECK(e.ino != 0);   // inode reported (st_ino)
     CHECK(e.isSymlink == false);
     CHECK(e.isDir == false);
 }

--- a/src/platform/Generator.hpp
+++ b/src/platform/Generator.hpp
@@ -14,8 +14,7 @@
 // Define ENDO_GENERATOR_FORCE_FALLBACK to compile the self-contained fallback even
 // when std::generator is available — used to exercise the fallback on platforms whose
 // standard library ships <generator> (e.g. MSVC STL).
-#if defined(__cpp_lib_generator) && __cpp_lib_generator >= 202207L \
-    && !defined(ENDO_GENERATOR_FORCE_FALLBACK)
+#if defined(__cpp_lib_generator) && __cpp_lib_generator >= 202207L && !defined(ENDO_GENERATOR_FORCE_FALLBACK)
 
     #include <generator>
 

--- a/src/platform/LinuxProcessProvider_test.cpp
+++ b/src/platform/LinuxProcessProvider_test.cpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #if !defined(_WIN32)
 
-    #include "linux/ProcStatusParser.hpp"
-
     #include <catch2/catch_test_macros.hpp>
+
+    #include "linux/ProcStatusParser.hpp"
 
 using namespace endo::platform;
 

--- a/src/platform/darwin/DarwinProcessProvider.cpp
+++ b/src/platform/darwin/DarwinProcessProvider.cpp
@@ -9,9 +9,10 @@
     #include <string>
     #include <vector>
 
+    #include <sys/sysctl.h>
+
     #include <libproc.h>
     #include <pwd.h>
-    #include <sys/sysctl.h>
     #include <unistd.h>
 
 namespace endo::platform

--- a/src/platform/linux/LinuxProcessProvider.cpp
+++ b/src/platform/linux/LinuxProcessProvider.cpp
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "LinuxProcessProvider.hpp"
-#include "ProcStatusParser.hpp"
 
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
+
+#include "ProcStatusParser.hpp"
 
 #if !defined(_WIN32)
     #include <pwd.h>

--- a/src/platform/posix/PosixEnvironmentProvider.cpp
+++ b/src/platform/posix/PosixEnvironmentProvider.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "PosixEnvironmentProvider.hpp"
 
-#include <platform/PathUtils.hpp>
-
 #include <algorithm>
 #include <filesystem>
 
 #include <unistd.h>
+
+#include <platform/PathUtils.hpp>
 
 #if defined(__APPLE__)
     #include <crt_externs.h>

--- a/src/tui/FuzzyPickerPopup.cpp
+++ b/src/tui/FuzzyPickerPopup.cpp
@@ -265,10 +265,10 @@ void FuzzyPickerPopup::refilter()
             // Boost by coverage: more of the path covered = higher rank
             if (ciResult.textGraphemeCount > 0)
             {
-                auto const coveragePercent = static_cast<int>(
-                    (static_cast<double>(ciResult.patternGraphemeCount)
-                     / static_cast<double>(ciResult.textGraphemeCount))
-                    * 150);
+                auto const coveragePercent =
+                    static_cast<int>((static_cast<double>(ciResult.patternGraphemeCount)
+                                      / static_cast<double>(ciResult.textGraphemeCount))
+                                     * 150);
                 score += coveragePercent;
             }
 


### PR DESCRIPTION
## Summary

Applies **clang-format 21** to the eight `platform/`/`tui/` sources that deviated from the repository `.clang-format`. Pure whitespace/order changes — include regrouping, constructor-initializer wrapping, and trailing-comment alignment — with no semantic effect.

Files:
- `src/platform/DarwinProcessProvider_test.cpp`
- `src/platform/FileInfoProvider_test.cpp`
- `src/platform/Generator.hpp`
- `src/platform/LinuxProcessProvider_test.cpp`
- `src/platform/darwin/DarwinProcessProvider.cpp`
- `src/platform/linux/LinuxProcessProvider.cpp`
- `src/platform/posix/PosixEnvironmentProvider.cpp`
- `src/tui/FuzzyPickerPopup.cpp`

## Why

These libraries are vendored byte-for-byte into the sibling **tuidu** project, which just gained a `clang-format` CI gate. This pass keeps the shared trees synchronizable: after merge, the formatted bytes match tuidu's copies exactly.

## Risk / performance / coverage

- **Risk:** very low — whitespace-only; no behavioral change.
- **Performance:** none.
- **Coverage:** unchanged; existing tests unaffected.