### PR TITLE
style: enforce CamelCase for constexpr & class constants (drop k-prefix)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,7 +68,7 @@ Checks: >-
 WarningsAsErrors: >-
   *
 UseColor: true
-HeaderFilterRegex: 'src/(CoreVM|endo-language|shell|tui|agent|dap|editor-protocol|lsp|platform|http)/[^.]'
+HeaderFilterRegex: 'src/(CoreVM|agent|coro|dap|editor-protocol|endo-language|endo-test|http|lsp|platform|shell|testing|tui|vtparser)/[^.]'
 FormatStyle:     none
 CheckOptions:
   - key:             bugprone-easily-swappable-parameters.MinimumLength
@@ -126,4 +126,8 @@ CheckOptions:
   - key:             readability-identifier-naming.ParameterPrefix
     value:           ''
   - key:             readability-identifier-naming.ScopedEnumConstantCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ConstexprVariableCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ClassConstantCase
     value:           CamelCase

--- a/src/CoreVM/vm/Instruction.cpp
+++ b/src/CoreVM/vm/Instruction.cpp
@@ -44,7 +44,7 @@ struct InstructionInfo
 // LiteralType:: stackOutput }
 
 // OPCODE, operandSignature, stackChange
-static constexpr InstructionInfo instructionInfos[] = {
+static constexpr InstructionInfo InstructionInfos[] = {
     // misc
     IIDEF(NOP, V, 0, Void),
     IIDEF(ALLOCA, I, 0, Void),
@@ -225,7 +225,7 @@ int getStackChange(Instruction instr)
         case Opcode::IUTCALL:
             // Indirect tail call: handled dynamically (reuses frame). For static analysis treat as 0.
             return 0;
-        default: return instructionInfos[opc].stackChange;
+        default: return InstructionInfos[opc].stackChange;
     }
 }
 
@@ -249,17 +249,17 @@ size_t computeStackSize(const Instruction* program, size_t programSize)
 
 OperandSig operandSignature(Opcode opc)
 {
-    return instructionInfos[static_cast<size_t>(opc)].operandSig;
+    return InstructionInfos[static_cast<size_t>(opc)].operandSig;
 }
 
 const char* mnemonic(Opcode opc)
 {
-    return instructionInfos[static_cast<size_t>(opc)].mnemonic;
+    return InstructionInfos[static_cast<size_t>(opc)].mnemonic;
 }
 
 LiteralType resultType(Opcode opc)
 {
-    return instructionInfos[static_cast<size_t>(opc)].stackOutput;
+    return InstructionInfos[static_cast<size_t>(opc)].stackOutput;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/CoreVM/vm/ObjectPool.cpp
+++ b/src/CoreVM/vm/ObjectPool.cpp
@@ -10,20 +10,20 @@ namespace CoreVM
 
 ObjectPool::ObjectPool(size_t slabCapacity): _slabCapacity(slabCapacity)
 {
-    for (size_t i = 0; i < kNumSizeClasses; ++i)
-        _sizeClasses[i].cellSize = kSizeClasses[i];
+    for (size_t i = 0; i < NumSizeClasses; ++i)
+        _sizeClasses[i].cellSize = SizeClasses[i];
 }
 
 size_t ObjectPool::sizeClassIndex(size_t allocSize) noexcept
 {
-    for (size_t i = 0; i < kNumSizeClasses; ++i)
+    for (size_t i = 0; i < NumSizeClasses; ++i)
     {
-        if (allocSize <= kSizeClasses[i])
+        if (allocSize <= SizeClasses[i])
             return i;
     }
     // Should never happen for supported object sizes.
     COREVM_ASSERT(false, "allocation size exceeds maximum size class (256 bytes)");
-    return kNumSizeClasses - 1;
+    return NumSizeClasses - 1;
 }
 
 void ObjectPool::addSlab(size_t sizeClassIdx)

--- a/src/CoreVM/vm/ObjectPool.hpp
+++ b/src/CoreVM/vm/ObjectPool.hpp
@@ -57,8 +57,8 @@ class ObjectPool
 
   private:
     /// Size classes in bytes, covering objects from 0 slots (16 bytes) to ~30 slots (256 bytes).
-    static constexpr size_t kSizeClasses[] = { 16, 24, 32, 48, 64, 96, 128, 256 };
-    static constexpr size_t kNumSizeClasses = sizeof(kSizeClasses) / sizeof(kSizeClasses[0]);
+    static constexpr size_t SizeClasses[] = { 16, 24, 32, 48, 64, 96, 128, 256 };
+    static constexpr size_t NumSizeClasses = sizeof(SizeClasses) / sizeof(SizeClasses[0]);
 
     /// A contiguous memory region divided into fixed-size cells.
     struct Slab
@@ -83,7 +83,7 @@ class ObjectPool
     /// Adds a new slab to the size class at the given index.
     void addSlab(size_t sizeClassIdx);
 
-    SizeClass _sizeClasses[kNumSizeClasses];
+    SizeClass _sizeClasses[NumSizeClasses];
     size_t _liveCount = 0;
     size_t _totalAllocations = 0;
     size_t _slabCapacity;

--- a/src/CoreVM/vm/Runner.cpp
+++ b/src/CoreVM/vm/Runner.cpp
@@ -1620,7 +1620,7 @@ Runner::RunResult Runner::loopWithResult()
             auto functionId = A;
             auto argc = B;
 
-            if (_callStack.size() >= maxCallDepth)
+            if (_callStack.size() >= MaxCallDepth)
             {
                 _ip = get_pc();
                 return handleRuntimeError(makeError("call stack overflow (exceeded maximum call depth)"));
@@ -1798,7 +1798,7 @@ Runner::RunResult Runner::loopWithResult()
 
             auto const totalArgc = captureCount + argc;
 
-            if (_callStack.size() >= maxCallDepth)
+            if (_callStack.size() >= MaxCallDepth)
             {
                 _ip = get_pc();
                 return handleRuntimeError(makeError("call stack overflow (exceeded maximum call depth)"));
@@ -1965,7 +1965,7 @@ Runner::RunResult Runner::loopWithResult()
 
             auto argc = captureCount;
 
-            if (_callStack.size() >= maxCallDepth)
+            if (_callStack.size() >= MaxCallDepth)
             {
                 if (releaseObject(lazy))
                     releaseAndFree(lazy);

--- a/src/CoreVM/vm/Runner.hpp
+++ b/src/CoreVM/vm/Runner.hpp
@@ -297,7 +297,7 @@ class Runner
 
     std::vector<CallFrame> _callStack;
 
-    static constexpr size_t maxCallDepth = 10000;
+    static constexpr size_t MaxCallDepth = 10000;
 };
 
 } // namespace CoreVM

--- a/src/agent/auth/LoginCommand.cpp
+++ b/src/agent/auth/LoginCommand.cpp
@@ -76,13 +76,13 @@ namespace
     /// @return The selected provider name, or empty on cancel.
     auto promptProviderSelection() -> std::string
     {
-        constexpr auto labels = std::array {
+        constexpr auto Labels = std::array {
             "Claude (Anthropic)"sv,
             "OpenAI"sv,
             "Gemini (Google)"sv,
             "GitHub Copilot"sv,
         };
-        auto const sel = askSingleSelect("Select a provider to authenticate:", labels);
+        auto const sel = askSingleSelect("Select a provider to authenticate:", Labels);
         if (!sel)
             return {};
         return std::string(KnownProviders[*sel].name);
@@ -293,11 +293,11 @@ namespace
         }
 
         // Ask which account type.
-        constexpr auto accountTypes = std::array {
+        constexpr auto AccountTypes = std::array {
             "Claude.ai (MAX/Pro subscription)"sv,
             "Anthropic Console (Teams/Enterprise)"sv,
         };
-        auto const accountSel = askSingleSelect("Select account type:", accountTypes);
+        auto const accountSel = askSingleSelect("Select account type:", AccountTypes);
         if (!accountSel)
             return EXIT_FAILURE;
 

--- a/src/agent/providers/local/ModelManager.cpp
+++ b/src/agent/providers/local/ModelManager.cpp
@@ -50,12 +50,12 @@ namespace
     [[nodiscard]] auto detectToolUseSupport(std::string_view arch) -> bool
     {
         // Models known to support tool calling well.
-        static constexpr auto toolUseArchitectures = std::array {
+        static constexpr auto ToolUseArchitectures = std::array {
             std::string_view { "llama" },     std::string_view { "qwen2" },
             std::string_view { "qwen2_moe" }, std::string_view { "mistral" },
             std::string_view { "command-r" },
         };
-        return std::ranges::any_of(toolUseArchitectures, [&](auto const& a) { return a == arch; });
+        return std::ranges::any_of(ToolUseArchitectures, [&](auto const& a) { return a == arch; });
     }
 
     /// Reads a string metadata value from the model.

--- a/src/agent/providers/local/ModelRegistry.cpp
+++ b/src/agent/providers/local/ModelRegistry.cpp
@@ -250,12 +250,12 @@ namespace
     [[nodiscard]] auto splitGroupKey(std::string_view filename) -> std::string
     {
         // Must end with ".gguf"
-        constexpr auto suffix = std::string_view { ".gguf" };
-        if (filename.size() < suffix.size() || filename.substr(filename.size() - suffix.size()) != suffix)
+        constexpr auto Suffix = std::string_view { ".gguf" };
+        if (filename.size() < Suffix.size() || filename.substr(filename.size() - Suffix.size()) != Suffix)
             return {};
 
         // Strip ".gguf" to get stem
-        auto const stem = filename.substr(0, filename.size() - suffix.size());
+        auto const stem = filename.substr(0, filename.size() - Suffix.size());
 
         // Look for "-NNNNN-of-NNNNN" at the end of stem
         // Minimum: "-N-of-N" = 7 chars, but we expect 5-digit parts: "-00001-of-00004" = 15 chars

--- a/src/agent/providers/local/ModelsCommand.cpp
+++ b/src/agent/providers/local/ModelsCommand.cpp
@@ -80,7 +80,7 @@ namespace
     }
 
     /// Status column index in the models table.
-    constexpr std::size_t statusColumnIndex = 3;
+    constexpr std::size_t StatusColumnIndex = 3;
 
     /// Runs `endo agent models list`.
     auto runList() -> int
@@ -149,7 +149,7 @@ namespace
 
         renderer.setCellStyleCallback(
             [&](size_t /*row*/, size_t col, std::string_view text) -> std::optional<tui::Style> {
-                if (col == statusColumnIndex)
+                if (col == StatusColumnIndex)
                 {
                     if (text == "downloaded")
                         return greenStyle;
@@ -168,13 +168,13 @@ namespace
     /// Renders a terminal progress bar.
     void renderProgress(Colors const& c, std::string_view label, size_t totalBytes, size_t downloadedBytes)
     {
-        constexpr int barWidth = 30;
+        constexpr int BarWidth = 30;
         auto const fraction =
             (totalBytes > 0) ? static_cast<double>(downloadedBytes) / static_cast<double>(totalBytes) : 0.0;
-        auto const filled = static_cast<int>(fraction * barWidth);
+        auto const filled = static_cast<int>(fraction * BarWidth);
 
         std::print("\r  {}[", c.cyan);
-        for (int i = 0; i < barWidth; ++i)
+        for (int i = 0; i < BarWidth; ++i)
             std::print("{}", (i < filled) ? "█" : "░");
         std::print("]{} {:3.0f}%  {} / {}   ",
                    c.reset,

--- a/src/agent/providers/local/ToolCallParser.cpp
+++ b/src/agent/providers/local/ToolCallParser.cpp
@@ -57,8 +57,8 @@ namespace
                                 std::span<ToolDefinition const> tools,
                                 ToolCallParseResult& result) -> bool
     {
-        constexpr auto openTag = std::string_view { "<tool_call>" };
-        constexpr auto closeTag = std::string_view { "</tool_call>" };
+        constexpr auto OpenTag = std::string_view { "<tool_call>" };
+        constexpr auto CloseTag = std::string_view { "</tool_call>" };
 
         auto foundAnyTag = false;
         auto pos = size_t { 0 };
@@ -67,7 +67,7 @@ namespace
 
         while (pos < text.size())
         {
-            auto const tagStart = text.find(openTag, pos);
+            auto const tagStart = text.find(OpenTag, pos);
             if (tagStart == std::string::npos)
                 break;
 
@@ -87,8 +87,8 @@ namespace
                 }
             }
 
-            auto const contentStart = tagStart + openTag.size();
-            auto const tagEnd = text.find(closeTag, contentStart);
+            auto const contentStart = tagStart + OpenTag.size();
+            auto const tagEnd = text.find(CloseTag, contentStart);
             if (tagEnd == std::string::npos)
             {
                 result.hadParsingErrors = true;
@@ -98,7 +98,7 @@ namespace
             }
 
             auto const content = text.substr(contentStart, tagEnd - contentStart);
-            lastEnd = tagEnd + closeTag.size();
+            lastEnd = tagEnd + CloseTag.size();
             pos = lastEnd;
 
             try
@@ -148,8 +148,8 @@ namespace
                                       std::span<ToolDefinition const> tools,
                                       ToolCallParseResult& result) -> bool
     {
-        constexpr auto openFence = std::string_view { "```json" };
-        constexpr auto closeFence = std::string_view { "```" };
+        constexpr auto OpenFence = std::string_view { "```json" };
+        constexpr auto CloseFence = std::string_view { "```" };
 
         auto foundAnyBlock = false;
         auto pos = size_t { 0 };
@@ -158,7 +158,7 @@ namespace
 
         while (pos < text.size())
         {
-            auto const blockStart = text.find(openFence, pos);
+            auto const blockStart = text.find(OpenFence, pos);
             if (blockStart == std::string::npos)
                 break;
 
@@ -178,8 +178,8 @@ namespace
                 }
             }
 
-            auto const contentStart = blockStart + openFence.size();
-            auto const blockEnd = text.find(closeFence, contentStart);
+            auto const contentStart = blockStart + OpenFence.size();
+            auto const blockEnd = text.find(CloseFence, contentStart);
             if (blockEnd == std::string::npos)
             {
                 result.hadParsingErrors = true;
@@ -189,7 +189,7 @@ namespace
             }
 
             auto const content = text.substr(contentStart, blockEnd - contentStart);
-            lastEnd = blockEnd + closeFence.size();
+            lastEnd = blockEnd + CloseFence.size();
             pos = lastEnd;
 
             try

--- a/src/agent/session/AgentSession.cpp
+++ b/src/agent/session/AgentSession.cpp
@@ -325,11 +325,11 @@ auto AgentSession::processMessageForPlan(
         _traceEventCallback(TraceUserMessageEvent { .mode = "plan", .content = std::string(userMessage) });
 
     // Build filtered tool definitions: only read-only tools + submit_plan
-    static constexpr auto allowedTools = std::array<std::string_view, 5> {
+    static constexpr auto AllowedTools = std::array<std::string_view, 5> {
         "read_file", "glob", "grep", "git", "submit_plan",
     };
     auto const filteredDefs = _toolRegistry->definitions([](std::string_view toolName) {
-        for (auto const& allowed: allowedTools)
+        for (auto const& allowed: AllowedTools)
             if (toolName == allowed)
                 return true;
         return false;

--- a/src/agent/tracing/TraceTerminalRenderer.cpp
+++ b/src/agent/tracing/TraceTerminalRenderer.cpp
@@ -14,13 +14,13 @@ namespace endo::agent
 namespace
 {
     /// Dim style for trace labels.
-    constexpr auto dimStyle = tui::Style { .dim = true };
+    constexpr auto DimStyle = tui::Style { .dim = true };
 
     /// Style for error trace lines.
-    constexpr auto errorStyle = tui::Style { .fg = uint8_t { 196 }, .bold = true }; // bright red
+    constexpr auto ErrorStyle = tui::Style { .fg = uint8_t { 196 }, .bold = true }; // bright red
 
     /// Style for the trace prefix label.
-    constexpr auto prefixStyle = tui::Style { .fg = uint8_t { 243 }, .dim = true }; // gray
+    constexpr auto PrefixStyle = tui::Style { .fg = uint8_t { 243 }, .dim = true }; // gray
 
     /// Formats a duration in milliseconds as a human-readable string.
     auto formatDuration(std::chrono::milliseconds ms) -> std::string
@@ -98,24 +98,24 @@ namespace
 
         void operator()(TraceUserMessageEvent const& e) const
         {
-            out.writeText("[trace \xe2\x86\x92] ", prefixStyle);
+            out.writeText("[trace \xe2\x86\x92] ", PrefixStyle);
             auto const preview = truncateContent(e.content, 80);
-            out.writeText(std::format("User ({}): \"{}\"\n", e.mode, preview), dimStyle);
+            out.writeText(std::format("User ({}): \"{}\"\n", e.mode, preview), DimStyle);
         }
 
         void operator()(TraceLlmRequestEvent const& e) const
         {
-            out.writeText("[trace \xe2\x86\x92] ", prefixStyle);
+            out.writeText("[trace \xe2\x86\x92] ", PrefixStyle);
             out.writeText(std::format("LLM request #{}: {} msgs, ~{} tokens\n",
                                       e.iteration,
                                       e.messageCount,
                                       formatCount(e.tokenEstimate)),
-                          dimStyle);
+                          DimStyle);
         }
 
         void operator()(TraceLlmResponseEvent const& e) const
         {
-            out.writeText("[trace \xe2\x86\x90] ", prefixStyle);
+            out.writeText("[trace \xe2\x86\x90] ", PrefixStyle);
             auto line = std::format("LLM response #{}: ", e.iteration);
             if (e.hasToolCalls)
                 line += std::format("{} tool call{}", e.toolCount, e.toolCount == 1 ? "" : "s");
@@ -127,12 +127,12 @@ namespace
                                     formatCount(static_cast<size_t>(e.usage->inputTokens)),
                                     formatCount(static_cast<size_t>(e.usage->outputTokens)));
             line += "\n";
-            out.writeText(line, dimStyle);
+            out.writeText(line, DimStyle);
         }
 
         void operator()(TraceToolCallEvent const& e) const
         {
-            out.writeText("[trace \xe2\x86\x94] ", prefixStyle);
+            out.writeText("[trace \xe2\x86\x94] ", PrefixStyle);
             auto const argSummary = summarizeArguments(e.arguments);
             auto const resultSummary = formatResultSummary(e.resultContent, e.resultIsError);
             out.writeText(std::format("{} {} \xe2\x86\x92 {} ({})\n",
@@ -140,24 +140,24 @@ namespace
                                       argSummary,
                                       resultSummary,
                                       formatDuration(e.duration)),
-                          e.resultIsError ? errorStyle : dimStyle);
+                          e.resultIsError ? ErrorStyle : DimStyle);
         }
 
         void operator()(TraceCompactionEvent const& e) const
         {
-            out.writeText("[trace \xe2\x88\xbc] ", prefixStyle);
+            out.writeText("[trace \xe2\x88\xbc] ", PrefixStyle);
             out.writeText(std::format("Compaction: {}\xe2\x86\x92{} msgs, {}\xe2\x86\x92{} tokens\n",
                                       e.beforeMessages,
                                       e.afterMessages,
                                       formatCount(e.beforeTokens),
                                       formatCount(e.afterTokens)),
-                          dimStyle);
+                          DimStyle);
         }
 
         void operator()(TraceErrorEvent const& e) const
         {
-            out.writeText("[trace !] ", prefixStyle);
-            out.writeText(std::format("Error ({}): {}\n", e.code, e.message), errorStyle);
+            out.writeText("[trace !] ", PrefixStyle);
+            out.writeText(std::format("Error ({}): {}\n", e.code, e.message), ErrorStyle);
         }
     };
 
@@ -165,9 +165,9 @@ namespace
     auto formatForStderr(TraceEvent const& event) -> std::string
     {
         // dim = ESC[2m, reset = ESC[0m, bold red = ESC[1;31m
-        constexpr auto dim = "\033[2m";
-        constexpr auto red = "\033[1;31m";
-        constexpr auto reset = "\033[0m";
+        constexpr auto Dim = "\033[2m";
+        constexpr auto Red = "\033[1;31m";
+        constexpr auto Reset = "\033[0m";
 
         return std::visit(
             [&](auto const& e) -> std::string {
@@ -176,20 +176,20 @@ namespace
                 {
                     auto const preview = truncateContent(e.content, 80);
                     return std::format(
-                        "{}[trace \xe2\x86\x92] User ({}): \"{}\"{}\n", dim, e.mode, preview, reset);
+                        "{}[trace \xe2\x86\x92] User ({}): \"{}\"{}\n", Dim, e.mode, preview, Reset);
                 }
                 else if constexpr (std::is_same_v<T, TraceLlmRequestEvent>)
                 {
                     return std::format("{}[trace \xe2\x86\x92] LLM request #{}: {} msgs, ~{} tokens{}\n",
-                                       dim,
+                                       Dim,
                                        e.iteration,
                                        e.messageCount,
                                        formatCount(e.tokenEstimate),
-                                       reset);
+                                       Reset);
                 }
                 else if constexpr (std::is_same_v<T, TraceLlmResponseEvent>)
                 {
-                    auto line = std::format("{}[trace \xe2\x86\x90] LLM response #{}: ", dim, e.iteration);
+                    auto line = std::format("{}[trace \xe2\x86\x90] LLM response #{}: ", Dim, e.iteration);
                     if (e.hasToolCalls)
                         line += std::format("{} tool call{}", e.toolCount, e.toolCount == 1 ? "" : "s");
                     else
@@ -199,36 +199,36 @@ namespace
                         line += std::format(", in:{} out:{}",
                                             formatCount(static_cast<size_t>(e.usage->inputTokens)),
                                             formatCount(static_cast<size_t>(e.usage->outputTokens)));
-                    line += std::format("{}\n", reset);
+                    line += std::format("{}\n", Reset);
                     return line;
                 }
                 else if constexpr (std::is_same_v<T, TraceToolCallEvent>)
                 {
                     auto const argSummary = summarizeArguments(e.arguments);
                     auto const resultSummary = formatResultSummary(e.resultContent, e.resultIsError);
-                    auto const style = e.resultIsError ? red : dim;
+                    auto const style = e.resultIsError ? Red : Dim;
                     return std::format("{}[trace \xe2\x86\x94] {} {} \xe2\x86\x92 {} ({}){}\n",
                                        style,
                                        e.name,
                                        argSummary,
                                        resultSummary,
                                        formatDuration(e.duration),
-                                       reset);
+                                       Reset);
                 }
                 else if constexpr (std::is_same_v<T, TraceCompactionEvent>)
                 {
                     return std::format("{}[trace \xe2\x88\xbc] Compaction: {}\xe2\x86\x92{} msgs, "
                                        "{}\xe2\x86\x92{} tokens{}\n",
-                                       dim,
+                                       Dim,
                                        e.beforeMessages,
                                        e.afterMessages,
                                        formatCount(e.beforeTokens),
                                        formatCount(e.afterTokens),
-                                       reset);
+                                       Reset);
                 }
                 else if constexpr (std::is_same_v<T, TraceErrorEvent>)
                 {
-                    return std::format("{}[trace !] Error ({}): {}{}\n", red, e.code, e.message, reset);
+                    return std::format("{}[trace !] Error ({}): {}{}\n", Red, e.code, e.message, Reset);
                 }
                 else
                 {

--- a/src/agent/ui/AgentInputComponent.cpp
+++ b/src/agent/ui/AgentInputComponent.cpp
@@ -758,14 +758,14 @@ void AgentInputComponent::renderInfoLine(tui::Canvas& canvas, int row)
             std::string_view desc;
         };
 
-        static constexpr std::array hints = {
+        static constexpr std::array Hints = {
             Hint { .key = "Esc", .desc = "exit" },
             Hint { .key = "S-Tab", .desc = "mode" },
             Hint { .key = "C-/", .desc = "thinking" },
             Hint { .key = "C-.", .desc = "model" },
         };
 
-        for (auto const& [key, desc]: hints)
+        for (auto const& [key, desc]: Hints)
         {
             if (col > 1)
                 col += canvas.putString(row, col, "  ", {}); // gap between hints

--- a/src/coro/Cancellation.hpp
+++ b/src/coro/Cancellation.hpp
@@ -60,7 +60,7 @@ struct OperationCancelled
 /// token. Usage: `auto token = co_await endo::coro::thisCoroStopToken();`.
 struct ThisCoroStopToken
 {
-    StopToken token {}; ///< Filled from the awaiting promise in await_suspend.
+    StopToken token; ///< Filled from the awaiting promise in await_suspend.
 
     /// Never ready: await_suspend runs to capture the token, then resumes immediately.
     [[nodiscard]] bool await_ready() const noexcept { return false; }

--- a/src/coro/Task_test.cpp
+++ b/src/coro/Task_test.cpp
@@ -140,13 +140,13 @@ TEST_CASE("Deep co_await chains keep the stack bounded (symmetric transfer)", "[
 {
     // Without symmetric transfer this recursion would overflow the stack; with it
     // both the descent and the unwind are tail calls.
-    constexpr auto depth = 100000;
-    auto task = sumDown(depth);
+    constexpr auto Depth = 100000;
+    auto task = sumDown(Depth);
 
     task.handle().resume();
 
     REQUIRE(task.done());
-    REQUIRE(task.result() == depth);
+    REQUIRE(task.result() == Depth);
 }
 
 TEST_CASE("whenAll completes synchronously when every child does", "[Task][whenAll]")

--- a/src/editor-protocol/JsonTransport.cpp
+++ b/src/editor-protocol/JsonTransport.cpp
@@ -24,10 +24,10 @@ std::expected<nlohmann::json, std::string> readMessage(std::istream& input)
             break;
 
         // Parse Content-Length header
-        constexpr std::string_view prefix = "Content-Length: ";
-        if (line.starts_with(prefix))
+        constexpr std::string_view Prefix = "Content-Length: ";
+        if (line.starts_with(Prefix))
         {
-            auto const valueStr = std::string_view(line).substr(prefix.size());
+            auto const valueStr = std::string_view(line).substr(Prefix.size());
             auto const [ptr, ec] =
                 std::from_chars(valueStr.data(), valueStr.data() + valueStr.size(), contentLength);
             if (ec != std::errc {})

--- a/src/endo-language/TestHelper.cpp
+++ b/src/endo-language/TestHelper.cpp
@@ -44,7 +44,7 @@ namespace
             char const* command;
         };
 
-        constexpr MockProc procs[] = {
+        constexpr MockProc Procs[] = {
             { .pid = 1, .ppid = 0, .user = "root", .cpu = 0.1, .mem = 1024, .command = "/sbin/init" },
             { .pid = 42, .ppid = 1, .user = "alice", .cpu = 15.5, .mem = 4096, .command = "firefox" },
             { .pid = 100, .ppid = 1, .user = "bob", .cpu = 2.3, .mem = 2048, .command = "vim" },
@@ -52,7 +52,7 @@ namespace
         auto* list = runner->makeNilList(CoreVM::LiteralType::Object);
         for (int i = 2; i >= 0; --i)
         {
-            auto const& p = procs[i];
+            auto const& p = Procs[i];
             auto* record = runner->allocObject(CoreVM::BuiltinTypeId::ProcessInfo);
             record->setSlot(0, static_cast<uint64_t>(p.pid));
             record->setSlot(1, static_cast<uint64_t>(p.ppid));
@@ -81,7 +81,7 @@ namespace
             bool isDir;
         };
 
-        constexpr MockFile allFiles[] = {
+        constexpr MockFile AllFiles[] = {
             { .name = "docs", .size = 4096, .mode = 0755, .mtime = 1700000000, .isDir = true },
             { .name = "hello.txt", .size = 42, .mode = 0644, .mtime = 1700001000, .isDir = false },
             { .name = "script.sh", .size = 256, .mode = 0755, .mtime = 1700002000, .isDir = false },
@@ -93,7 +93,7 @@ namespace
         auto* list = runner->makeNilList(CoreVM::LiteralType::Object);
         for (int i = 2; i >= 0; --i)
         {
-            auto const& f = allFiles[i];
+            auto const& f = AllFiles[i];
 
             // Filter: directory path returns all, glob filters by pattern, else exact name match.
             if (!path.empty() && path != "." && path != "/tmp" && !path.starts_with("/home/testuser"))
@@ -138,7 +138,7 @@ namespace
             int64_t pid;
         };
 
-        constexpr MockJob jobs[] = {
+        constexpr MockJob Jobs[] = {
             { .id = 1, .state = "Running", .command = "sleep 100", .pid = 1234 },
             { .id = 2, .state = "Stopped", .command = "vim", .pid = 5678 },
             { .id = 3, .state = "Done", .command = "make build", .pid = 9012 },
@@ -146,7 +146,7 @@ namespace
         auto* list = runner->makeNilList(CoreVM::LiteralType::Object);
         for (int i = 2; i >= 0; --i)
         {
-            auto const& j = jobs[i];
+            auto const& j = Jobs[i];
             auto* record = runner->allocObject(CoreVM::BuiltinTypeId::JobInfo);
             record->setSlot(0, static_cast<uint64_t>(j.id));
             record->setSlot(1, reinterpret_cast<uintptr_t>(runner->newString(j.state)));
@@ -168,7 +168,7 @@ namespace
             char const* action;
         };
 
-        constexpr MockBinding bindings[] = {
+        constexpr MockBinding Bindings[] = {
             { .key = "ctrl+z", .action = "undo" },
             { .key = "ctrl+y", .action = "redo" },
             { .key = "ctrl+a", .action = "select-all" },
@@ -176,7 +176,7 @@ namespace
         auto* list = runner->makeNilList(CoreVM::LiteralType::Object);
         for (int i = 2; i >= 0; --i)
         {
-            auto const& b = bindings[i];
+            auto const& b = Bindings[i];
             auto* record = runner->allocObject(CoreVM::BuiltinTypeId::KeyBindingInfo);
             record->setSlot(0, reinterpret_cast<uintptr_t>(runner->newString(b.key)));
             record->setSlot(1, reinterpret_cast<uintptr_t>(runner->newString(b.action)));
@@ -201,7 +201,7 @@ namespace
             char const* names;
         };
 
-        constexpr MockContainer containers[] = {
+        constexpr MockContainer Containers[] = {
             { .id = "abc123def",
               .image = "nginx:latest",
               .command = "/docker-entrypoint…",
@@ -227,7 +227,7 @@ namespace
         auto* list = runner->makeNilList(CoreVM::LiteralType::Object);
         for (int i = 2; i >= 0; --i)
         {
-            auto const& c = containers[i];
+            auto const& c = Containers[i];
             auto* record = runner->allocObject(CoreVM::BuiltinTypeId::OutputDefBase);
             record->setSlot(0, reinterpret_cast<uintptr_t>(runner->newString(c.id)));
             record->setSlot(1, reinterpret_cast<uintptr_t>(runner->newString(c.image)));
@@ -255,7 +255,7 @@ namespace
             char const* size;
         };
 
-        constexpr MockImage images[] = {
+        constexpr MockImage Images[] = {
             { .id = "sha256:abc",
               .repository = "nginx",
               .tag = "latest",
@@ -275,9 +275,9 @@ namespace
         auto* list = runner->makeNilList(CoreVM::LiteralType::Object);
         for (int i = 2; i >= 0; --i)
         {
-            auto const& img = images[i];
-            constexpr uint16_t typeId = CoreVM::BuiltinTypeId::OutputDefBase + 1;
-            auto* record = runner->allocObject(typeId);
+            auto const& img = Images[i];
+            constexpr uint16_t TypeId = CoreVM::BuiltinTypeId::OutputDefBase + 1;
+            auto* record = runner->allocObject(TypeId);
             record->setSlot(0, reinterpret_cast<uintptr_t>(runner->newString(img.id)));
             record->setSlot(1, reinterpret_cast<uintptr_t>(runner->newString(img.repository)));
             record->setSlot(2, reinterpret_cast<uintptr_t>(runner->newString(img.tag)));
@@ -302,7 +302,7 @@ namespace
             char const* message;
         };
 
-        constexpr MockCommit commits[] = {
+        constexpr MockCommit Commits[] = {
             { .sha = "abc123",
               .author = "Alice",
               .email = "alice@example.com",
@@ -322,9 +322,9 @@ namespace
         auto* list = runner->makeNilList(CoreVM::LiteralType::Object);
         for (int i = 2; i >= 0; --i)
         {
-            auto const& c = commits[i];
-            constexpr uint16_t typeId = CoreVM::BuiltinTypeId::OutputDefBase + 2;
-            auto* record = runner->allocObject(typeId);
+            auto const& c = Commits[i];
+            constexpr uint16_t TypeId = CoreVM::BuiltinTypeId::OutputDefBase + 2;
+            auto* record = runner->allocObject(TypeId);
             record->setSlot(0, reinterpret_cast<uintptr_t>(runner->newString(c.sha)));
             record->setSlot(1, reinterpret_cast<uintptr_t>(runner->newString(c.author)));
             record->setSlot(2, reinterpret_cast<uintptr_t>(runner->newString(c.email)));
@@ -346,7 +346,7 @@ namespace
             char const* path;
         };
 
-        constexpr MockStatusEntry entries[] = {
+        constexpr MockStatusEntry Entries[] = {
             { .status = "M", .path = "src/main.cpp" },
             { .status = "??", .path = "README.md" },
             { .status = "A", .path = ".gitignore" },
@@ -354,9 +354,9 @@ namespace
         auto* list = runner->makeNilList(CoreVM::LiteralType::Object);
         for (int i = 2; i >= 0; --i)
         {
-            auto const& e = entries[i];
-            constexpr uint16_t typeId = CoreVM::BuiltinTypeId::OutputDefBase + 3;
-            auto* record = runner->allocObject(typeId);
+            auto const& e = Entries[i];
+            constexpr uint16_t TypeId = CoreVM::BuiltinTypeId::OutputDefBase + 3;
+            auto* record = runner->allocObject(TypeId);
             record->setSlot(0, reinterpret_cast<uintptr_t>(runner->newString(e.status)));
             record->setSlot(1, reinterpret_cast<uintptr_t>(runner->newString(e.path)));
             list =
@@ -1207,9 +1207,9 @@ FSharpPersistentState createMockStructuredState()
 
     // DockerPsRecord (typeId = OutputDefBase = 100)
     {
-        constexpr uint16_t typeId = CoreVM::BuiltinTypeId::OutputDefBase;
+        constexpr uint16_t TypeId = CoreVM::BuiltinTypeId::OutputDefBase;
         state.outputDefinitionTypes["DockerPsRecord"] = {
-            .typeId = typeId,
+            .typeId = TypeId,
             .fields = {
                 { .name="id", .offset=0, .type=LiteralType::String },
                 { .name="image", .offset=1, .type=LiteralType::String },
@@ -1222,7 +1222,7 @@ FSharpPersistentState createMockStructuredState()
         };
         state.structuredCommands[std::string("docker\0ps", 9)] = {
             .builtinCallbackName = "structured_docker_ps",
-            .recordTypeId = typeId,
+            .recordTypeId = TypeId,
             .recordTypeName = "DockerPsRecord",
         };
         state.recordTypeFields["DockerPsRecord"] = {
@@ -1235,9 +1235,9 @@ FSharpPersistentState createMockStructuredState()
 
     // DockerImagesRecord (typeId = OutputDefBase + 1 = 101)
     {
-        constexpr uint16_t typeId = CoreVM::BuiltinTypeId::OutputDefBase + 1;
+        constexpr uint16_t TypeId = CoreVM::BuiltinTypeId::OutputDefBase + 1;
         state.outputDefinitionTypes["DockerImagesRecord"] = {
-            .typeId = typeId,
+            .typeId = TypeId,
             .fields = {
                 { .name="id", .offset=0, .type=LiteralType::String },
                 { .name="repository", .offset=1, .type=LiteralType::String },
@@ -1248,7 +1248,7 @@ FSharpPersistentState createMockStructuredState()
         };
         state.structuredCommands[std::string("docker\0images", 13)] = {
             .builtinCallbackName = "structured_docker_images",
-            .recordTypeId = typeId,
+            .recordTypeId = TypeId,
             .recordTypeName = "DockerImagesRecord",
         };
         state.recordTypeFields["DockerImagesRecord"] = {
@@ -1260,9 +1260,9 @@ FSharpPersistentState createMockStructuredState()
 
     // GitLogRecord (typeId = OutputDefBase + 2 = 102)
     {
-        constexpr uint16_t typeId = CoreVM::BuiltinTypeId::OutputDefBase + 2;
+        constexpr uint16_t TypeId = CoreVM::BuiltinTypeId::OutputDefBase + 2;
         state.outputDefinitionTypes["GitLogRecord"] = {
-            .typeId = typeId,
+            .typeId = TypeId,
             .fields = {
                 { .name="sha", .offset=0, .type=LiteralType::String },
                 { .name="author", .offset=1, .type=LiteralType::String },
@@ -1273,7 +1273,7 @@ FSharpPersistentState createMockStructuredState()
         };
         state.structuredCommands[std::string("git\0log", 7)] = {
             .builtinCallbackName = "structured_git_log",
-            .recordTypeId = typeId,
+            .recordTypeId = TypeId,
             .recordTypeName = "GitLogRecord",
         };
         state.recordTypeFields["GitLogRecord"] = {
@@ -1285,9 +1285,9 @@ FSharpPersistentState createMockStructuredState()
 
     // GitStatusRecord (typeId = OutputDefBase + 3 = 103)
     {
-        constexpr uint16_t typeId = CoreVM::BuiltinTypeId::OutputDefBase + 3;
+        constexpr uint16_t TypeId = CoreVM::BuiltinTypeId::OutputDefBase + 3;
         state.outputDefinitionTypes["GitStatusRecord"] = {
-            .typeId = typeId,
+            .typeId = TypeId,
             .fields = {
                 { .name="status", .offset=0, .type=LiteralType::String },
                 { .name="path", .offset=1, .type=LiteralType::String },
@@ -1295,7 +1295,7 @@ FSharpPersistentState createMockStructuredState()
         };
         state.structuredCommands[std::string("git\0status", 10)] = {
             .builtinCallbackName = "structured_git_status",
-            .recordTypeId = typeId,
+            .recordTypeId = TypeId,
             .recordTypeName = "GitStatusRecord",
         };
         state.recordTypeFields["GitStatusRecord"] = {

--- a/src/endo-language/builtins/BuiltinImpls.cpp
+++ b/src/endo-language/builtins/BuiltinImpls.cpp
@@ -1636,11 +1636,11 @@ void processKill(CoreVM::Params& args)
 {
     auto const pid = static_cast<int>(args.getInt(1));
 #if defined(_WIN32)
-    constexpr auto defaultSignal = 0; // Windows uses TerminateProcess(), signal number is ignored
+    constexpr auto DefaultSignal = 0; // Windows uses TerminateProcess(), signal number is ignored
 #else
     constexpr auto defaultSignal = SIGTERM;
 #endif
-    auto const err = platformSendSignal(pid, defaultSignal);
+    auto const err = platformSendSignal(pid, DefaultSignal);
     if (!err.empty())
     {
         auto* errStr = args.caller()->newString(err);

--- a/src/endo-language/builtins/BuiltinImpls.cpp
+++ b/src/endo-language/builtins/BuiltinImpls.cpp
@@ -1638,7 +1638,7 @@ void processKill(CoreVM::Params& args)
 #if defined(_WIN32)
     constexpr auto DefaultSignal = 0; // Windows uses TerminateProcess(), signal number is ignored
 #else
-    constexpr auto defaultSignal = SIGTERM;
+    constexpr auto DefaultSignal = SIGTERM;
 #endif
     auto const err = platformSendSignal(pid, DefaultSignal);
     if (!err.empty())

--- a/src/endo-language/builtins/BuiltinSignatures.cpp
+++ b/src/endo-language/builtins/BuiltinSignatures.cpp
@@ -655,7 +655,7 @@ namespace
     /// here serve as the baseline for test binaries that don't call registration.
     /// New inline builtins only need an InlineCommandDescriptor entry — they will
     /// be auto-registered at startup.
-    constexpr std::array shellBuiltinDescriptors = {
+    constexpr std::array ShellBuiltinDescriptors = {
         // VM-level builtins (not in InlineCommandDescriptors)
         ShellBuiltinDescriptor { .name="cd", .description="builtin", .detail="**cd** -- builtin\n\nChanges the current working directory.\n\n```\ncd /tmp\ncd ~\n```" },
         ShellBuiltinDescriptor { .name="exit", .description="builtin", .detail="**exit** -- builtin\n\nExits the shell with an optional exit code.\n\n```\nexit\nexit 1\n```" },
@@ -764,7 +764,7 @@ namespace
         ShellBuiltinDescriptor { .name="until", .description="builtin", .detail="**until** -- builtin\n\nLoop until a condition is true." },
     };
 
-    constexpr std::array keywordDescriptors = {
+    constexpr std::array KeywordDescriptors = {
         ShellBuiltinDescriptor { .name="if", .description="builtin", .detail="**if** -- shell keyword\n\n```\nif condition then\n  body\nfi\n```" },
         ShellBuiltinDescriptor { .name="then", .description="builtin", .detail="**then** -- shell keyword\n\nFollows the condition in a shell `if` statement." },
         ShellBuiltinDescriptor { .name="else", .description="builtin", .detail="**else** -- shell keyword\n\nAlternative branch in a shell `if` statement." },
@@ -786,11 +786,11 @@ std::vector<BuiltinInfo> userFacingBuiltins()
     auto const stdlibDescs = stdlibDescriptors();
 
     std::vector<BuiltinInfo> result;
-    result.reserve(shellBuiltinDescriptors.size() + inlineBuiltins.size() + stdlibDescs.size()
-                   + keywordDescriptors.size() + allPropertyDescriptors().size());
+    result.reserve(ShellBuiltinDescriptors.size() + inlineBuiltins.size() + stdlibDescs.size()
+                   + KeywordDescriptors.size() + allPropertyDescriptors().size());
 
     // Shell builtins (non-inline)
-    for (auto const& desc: shellBuiltinDescriptors)
+    for (auto const& desc: ShellBuiltinDescriptors)
         result.push_back({ .name = std::string(desc.name),
                            .description = std::string(desc.description),
                            .isProperty = false,
@@ -809,7 +809,7 @@ std::vector<BuiltinInfo> userFacingBuiltins()
                                .detail = std::string(desc.detail) });
 
     // Keywords
-    for (auto const& desc: keywordDescriptors)
+    for (auto const& desc: KeywordDescriptors)
         result.push_back({ .name = std::string(desc.name),
                            .description = std::string(desc.description),
                            .isProperty = false,

--- a/src/endo-language/builtins/PropertyDescriptors.cpp
+++ b/src/endo-language/builtins/PropertyDescriptors.cpp
@@ -13,7 +13,7 @@ namespace endo
 // ---------------------------------------------------------------------------
 
 // clang-format off
-static constexpr std::array presetValues = {
+static constexpr std::array PresetValues = {
     EnumValueEntry { .value="minimal-arrow", .description="Clean arrow-based prompt" },
     EnumValueEntry { .value="lambda-clean", .description="Lambda symbol prompt" },
     EnumValueEntry { .value="opencode-bar", .description="OpenCode-style bar prompt" },
@@ -26,14 +26,14 @@ static constexpr std::array presetValues = {
     EnumValueEntry { .value="endo-signature", .description="Endo signature prompt" },
 };
 
-static constexpr std::array layoutValues = {
+static constexpr std::array LayoutValues = {
     EnumValueEntry { .value="single-line", .description="Single line prompt" },
     EnumValueEntry { .value="two-line", .description="Two line prompt" },
     EnumValueEntry { .value="boxed", .description="Boxed prompt layout" },
     EnumValueEntry { .value="powerline", .description="Powerline prompt layout" },
 };
 
-static constexpr std::array separatorValues = {
+static constexpr std::array SeparatorValues = {
     EnumValueEntry { .value="none", .description="No separator" },
     EnumValueEntry { .value="bar", .description="Bar separator (|)" },
     EnumValueEntry { .value="powerline", .description="Powerline separator" },
@@ -41,13 +41,13 @@ static constexpr std::array separatorValues = {
     EnumValueEntry { .value="boxed", .description="Boxed separator" },
 };
 
-static constexpr std::array transientValues = {
+static constexpr std::array TransientValues = {
     EnumValueEntry { .value="off", .description="Disable transient prompt" },
     EnumValueEntry { .value="minimal", .description="Minimal transient prompt" },
     EnumValueEntry { .value="arrow", .description="Arrow transient prompt" },
 };
 
-static constexpr std::array providerValues = {
+static constexpr std::array ProviderValues = {
     EnumValueEntry { .value="claude", .description="Anthropic Claude" },
     EnumValueEntry { .value="openai", .description="OpenAI" },
     EnumValueEntry { .value="gemini", .description="Google Gemini" },
@@ -55,12 +55,12 @@ static constexpr std::array providerValues = {
     EnumValueEntry { .value="local", .description="Local model (llama.cpp)" },
 };
 
-static constexpr std::array boolValues = {
+static constexpr std::array BoolValues = {
     EnumValueEntry { .value="true", .description="Enable" },
     EnumValueEntry { .value="false", .description="Disable" },
 };
 
-static constexpr std::array colorValues = {
+static constexpr std::array ColorValues = {
     EnumValueEntry { .value="transparent", .description="Use terminal default background" },
     EnumValueEntry { .value="theme", .description="Use theme default color" },
 };
@@ -68,18 +68,18 @@ static constexpr std::array colorValues = {
 /// Setter-argument types for properties that additionally accept a zero-argument
 /// function returning a string (`shell_prompt_indicator`, `shell_prompt_color_*`).
 /// Referenced from PropertyDescriptor::extraSetterTypes.
-static constexpr std::array stringOrFunctionExtraTypes = {
+static constexpr std::array StringOrFunctionExtraTypes = {
     CoreVM::LiteralType::Function,
 };
 // clang-format on
 
-static constexpr std::array webSearchEngineValues = {
+static constexpr std::array WebSearchEngineValues = {
     EnumValueEntry { .value = "duckduckgo", .description = "DuckDuckGo (no API key required)" },
     EnumValueEntry { .value = "brave", .description = "Brave Search" },
     EnumValueEntry { .value = "google", .description = "Google Custom Search" },
 };
 
-static constexpr std::array claudeModelValues = {
+static constexpr std::array ClaudeModelValues = {
     EnumValueEntry { .value = "claude-opus-4-6", .description = "Claude Opus 4.6" },
     EnumValueEntry { .value = "claude-sonnet-4-6", .description = "Claude Sonnet 4.6" },
     EnumValueEntry { .value = "claude-haiku-4-5-20251001", .description = "Claude Haiku 4.5" },
@@ -87,39 +87,39 @@ static constexpr std::array claudeModelValues = {
     EnumValueEntry { .value = "claude-opus-4-20250514", .description = "Claude Opus 4" },
 };
 
-static constexpr std::array openaiModelValues = {
+static constexpr std::array OpenaiModelValues = {
     EnumValueEntry { .value = "gpt-4o", .description = "GPT-4o" },
     EnumValueEntry { .value = "gpt-4o-mini", .description = "GPT-4o Mini" },
     EnumValueEntry { .value = "o3-mini", .description = "O3 Mini" },
     EnumValueEntry { .value = "o1", .description = "O1" },
 };
 
-static constexpr std::array geminiModelValues = {
+static constexpr std::array GeminiModelValues = {
     EnumValueEntry { .value = "gemini-2.5-flash", .description = "Gemini 2.5 Flash" },
     EnumValueEntry { .value = "gemini-2.5-pro", .description = "Gemini 2.5 Pro" },
     EnumValueEntry { .value = "gemini-2.0-flash", .description = "Gemini 2.0 Flash" },
 };
 
-static constexpr std::array thinkingModeValues = {
+static constexpr std::array ThinkingModeValues = {
     EnumValueEntry { .value = "off", .description = "No thinking (provider default)" },
     EnumValueEntry { .value = "normal", .description = "Moderate thinking budget" },
     EnumValueEntry { .value = "extended", .description = "Maximum thinking budget" },
 };
 
-static constexpr std::array authTypeValues = {
+static constexpr std::array AuthTypeValues = {
     EnumValueEntry { .value = "auto", .description = "Auto-detect (OAuth preferred)" },
     EnumValueEntry { .value = "oauth", .description = "OAuth authentication" },
     EnumValueEntry { .value = "api_key", .description = "API key authentication" },
 };
 
-static constexpr std::array errorRecoveryActionValues = {
+static constexpr std::array ErrorRecoveryActionValues = {
     EnumValueEntry { .value = "ask", .description = "Ask user before analyzing (default)" },
     EnumValueEntry { .value = "analyze", .description = "Automatically analyze failed commands" },
     EnumValueEntry { .value = "ignore", .description = "Do nothing on command failure" },
 };
 
 /// Combined model values for agent_error_recovery_model (all providers).
-static constexpr std::array errorRecoveryModelValues = {
+static constexpr std::array ErrorRecoveryModelValues = {
     // Claude models
     EnumValueEntry { .value = "claude-opus-4-6", .description = "Claude Opus 4.6" },
     EnumValueEntry { .value = "claude-sonnet-4-6", .description = "Claude Sonnet 4.6" },
@@ -141,7 +141,7 @@ static constexpr std::array errorRecoveryModelValues = {
 // Prompt/Shell property descriptors
 // ---------------------------------------------------------------------------
 
-static constexpr std::array promptProperties = {
+static constexpr std::array PromptProperties = {
     PropertyDescriptor {
         .name = "shell_prompt_preset",
         .type = CoreVM::LiteralType::String,
@@ -149,7 +149,7 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_preset** -- property\n\nSets the prompt theme "
                   "preset.\n\n```\nshell_prompt_preset powerline\n```",
         .readOnly = false,
-        .enumValues = presetValues,
+        .enumValues = PresetValues,
     },
     PropertyDescriptor {
         .name = "shell_prompt_indicator",
@@ -158,7 +158,7 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_indicator** -- property\n\nSets the prompt indicator character(s). "
                   "Accepts either a string or a zero-argument function returning a string "
                   "(invoked at each prompt render).",
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_layout",
@@ -167,7 +167,7 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_layout** -- property\n\nSets the prompt layout style (single-line, "
                   "two-line, boxed, powerline).",
         .readOnly = false,
-        .enumValues = layoutValues,
+        .enumValues = LayoutValues,
     },
     PropertyDescriptor {
         .name = "shell_prompt_separator",
@@ -176,7 +176,7 @@ static constexpr std::array promptProperties = {
         .detail =
             "**shell_prompt_separator** -- property\n\nSets the separator style between prompt modules.",
         .readOnly = false,
-        .enumValues = separatorValues,
+        .enumValues = SeparatorValues,
     },
     PropertyDescriptor {
         .name = "shell_prompt_transient",
@@ -185,7 +185,7 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_transient** -- property\n\nControls transient prompt behavior (off, "
                   "minimal, arrow).",
         .readOnly = false,
-        .enumValues = transientValues,
+        .enumValues = TransientValues,
     },
     PropertyDescriptor {
         .name = "shell_prompt_duration_threshold",
@@ -240,7 +240,7 @@ static constexpr std::array promptProperties = {
                   "transparent\nshell_prompt_color_background \"#2D3237\"\nshell_prompt_color_background "
                   "theme\n```",
         .readOnly = false,
-        .enumValues = colorValues,
+        .enumValues = ColorValues,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_path",
@@ -251,8 +251,8 @@ static constexpr std::array promptProperties = {
             "colors and gradients.\n\n```\nshell_prompt_color_path \"#FF6600\"\nshell_prompt_color_path "
             "\"#5078FF:#00DCC8\"\nshell_prompt_color_path theme\n```",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_git_clean",
@@ -261,8 +261,8 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_git_clean** -- property\n\nSets the git branch text color when the "
                   "repository is clean.",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_git_dirty",
@@ -271,8 +271,8 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_git_dirty** -- property\n\nSets the git branch text color when there "
                   "are unstaged changes.",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_git_staged",
@@ -281,8 +281,8 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_git_staged** -- property\n\nSets the git indicator color when staged "
                   "changes exist.",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_indicator",
@@ -291,8 +291,8 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_indicator** -- property\n\nSets the input line indicator color "
                   "(e.g., `|> `).",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_indicator_error",
@@ -301,8 +301,8 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_indicator_error** -- property\n\nSets the indicator color when the "
                   "last command failed (non-zero exit).",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_exit_code",
@@ -310,8 +310,8 @@ static constexpr std::array promptProperties = {
         .description = "Exit code badge color (#RRGGBB, gradient, or theme)",
         .detail = "**shell_prompt_color_exit_code** -- property\n\nSets the exit code badge color.",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_duration",
@@ -319,8 +319,8 @@ static constexpr std::array promptProperties = {
         .description = "Duration badge color (#RRGGBB, gradient, or theme)",
         .detail = "**shell_prompt_color_duration** -- property\n\nSets the command duration badge color.",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_hostname",
@@ -329,8 +329,8 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_hostname** -- property\n\nSets the hostname module text color (shown "
                   "in SSH sessions).",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_separator",
@@ -338,8 +338,8 @@ static constexpr std::array promptProperties = {
         .description = "Separator/bar color (#RRGGBB, gradient, or theme)",
         .detail = "**shell_prompt_color_separator** -- property\n\nSets the left bar / separator color.",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_badge",
@@ -348,8 +348,8 @@ static constexpr std::array promptProperties = {
         .detail = "**shell_prompt_color_badge** -- property\n\nSets the badge background color (used by F# "
                   "mode, structured output).",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_badge_text",
@@ -357,8 +357,8 @@ static constexpr std::array promptProperties = {
         .description = "Badge text color (#RRGGBB or theme)",
         .detail = "**shell_prompt_color_badge_text** -- property\n\nSets the badge text color.",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
     PropertyDescriptor {
         .name = "shell_prompt_color_clock",
@@ -366,8 +366,8 @@ static constexpr std::array promptProperties = {
         .description = "Clock text color (#RRGGBB or theme)",
         .detail = "**shell_prompt_color_clock** -- property\n\nSets the clock module text color.",
         .readOnly = false,
-        .enumValues = colorValues,
-        .extraSetterTypes = stringOrFunctionExtraTypes,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
     },
 };
 
@@ -375,7 +375,7 @@ static constexpr std::array promptProperties = {
 // Agent configuration property descriptors
 // ---------------------------------------------------------------------------
 
-static constexpr std::array agentProperties = {
+static constexpr std::array AgentProperties = {
     // --- Top-level agent settings ---
     PropertyDescriptor {
         .name = "agent_provider",
@@ -384,7 +384,7 @@ static constexpr std::array agentProperties = {
         .detail = "**agent_provider** -- property\n\nSets the active AI provider (claude, openai, gemini, "
                   "openai_compat).",
         .readOnly = false,
-        .enumValues = providerValues,
+        .enumValues = ProviderValues,
     },
     PropertyDescriptor {
         .name = "agent_prompt_indicator",
@@ -404,7 +404,7 @@ static constexpr std::array agentProperties = {
         .description = "Enable/disable tool invocation logging",
         .detail = "**agent_log_tool_uses** -- property\n\nEnables or disables logging of tool invocations.",
         .readOnly = false,
-        .enumValues = boolValues,
+        .enumValues = BoolValues,
     },
     // --- Claude provider ---
     PropertyDescriptor {
@@ -426,7 +426,7 @@ static constexpr std::array agentProperties = {
         .description = "Claude model identifier",
         .detail = "**agent_claude_model** -- property\n\nSets the Claude model identifier.",
         .readOnly = false,
-        .enumValues = claudeModelValues,
+        .enumValues = ClaudeModelValues,
     },
     PropertyDescriptor {
         .name = "agent_claude_max_tokens",
@@ -441,7 +441,7 @@ static constexpr std::array agentProperties = {
         .detail = "**agent_claude_thinking_mode** -- property\n\nSets Claude thinking/reasoning mode (off, "
                   "normal, extended).",
         .readOnly = false,
-        .enumValues = thinkingModeValues,
+        .enumValues = ThinkingModeValues,
     },
     PropertyDescriptor {
         .name = "agent_claude_prompt_caching",
@@ -456,7 +456,7 @@ static constexpr std::array agentProperties = {
         .detail = "**agent_claude_auth_type** -- property\n\nSets the Claude authentication method (auto, "
                   "oauth, api_key).",
         .readOnly = false,
-        .enumValues = authTypeValues,
+        .enumValues = AuthTypeValues,
     },
     // --- OpenAI provider ---
     PropertyDescriptor {
@@ -478,7 +478,7 @@ static constexpr std::array agentProperties = {
         .description = "OpenAI model identifier",
         .detail = "**agent_openai_model** -- property\n\nSets the OpenAI model identifier.",
         .readOnly = false,
-        .enumValues = openaiModelValues,
+        .enumValues = OpenaiModelValues,
     },
     PropertyDescriptor {
         .name = "agent_openai_base_url",
@@ -498,7 +498,7 @@ static constexpr std::array agentProperties = {
         .description = "OpenAI thinking/reasoning mode",
         .detail = "**agent_openai_thinking_mode** -- property\n\nSets OpenAI thinking/reasoning mode.",
         .readOnly = false,
-        .enumValues = thinkingModeValues,
+        .enumValues = ThinkingModeValues,
     },
     // --- OpenAI-compatible provider ---
     PropertyDescriptor {
@@ -520,7 +520,7 @@ static constexpr std::array agentProperties = {
         .description = "OpenAI-compatible model identifier",
         .detail = "**agent_openai_compat_model** -- property\n\nSets the OpenAI-compatible model identifier.",
         .readOnly = false,
-        .enumValues = openaiModelValues,
+        .enumValues = OpenaiModelValues,
     },
     PropertyDescriptor {
         .name = "agent_openai_compat_base_url",
@@ -540,7 +540,7 @@ static constexpr std::array agentProperties = {
         .description = "OpenAI-compatible thinking mode",
         .detail = "**agent_openai_compat_thinking_mode** -- property\n\nSets the thinking mode.",
         .readOnly = false,
-        .enumValues = thinkingModeValues,
+        .enumValues = ThinkingModeValues,
     },
     // --- Gemini provider ---
     PropertyDescriptor {
@@ -562,7 +562,7 @@ static constexpr std::array agentProperties = {
         .description = "Gemini model identifier",
         .detail = "**agent_gemini_model** -- property\n\nSets the Gemini model identifier.",
         .readOnly = false,
-        .enumValues = geminiModelValues,
+        .enumValues = GeminiModelValues,
     },
     PropertyDescriptor {
         .name = "agent_gemini_max_tokens",
@@ -576,7 +576,7 @@ static constexpr std::array agentProperties = {
         .description = "Gemini thinking/reasoning mode",
         .detail = "**agent_gemini_thinking_mode** -- property\n\nSets Gemini thinking/reasoning mode.",
         .readOnly = false,
-        .enumValues = thinkingModeValues,
+        .enumValues = ThinkingModeValues,
     },
     // --- Plan mode ---
     PropertyDescriptor {
@@ -585,7 +585,7 @@ static constexpr std::array agentProperties = {
         .description = "Enable/disable plan mode",
         .detail = "**agent_plan_mode_enabled** -- property\n\nEnables or disables plan mode.",
         .readOnly = false,
-        .enumValues = boolValues,
+        .enumValues = BoolValues,
     },
     PropertyDescriptor {
         .name = "agent_plan_mode_pause_between_steps",
@@ -594,7 +594,7 @@ static constexpr std::array agentProperties = {
         .detail = "**agent_plan_mode_pause_between_steps** -- property\n\nPause for confirmation between "
                   "plan steps.",
         .readOnly = false,
-        .enumValues = boolValues,
+        .enumValues = BoolValues,
     },
     PropertyDescriptor {
         .name = "agent_plan_mode_max_exploration_turns",
@@ -631,7 +631,7 @@ static constexpr std::array agentProperties = {
         .description = "Enable/disable trace logging",
         .detail = "**agent_trace_enabled** -- property\n\nEnables or disables trace logging.",
         .readOnly = false,
-        .enumValues = boolValues,
+        .enumValues = BoolValues,
     },
     PropertyDescriptor {
         .name = "agent_trace_default_path",
@@ -653,7 +653,7 @@ static constexpr std::array agentProperties = {
             "**agent_trace_terminal** -- property\n\nEnables real-time display of agent trace events on the "
             "terminal.\nShows LLM requests/responses, tool calls, compaction events, and errors.",
         .readOnly = false,
-        .enumValues = boolValues,
+        .enumValues = BoolValues,
     },
     // --- Permissions ---
     PropertyDescriptor {
@@ -684,7 +684,7 @@ static constexpr std::array agentProperties = {
         .detail = "**agent_web_search_engine** -- property\n\nSets the web search engine (duckduckgo, brave, "
                   "google).",
         .readOnly = false,
-        .enumValues = webSearchEngineValues,
+        .enumValues = WebSearchEngineValues,
     },
     PropertyDescriptor {
         .name = "agent_web_search_api_key",
@@ -762,7 +762,7 @@ static constexpr std::array agentProperties = {
         .detail = "**agent_local_flash_attention** -- property\n\nEnables or disables Flash Attention for "
                   "local inference.",
         .readOnly = false,
-        .enumValues = boolValues,
+        .enumValues = BoolValues,
     },
     PropertyDescriptor {
         .name = "agent_local_max_tokens",
@@ -786,7 +786,7 @@ static constexpr std::array agentProperties = {
         .detail = "**agent_error_recovery_action** -- property\n\nAction on command failure (ask, analyze, "
                   "ignore).",
         .readOnly = false,
-        .enumValues = errorRecoveryActionValues,
+        .enumValues = ErrorRecoveryActionValues,
     },
     PropertyDescriptor {
         .name = "agent_error_recovery_model",
@@ -795,7 +795,7 @@ static constexpr std::array agentProperties = {
         .detail = "**agent_error_recovery_model** -- property\n\nModel to use for error analysis. Empty uses "
                   "the active model.",
         .readOnly = false,
-        .enumValues = errorRecoveryModelValues,
+        .enumValues = ErrorRecoveryModelValues,
     },
 };
 // clang-format on
@@ -810,9 +810,9 @@ static std::vector<PropertyDescriptor> const& allProperties()
 {
     static auto const combined = [] {
         std::vector<PropertyDescriptor> result;
-        result.reserve(promptProperties.size() + agentProperties.size());
-        result.insert(result.end(), promptProperties.begin(), promptProperties.end());
-        result.insert(result.end(), agentProperties.begin(), agentProperties.end());
+        result.reserve(PromptProperties.size() + AgentProperties.size());
+        result.insert(result.end(), PromptProperties.begin(), PromptProperties.end());
+        result.insert(result.end(), AgentProperties.begin(), AgentProperties.end());
         return result;
     }();
     return combined;
@@ -824,12 +824,12 @@ static std::vector<PropertyDescriptor> const& allProperties()
 
 std::span<PropertyDescriptor const> promptPropertyDescriptors()
 {
-    return promptProperties;
+    return PromptProperties;
 }
 
 std::span<PropertyDescriptor const> agentPropertyDescriptors()
 {
-    return agentProperties;
+    return AgentProperties;
 }
 
 std::span<PropertyDescriptor const> allPropertyDescriptors()

--- a/src/endo-language/builtins/StdlibDescriptors.cpp
+++ b/src/endo-language/builtins/StdlibDescriptors.cpp
@@ -16,59 +16,59 @@ using LT = CoreVM::LiteralType;
 // ---------------------------------------------------------------------------
 
 // Common single-param patterns
-static constexpr ParamDescriptor textStringParam[] = { { .name="text", .type=LT::String } };
-static constexpr ParamDescriptor keyStringParam[] = { { .name="key", .type=LT::String } };
-static constexpr ParamDescriptor listNumberParam[] = { { .name="list", .type=LT::Number } };
-static constexpr ParamDescriptor objNumberParam[] = { { .name="obj", .type=LT::Number } };
-static constexpr ParamDescriptor nNumberParam[] = { { .name="n", .type=LT::Number } };
-static constexpr ParamDescriptor epochNumberParam[] = { { .name="epoch", .type=LT::Number } };
-static constexpr ParamDescriptor modeNumberParam[] = { { .name="mode", .type=LT::Number } };
-static constexpr ParamDescriptor programStringParam[] = { { .name="program", .type=LT::String } };
-static constexpr ParamDescriptor urlStringParam[] = { { .name="url", .type=LT::String } };
-static constexpr ParamDescriptor nameStringParam[] = { { .name="name", .type=LT::String } };
-static constexpr ParamDescriptor valueNumberParam[] = { { .name="value", .type=LT::Number } };
-static constexpr ParamDescriptor pairsNumberParam[] = { { .name="pairs", .type=LT::Number } };
-static constexpr ParamDescriptor mdNumberParam[] = { { .name="md", .type=LT::Number } };
+static constexpr ParamDescriptor TextStringParam[] = { { .name="text", .type=LT::String } };
+static constexpr ParamDescriptor KeyStringParam[] = { { .name="key", .type=LT::String } };
+static constexpr ParamDescriptor ListNumberParam[] = { { .name="list", .type=LT::Number } };
+static constexpr ParamDescriptor ObjNumberParam[] = { { .name="obj", .type=LT::Number } };
+static constexpr ParamDescriptor NNumberParam[] = { { .name="n", .type=LT::Number } };
+static constexpr ParamDescriptor EpochNumberParam[] = { { .name="epoch", .type=LT::Number } };
+static constexpr ParamDescriptor ModeNumberParam[] = { { .name="mode", .type=LT::Number } };
+static constexpr ParamDescriptor ProgramStringParam[] = { { .name="program", .type=LT::String } };
+static constexpr ParamDescriptor UrlStringParam[] = { { .name="url", .type=LT::String } };
+static constexpr ParamDescriptor NameStringParam[] = { { .name="name", .type=LT::String } };
+static constexpr ParamDescriptor ValueNumberParam[] = { { .name="value", .type=LT::Number } };
+static constexpr ParamDescriptor PairsNumberParam[] = { { .name="pairs", .type=LT::Number } };
+static constexpr ParamDescriptor MdNumberParam[] = { { .name="md", .type=LT::Number } };
 
 // Multi-param patterns
-static constexpr ParamDescriptor exportTwoParams[] = { { .name="name", .type=LT::String }, { .name="value", .type=LT::String } };
-static constexpr ParamDescriptor listConcatParams[] = { { .name="left", .type=LT::Number }, { .name="right", .type=LT::Number } };
-static constexpr ParamDescriptor listNthParams[] = { { .name="index", .type=LT::Number }, { .name="list", .type=LT::Number } };
-static constexpr ParamDescriptor listReplicateParams[] = { { .name="count", .type=LT::Number }, { .name="value", .type=LT::Number } };
-static constexpr ParamDescriptor listCharRangeParams[] = { { .name="start", .type=LT::Number }, { .name="end", .type=LT::Number } };
-static constexpr ParamDescriptor listRangeParams[] = { { .name="start", .type=LT::Number }, { .name="step", .type=LT::Number }, { .name="end", .type=LT::Number } };
-static constexpr ParamDescriptor stringRepeatParams[] = { { .name="str", .type=LT::String }, { .name="count", .type=LT::Number } };
-static constexpr ParamDescriptor stringReplaceParams[] = { { .name="old_str", .type=LT::String }, { .name="new_str", .type=LT::String }, { .name="text", .type=LT::String } };
-static constexpr ParamDescriptor stringSplitParams[] = { { .name="delimiter", .type=LT::String }, { .name="text", .type=LT::String } };
-static constexpr ParamDescriptor stringLinesParam[] = { { .name="text", .type=LT::String } };
-static constexpr ParamDescriptor stringJoinParams[] = { { .name="separator", .type=LT::String }, { .name="list", .type=LT::Number } };
-static constexpr ParamDescriptor stringContainsParams[] = { { .name="substr", .type=LT::String }, { .name="text", .type=LT::String } };
-static constexpr ParamDescriptor stringStartsWithParams[] = { { .name="prefix", .type=LT::String }, { .name="text", .type=LT::String } };
-static constexpr ParamDescriptor stringEndsWithParams[] = { { .name="suffix", .type=LT::String }, { .name="text", .type=LT::String } };
-static constexpr ParamDescriptor formatNumberTwoParams[] = { { .name="separator", .type=LT::String }, { .name="number", .type=LT::Number } };
-static constexpr ParamDescriptor formatNumberOneParams[] = { { .name="number", .type=LT::Number } };
-static constexpr ParamDescriptor randRangeParams[] = { { .name="min", .type=LT::Number }, { .name="max", .type=LT::Number } };
-static constexpr ParamDescriptor fetchTwoParams[] = { { .name="url", .type=LT::String }, { .name="headers", .type=LT::Number } };
-static constexpr ParamDescriptor jsonQueryParams[] = { { .name="path", .type=LT::String }, { .name="json", .type=LT::String } };
-static constexpr ParamDescriptor registerCompleterParams[] = { { .name="command", .type=LT::String }, { .name="function_name", .type=LT::String } };
+static constexpr ParamDescriptor ExportTwoParams[] = { { .name="name", .type=LT::String }, { .name="value", .type=LT::String } };
+static constexpr ParamDescriptor ListConcatParams[] = { { .name="left", .type=LT::Number }, { .name="right", .type=LT::Number } };
+static constexpr ParamDescriptor ListNthParams[] = { { .name="index", .type=LT::Number }, { .name="list", .type=LT::Number } };
+static constexpr ParamDescriptor ListReplicateParams[] = { { .name="count", .type=LT::Number }, { .name="value", .type=LT::Number } };
+static constexpr ParamDescriptor ListCharRangeParams[] = { { .name="start", .type=LT::Number }, { .name="end", .type=LT::Number } };
+static constexpr ParamDescriptor ListRangeParams[] = { { .name="start", .type=LT::Number }, { .name="step", .type=LT::Number }, { .name="end", .type=LT::Number } };
+static constexpr ParamDescriptor StringRepeatParams[] = { { .name="str", .type=LT::String }, { .name="count", .type=LT::Number } };
+static constexpr ParamDescriptor StringReplaceParams[] = { { .name="old_str", .type=LT::String }, { .name="new_str", .type=LT::String }, { .name="text", .type=LT::String } };
+static constexpr ParamDescriptor StringSplitParams[] = { { .name="delimiter", .type=LT::String }, { .name="text", .type=LT::String } };
+static constexpr ParamDescriptor StringLinesParam[] = { { .name="text", .type=LT::String } };
+static constexpr ParamDescriptor StringJoinParams[] = { { .name="separator", .type=LT::String }, { .name="list", .type=LT::Number } };
+static constexpr ParamDescriptor StringContainsParams[] = { { .name="substr", .type=LT::String }, { .name="text", .type=LT::String } };
+static constexpr ParamDescriptor StringStartsWithParams[] = { { .name="prefix", .type=LT::String }, { .name="text", .type=LT::String } };
+static constexpr ParamDescriptor StringEndsWithParams[] = { { .name="suffix", .type=LT::String }, { .name="text", .type=LT::String } };
+static constexpr ParamDescriptor FormatNumberTwoParams[] = { { .name="separator", .type=LT::String }, { .name="number", .type=LT::Number } };
+static constexpr ParamDescriptor FormatNumberOneParams[] = { { .name="number", .type=LT::Number } };
+static constexpr ParamDescriptor RandRangeParams[] = { { .name="min", .type=LT::Number }, { .name="max", .type=LT::Number } };
+static constexpr ParamDescriptor FetchTwoParams[] = { { .name="url", .type=LT::String }, { .name="headers", .type=LT::Number } };
+static constexpr ParamDescriptor JsonQueryParams[] = { { .name="path", .type=LT::String }, { .name="json", .type=LT::String } };
+static constexpr ParamDescriptor RegisterCompleterParams[] = { { .name="command", .type=LT::String }, { .name="function_name", .type=LT::String } };
 
 // Completion module params
-static constexpr ParamDescriptor completionEntryParams[] = { { .name="text", .type=LT::String } };
-static constexpr ParamDescriptor completionDescribedParams[] = { { .name="text", .type=LT::String }, { .name="description", .type=LT::String } };
-static constexpr ParamDescriptor completionDetailedParams[] = { { .name="text", .type=LT::String }, { .name="description", .type=LT::String }, { .name="detail", .type=LT::String } };
+static constexpr ParamDescriptor CompletionEntryParams[] = { { .name="text", .type=LT::String } };
+static constexpr ParamDescriptor CompletionDescribedParams[] = { { .name="text", .type=LT::String }, { .name="description", .type=LT::String } };
+static constexpr ParamDescriptor CompletionDetailedParams[] = { { .name="text", .type=LT::String }, { .name="description", .type=LT::String }, { .name="detail", .type=LT::String } };
 
 // File I/O params
-static constexpr ParamDescriptor fileOpenParams[] = { { .name="path", .type=LT::String }, { .name="mode", .type=LT::String } };
-static constexpr ParamDescriptor fdNumberParam[] = { { .name="fd", .type=LT::Number } };
-static constexpr ParamDescriptor pathStringParam[] = { { .name="path", .type=LT::String } };
-static constexpr ParamDescriptor fileWriteParams[] = { { .name="path", .type=LT::String }, { .name="content", .type=LT::String } };
+static constexpr ParamDescriptor FileOpenParams[] = { { .name="path", .type=LT::String }, { .name="mode", .type=LT::String } };
+static constexpr ParamDescriptor FdNumberParam[] = { { .name="fd", .type=LT::Number } };
+static constexpr ParamDescriptor PathStringParam[] = { { .name="path", .type=LT::String } };
+static constexpr ParamDescriptor FileWriteParams[] = { { .name="path", .type=LT::String }, { .name="content", .type=LT::String } };
 
 // Process signal params
-static constexpr ParamDescriptor processPidParam[] = { { .name="pid", .type=LT::Number } };
+static constexpr ParamDescriptor ProcessPidParam[] = { { .name="pid", .type=LT::Number } };
 
 // Ref cell params
-static constexpr ParamDescriptor refObjParam[] = { { .name="ref", .type=LT::Number } };
-static constexpr ParamDescriptor processSignalParams[] = { { .name="signum", .type=LT::Number }, { .name="pid", .type=LT::Number } };
+static constexpr ParamDescriptor RefObjParam[] = { { .name="ref", .type=LT::Number } };
+static constexpr ParamDescriptor ProcessSignalParams[] = { { .name="signum", .type=LT::Number }, { .name="pid", .type=LT::Number } };
 
 // ---------------------------------------------------------------------------
 // Unified descriptor table
@@ -84,8 +84,8 @@ static const std::array descriptors = {
     // -----------------------------------------------------------------------
     // Output (Shell builtins — not stdlib candidates, but need VM registration)
     // -----------------------------------------------------------------------
-    StdlibDescriptor { .userFacingName="", .vmName="print", .returnType=LT::Void, .params=textStringParam, .sharedImpl=nullptr, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="println", .returnType=LT::Void, .params=textStringParam, .sharedImpl=nullptr, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="print", .returnType=LT::Void, .params=TextStringParam, .sharedImpl=nullptr, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="println", .returnType=LT::Void, .params=TextStringParam, .sharedImpl=nullptr, .description="", .detail="" },
 
     // -----------------------------------------------------------------------
     // Type Conversion (IR-generated, no VM registration)
@@ -109,81 +109,81 @@ static const std::array descriptors = {
     // -----------------------------------------------------------------------
     // String Operations
     // -----------------------------------------------------------------------
-    StdlibDescriptor { .userFacingName="trim", .vmName="string_trim", .returnType=LT::String, .params=textStringParam, .sharedImpl=&builtins::stringTrim,
+    StdlibDescriptor { .userFacingName="trim", .vmName="string_trim", .returnType=LT::String, .params=TextStringParam, .sharedImpl=&builtins::stringTrim,
         .description="trim s -> string",
         .detail="**trim** `s -> string`\n\nRemoves leading and trailing whitespace from **s**." },
-    StdlibDescriptor { .userFacingName="toLower", .vmName="string_toLower", .returnType=LT::String, .params=textStringParam, .sharedImpl=&builtins::stringToLower,
+    StdlibDescriptor { .userFacingName="toLower", .vmName="string_toLower", .returnType=LT::String, .params=TextStringParam, .sharedImpl=&builtins::stringToLower,
         .description="toLower s -> string",
         .detail="**toLower** `s -> string`\n\nConverts all characters in **s** to lowercase." },
-    StdlibDescriptor { .userFacingName="toUpper", .vmName="string_toUpper", .returnType=LT::String, .params=textStringParam, .sharedImpl=&builtins::stringToUpper,
+    StdlibDescriptor { .userFacingName="toUpper", .vmName="string_toUpper", .returnType=LT::String, .params=TextStringParam, .sharedImpl=&builtins::stringToUpper,
         .description="toUpper s -> string",
         .detail="**toUpper** `s -> string`\n\nConverts all characters in **s** to uppercase." },
-    StdlibDescriptor { .userFacingName="contains", .vmName="string_contains", .returnType=LT::Boolean, .params=stringContainsParams, .sharedImpl=&builtins::stringContains,
+    StdlibDescriptor { .userFacingName="contains", .vmName="string_contains", .returnType=LT::Boolean, .params=StringContainsParams, .sharedImpl=&builtins::stringContains,
         .description="contains substr s -> bool",
         .detail="**contains** `substr s -> bool`\n\nReturns true if **s** contains **substr**." },
-    StdlibDescriptor { .userFacingName="startsWith", .vmName="string_startsWith", .returnType=LT::Boolean, .params=stringStartsWithParams, .sharedImpl=&builtins::stringStartsWith,
+    StdlibDescriptor { .userFacingName="startsWith", .vmName="string_startsWith", .returnType=LT::Boolean, .params=StringStartsWithParams, .sharedImpl=&builtins::stringStartsWith,
         .description="startsWith prefix s -> bool",
         .detail="**startsWith** `prefix s -> bool`\n\nReturns true if **s** starts with **prefix**." },
-    StdlibDescriptor { .userFacingName="endsWith", .vmName="string_endsWith", .returnType=LT::Boolean, .params=stringEndsWithParams, .sharedImpl=&builtins::stringEndsWith,
+    StdlibDescriptor { .userFacingName="endsWith", .vmName="string_endsWith", .returnType=LT::Boolean, .params=StringEndsWithParams, .sharedImpl=&builtins::stringEndsWith,
         .description="endsWith suffix s -> bool",
         .detail="**endsWith** `suffix s -> bool`\n\nReturns true if **s** ends with **suffix**." },
-    StdlibDescriptor { .userFacingName="replace", .vmName="string_replace", .returnType=LT::String, .params=stringReplaceParams, .sharedImpl=&builtins::stringReplace,
+    StdlibDescriptor { .userFacingName="replace", .vmName="string_replace", .returnType=LT::String, .params=StringReplaceParams, .sharedImpl=&builtins::stringReplace,
         .description="replace old new s -> string",
         .detail="**replace** `old new s -> string`\n\nReplaces all occurrences of **old** with **new** in **s**." },
-    StdlibDescriptor { .userFacingName="split", .vmName="string_split", .returnType=LT::Number, .params=stringSplitParams, .sharedImpl=&builtins::stringSplit,
+    StdlibDescriptor { .userFacingName="split", .vmName="string_split", .returnType=LT::Number, .params=StringSplitParams, .sharedImpl=&builtins::stringSplit,
         .description="split delim s -> list<string>",
         .detail="**split** `delim s -> list<string>`\n\nSplits **s** by delimiter **delim**." },
-    StdlibDescriptor { .userFacingName="lines", .vmName="string_lines", .returnType=LT::Number, .params=stringLinesParam, .sharedImpl=&builtins::stringLines,
+    StdlibDescriptor { .userFacingName="lines", .vmName="string_lines", .returnType=LT::Number, .params=StringLinesParam, .sharedImpl=&builtins::stringLines,
         .description="lines s -> list<string>",
         .detail="**lines** `s -> list<string>`\n\nSplits **s** into a list of lines (by newline, stripping `\\r`)." },
-    StdlibDescriptor { .userFacingName="join", .vmName="string_join", .returnType=LT::String, .params=stringJoinParams, .sharedImpl=&builtins::stringJoin,
+    StdlibDescriptor { .userFacingName="join", .vmName="string_join", .returnType=LT::String, .params=StringJoinParams, .sharedImpl=&builtins::stringJoin,
         .description="join delim lst -> string",
         .detail="**join** `delim lst -> string`\n\nJoins list elements with **delim** between them." },
 
     // -----------------------------------------------------------------------
     // String Unicode Decomposition
     // -----------------------------------------------------------------------
-    StdlibDescriptor { .userFacingName="bytes", .vmName="string_to_bytes", .returnType=LT::Number, .params=textStringParam, .sharedImpl=&builtins::stringToBytes,
+    StdlibDescriptor { .userFacingName="bytes", .vmName="string_to_bytes", .returnType=LT::Number, .params=TextStringParam, .sharedImpl=&builtins::stringToBytes,
         .description="bytes s -> list<int>",
         .detail="**bytes** `s -> list<int>`\n\nReturns the list of UTF-8 byte values (0–255) of string **s**." },
-    StdlibDescriptor { .userFacingName="codepoints", .vmName="string_to_codepoints", .returnType=LT::Number, .params=textStringParam, .sharedImpl=&builtins::stringToCodepoints,
+    StdlibDescriptor { .userFacingName="codepoints", .vmName="string_to_codepoints", .returnType=LT::Number, .params=TextStringParam, .sharedImpl=&builtins::stringToCodepoints,
         .description="codepoints s -> list<int>",
         .detail="**codepoints** `s -> list<int>`\n\nReturns the list of Unicode codepoint values of string **s**." },
-    StdlibDescriptor { .userFacingName="graphemes", .vmName="string_to_graphemes", .returnType=LT::Number, .params=textStringParam, .sharedImpl=&builtins::stringToGraphemes,
+    StdlibDescriptor { .userFacingName="graphemes", .vmName="string_to_graphemes", .returnType=LT::Number, .params=TextStringParam, .sharedImpl=&builtins::stringToGraphemes,
         .description="graphemes s -> list<string>",
         .detail="**graphemes** `s -> list<string>`\n\nReturns the list of grapheme clusters (user-perceived characters) of string **s**." },
-    StdlibDescriptor { .userFacingName="byte_length", .vmName="string_byte_length", .returnType=LT::Number, .params=textStringParam, .sharedImpl=&builtins::stringByteLength,
+    StdlibDescriptor { .userFacingName="byte_length", .vmName="string_byte_length", .returnType=LT::Number, .params=TextStringParam, .sharedImpl=&builtins::stringByteLength,
         .description="byte_length s -> int",
         .detail="**byte_length** `s -> int`\n\nReturns the number of UTF-8 bytes in string **s**." },
-    StdlibDescriptor { .userFacingName="codepoint_length", .vmName="string_codepoint_length", .returnType=LT::Number, .params=textStringParam, .sharedImpl=&builtins::stringCodepointLength,
+    StdlibDescriptor { .userFacingName="codepoint_length", .vmName="string_codepoint_length", .returnType=LT::Number, .params=TextStringParam, .sharedImpl=&builtins::stringCodepointLength,
         .description="codepoint_length s -> int",
         .detail="**codepoint_length** `s -> int`\n\nReturns the number of Unicode codepoints in string **s**." },
-    StdlibDescriptor { .userFacingName="grapheme_length", .vmName="string_grapheme_length", .returnType=LT::Number, .params=textStringParam, .sharedImpl=&builtins::stringGraphemeLength,
+    StdlibDescriptor { .userFacingName="grapheme_length", .vmName="string_grapheme_length", .returnType=LT::Number, .params=TextStringParam, .sharedImpl=&builtins::stringGraphemeLength,
         .description="grapheme_length s -> int",
         .detail="**grapheme_length** `s -> int`\n\nReturns the number of grapheme clusters (user-perceived characters) in string **s**." },
 
     // -----------------------------------------------------------------------
     // List Basic
     // -----------------------------------------------------------------------
-    StdlibDescriptor { .userFacingName="head", .vmName="list_head", .returnType=LT::Number, .params=listNumberParam, .sharedImpl=&builtins::listHead,
+    StdlibDescriptor { .userFacingName="head", .vmName="list_head", .returnType=LT::Number, .params=ListNumberParam, .sharedImpl=&builtins::listHead,
         .description="head lst -> 'a",
         .detail="**head** `lst -> 'a`\n\nReturns the first element of the list." },
-    StdlibDescriptor { .userFacingName="tail", .vmName="list_tail", .returnType=LT::Number, .params=listNumberParam, .sharedImpl=&builtins::listTail,
+    StdlibDescriptor { .userFacingName="tail", .vmName="list_tail", .returnType=LT::Number, .params=ListNumberParam, .sharedImpl=&builtins::listTail,
         .description="tail lst -> list<'a>",
         .detail="**tail** `lst -> list<'a>`\n\nReturns the list without its first element." },
-    StdlibDescriptor { .userFacingName="length", .vmName="list_length", .returnType=LT::Number, .params=listNumberParam, .sharedImpl=&builtins::listLength,
+    StdlibDescriptor { .userFacingName="length", .vmName="list_length", .returnType=LT::Number, .params=ListNumberParam, .sharedImpl=&builtins::listLength,
         .description="length lst -> int",
         .detail="**length** `lst -> int`\n\nReturns the number of elements in the list." },
-    StdlibDescriptor { .userFacingName="isEmpty", .vmName="list_isEmpty", .returnType=LT::Boolean, .params=listNumberParam, .sharedImpl=&builtins::listIsEmpty,
+    StdlibDescriptor { .userFacingName="isEmpty", .vmName="list_isEmpty", .returnType=LT::Boolean, .params=ListNumberParam, .sharedImpl=&builtins::listIsEmpty,
         .description="isEmpty lst -> bool",
         .detail="**isEmpty** `lst -> bool`\n\nReturns true if the list is empty." },
-    StdlibDescriptor { .userFacingName="nth", .vmName="list_nth", .returnType=LT::Number, .params=listNthParams, .sharedImpl=&builtins::listNth,
+    StdlibDescriptor { .userFacingName="nth", .vmName="list_nth", .returnType=LT::Number, .params=ListNthParams, .sharedImpl=&builtins::listNth,
         .description="nth n lst -> 'a",
         .detail="**nth** `n lst -> 'a`\n\nReturns the element at index **n** (0-based)." },
-    StdlibDescriptor { .userFacingName="last", .vmName="list_last", .returnType=LT::Number, .params=listNumberParam, .sharedImpl=&builtins::listLast,
+    StdlibDescriptor { .userFacingName="last", .vmName="list_last", .returnType=LT::Number, .params=ListNumberParam, .sharedImpl=&builtins::listLast,
         .description="last lst -> 'a",
         .detail="**last** `lst -> 'a`\n\nReturns the last element of the list." },
-    StdlibDescriptor { .userFacingName="replicate", .vmName="list_replicate", .returnType=LT::Number, .params=listReplicateParams, .sharedImpl=&builtins::listReplicate,
+    StdlibDescriptor { .userFacingName="replicate", .vmName="list_replicate", .returnType=LT::Number, .params=ListReplicateParams, .sharedImpl=&builtins::listReplicate,
         .description="replicate n x -> list<'a>",
         .detail="**replicate** `n x -> list<'a>`\n\nCreates a list of **n** copies of **x**." },
 
@@ -218,13 +218,13 @@ static const std::array descriptors = {
     // -----------------------------------------------------------------------
     // List Transforms
     // -----------------------------------------------------------------------
-    StdlibDescriptor { .userFacingName="sort", .vmName="list_sort", .returnType=LT::Number, .params=listNumberParam, .sharedImpl=&builtins::listSort,
+    StdlibDescriptor { .userFacingName="sort", .vmName="list_sort", .returnType=LT::Number, .params=ListNumberParam, .sharedImpl=&builtins::listSort,
         .description="sort lst -> list<'a>",
         .detail="**sort** `lst -> list<'a>`\n\nReturns the list sorted in ascending order." },
     StdlibDescriptor { .userFacingName="reverse", .vmName="", .returnType=LT::Void, .params={}, .sharedImpl=nullptr,
         .description="reverse lst -> list<'a>",
         .detail="**reverse** `lst -> list<'a>`\n\nReturns the list in reverse order." },
-    StdlibDescriptor { .userFacingName="distinct", .vmName="list_distinct", .returnType=LT::Number, .params=listNumberParam, .sharedImpl=&builtins::listDistinct,
+    StdlibDescriptor { .userFacingName="distinct", .vmName="list_distinct", .returnType=LT::Number, .params=ListNumberParam, .sharedImpl=&builtins::listDistinct,
         .description="distinct lst -> list<'a>",
         .detail="**distinct** `lst -> list<'a>`\n\nRemoves duplicate elements from the list." },
     StdlibDescriptor { .userFacingName="sortBy", .vmName="", .returnType=LT::Void, .params={}, .sharedImpl=nullptr,
@@ -256,42 +256,42 @@ static const std::array descriptors = {
     // -----------------------------------------------------------------------
     // Formatting Helpers
     // -----------------------------------------------------------------------
-    StdlibDescriptor { .userFacingName="formatNumber", .vmName="format_number", .returnType=LT::String, .params=formatNumberTwoParams, .sharedImpl=&builtins::formatNumber,
+    StdlibDescriptor { .userFacingName="formatNumber", .vmName="format_number", .returnType=LT::String, .params=FormatNumberTwoParams, .sharedImpl=&builtins::formatNumber,
         .description="formatNumber sep n -> string  |  formatNumber n -> string (locale)",
         .detail="**formatNumber** `sep n -> string`\n\nFormats a number with thousands separator **sep**.\nAlso: `formatNumber n` uses locale default." },
-    StdlibDescriptor { .userFacingName="formatDateTime", .vmName="format_datetime", .returnType=LT::String, .params=epochNumberParam, .sharedImpl=&builtins::formatDatetime,
+    StdlibDescriptor { .userFacingName="formatDateTime", .vmName="format_datetime", .returnType=LT::String, .params=EpochNumberParam, .sharedImpl=&builtins::formatDatetime,
         .description="formatDateTime epoch -> string",
         .detail="**formatDateTime** `epoch -> string`\n\nFormats an epoch timestamp as a human-readable date/time." },
-    StdlibDescriptor { .userFacingName="formatMode", .vmName="format_mode", .returnType=LT::String, .params=modeNumberParam, .sharedImpl=&builtins::formatMode,
+    StdlibDescriptor { .userFacingName="formatMode", .vmName="format_mode", .returnType=LT::String, .params=ModeNumberParam, .sharedImpl=&builtins::formatMode,
         .description="formatMode mode -> string (rwxrwxrwx)",
         .detail="**formatMode** `mode -> string`\n\nFormats a file mode as `rwxrwxrwx` permission string." },
-    StdlibDescriptor { .userFacingName="toText", .vmName="list_to_string", .returnType=LT::String, .params=objNumberParam, .sharedImpl=&builtins::listToString,
+    StdlibDescriptor { .userFacingName="toText", .vmName="list_to_string", .returnType=LT::String, .params=ObjNumberParam, .sharedImpl=&builtins::listToString,
         .description="toText obj -> string",
         .detail="**toText** `obj -> string`\n\nConverts a structured object to a text representation." },
-    StdlibDescriptor { .userFacingName="string", .vmName="object_to_string", .returnType=LT::String, .params=objNumberParam, .sharedImpl=&builtins::objectToString,
+    StdlibDescriptor { .userFacingName="string", .vmName="object_to_string", .returnType=LT::String, .params=ObjNumberParam, .sharedImpl=&builtins::objectToString,
         .description="string x -> string",
         .detail="**string** `x -> string`\n\nConverts any value to its string representation." },
 
     // -----------------------------------------------------------------------
     // Permission Tests
     // -----------------------------------------------------------------------
-    StdlibDescriptor { .userFacingName="isReadable", .vmName="mode_isReadable", .returnType=LT::Boolean, .params=modeNumberParam, .sharedImpl=&builtins::modeIsReadable,
+    StdlibDescriptor { .userFacingName="isReadable", .vmName="mode_isReadable", .returnType=LT::Boolean, .params=ModeNumberParam, .sharedImpl=&builtins::modeIsReadable,
         .description="isReadable mode -> bool",
         .detail="**isReadable** `mode -> bool`\n\nReturns true if the file mode indicates read permission." },
-    StdlibDescriptor { .userFacingName="isWritable", .vmName="mode_isWritable", .returnType=LT::Boolean, .params=modeNumberParam, .sharedImpl=&builtins::modeIsWritable,
+    StdlibDescriptor { .userFacingName="isWritable", .vmName="mode_isWritable", .returnType=LT::Boolean, .params=ModeNumberParam, .sharedImpl=&builtins::modeIsWritable,
         .description="isWritable mode -> bool",
         .detail="**isWritable** `mode -> bool`\n\nReturns true if the file mode indicates write permission." },
-    StdlibDescriptor { .userFacingName="isExecutable", .vmName="mode_isExecutable", .returnType=LT::Boolean, .params=modeNumberParam, .sharedImpl=&builtins::modeIsExecutable,
+    StdlibDescriptor { .userFacingName="isExecutable", .vmName="mode_isExecutable", .returnType=LT::Boolean, .params=ModeNumberParam, .sharedImpl=&builtins::modeIsExecutable,
         .description="isExecutable mode -> bool",
         .detail="**isExecutable** `mode -> bool`\n\nReturns true if the file mode indicates execute permission." },
 
     // -----------------------------------------------------------------------
     // Environment/System (user-facing, Shell provides callbacks)
     // -----------------------------------------------------------------------
-    StdlibDescriptor { .userFacingName="env", .vmName="env.has", .returnType=LT::Boolean, .params=keyStringParam, .sharedImpl=nullptr,
+    StdlibDescriptor { .userFacingName="env", .vmName="env.has", .returnType=LT::Boolean, .params=KeyStringParam, .sharedImpl=nullptr,
         .description="env name -> option<string>",
         .detail="**env** `name -> option<string>`\n\nLooks up environment variable **name**. Returns `Some value` or `None`." },
-    StdlibDescriptor { .userFacingName="which", .vmName="which_find", .returnType=LT::Number, .params=programStringParam, .sharedImpl=nullptr,
+    StdlibDescriptor { .userFacingName="which", .vmName="which_find", .returnType=LT::Number, .params=ProgramStringParam, .sharedImpl=nullptr,
         .description="which name -> option<string>",
         .detail="**which** `name -> option<string>`\n\nFinds the full path of command **name** in `$PATH`." },
     StdlibDescriptor { .userFacingName="ps", .vmName="", .returnType=LT::Void, .params={}, .sharedImpl=nullptr,
@@ -303,12 +303,12 @@ static const std::array descriptors = {
     StdlibDescriptor { .userFacingName="rand", .vmName="rand", .returnType=LT::Number, .params={}, .sharedImpl=&builtins::randNoArgs,
         .description="rand -> int  |  rand min max -> int",
         .detail="**rand** `-> int`\n\nReturns a random integer.\nAlso: `rand min max` for a random integer in range." },
-    StdlibDescriptor { .userFacingName="fetch", .vmName="fetch", .returnType=LT::Number, .params=urlStringParam, .sharedImpl=nullptr,
+    StdlibDescriptor { .userFacingName="fetch", .vmName="fetch", .returnType=LT::Number, .params=UrlStringParam, .sharedImpl=nullptr,
         .description="fetch url -> result<string, string>",
         .detail="**fetch** `url -> result<string, string>`\n\nFetches content from **url**. Returns `Ok body` or `Error msg`." },
     // register_completer — kept for backward compatibility but no longer user-facing
     // (use Completion.register instead)
-    StdlibDescriptor { .userFacingName="", .vmName="", .returnType=LT::Void, .params=registerCompleterParams, .sharedImpl=nullptr,
+    StdlibDescriptor { .userFacingName="", .vmName="", .returnType=LT::Void, .params=RegisterCompleterParams, .sharedImpl=nullptr,
         .description="", .detail="" },
 
     // -----------------------------------------------------------------------
@@ -316,66 +316,66 @@ static const std::array descriptors = {
     // -----------------------------------------------------------------------
 
     // env.get — separate VM registration
-    StdlibDescriptor { .userFacingName="", .vmName="env.get", .returnType=LT::String, .params=keyStringParam, .sharedImpl=nullptr, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="env.get", .returnType=LT::String, .params=KeyStringParam, .sharedImpl=nullptr, .description="", .detail="" },
 
     // export — F#-style overloads
-    StdlibDescriptor { .userFacingName="", .vmName="export", .returnType=LT::Void, .params=exportTwoParams, .sharedImpl=nullptr, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="export", .returnType=LT::Void, .params=nameStringParam, .sharedImpl=nullptr, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="export", .returnType=LT::Void, .params=ExportTwoParams, .sharedImpl=nullptr, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="export", .returnType=LT::Void, .params=NameStringParam, .sharedImpl=nullptr, .description="", .detail="" },
 
     // display_result — Shell/REPL only
-    StdlibDescriptor { .userFacingName="", .vmName="display_result", .returnType=LT::Void, .params=valueNumberParam, .sharedImpl=nullptr, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="display_result", .returnType=LT::Void, .params=ValueNumberParam, .sharedImpl=nullptr, .description="", .detail="" },
 
     // Completion module constructors (accessed via Completion.entry/described/detailed)
-    StdlibDescriptor { .userFacingName="", .vmName="completer_register", .returnType=LT::Void, .params=registerCompleterParams,
+    StdlibDescriptor { .userFacingName="", .vmName="completer_register", .returnType=LT::Void, .params=RegisterCompleterParams,
         .sharedImpl=[](CoreVM::Params&){}, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="completion_entry", .returnType=LT::Number, .params=completionEntryParams, .sharedImpl=&builtins::completionEntry, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="completion_described", .returnType=LT::Number, .params=completionDescribedParams, .sharedImpl=&builtins::completionDescribed, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="completion_detailed", .returnType=LT::Number, .params=completionDetailedParams, .sharedImpl=&builtins::completionDetailed, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="completion_text", .returnType=LT::String, .params=objNumberParam, .sharedImpl=&builtins::completionText, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="completion_entry", .returnType=LT::Number, .params=CompletionEntryParams, .sharedImpl=&builtins::completionEntry, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="completion_described", .returnType=LT::Number, .params=CompletionDescribedParams, .sharedImpl=&builtins::completionDescribed, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="completion_detailed", .returnType=LT::Number, .params=CompletionDetailedParams, .sharedImpl=&builtins::completionDetailed, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="completion_text", .returnType=LT::String, .params=ObjNumberParam, .sharedImpl=&builtins::completionText, .description="", .detail="" },
 
     // Multi-arity overloads
-    StdlibDescriptor { .userFacingName="", .vmName="format_number", .returnType=LT::String, .params=formatNumberOneParams, .sharedImpl=&builtins::formatNumberWithLocale, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="rand", .returnType=LT::Number, .params=randRangeParams, .sharedImpl=&builtins::randRange, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="fetch", .returnType=LT::Number, .params=fetchTwoParams, .sharedImpl=nullptr, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="format_number", .returnType=LT::String, .params=FormatNumberOneParams, .sharedImpl=&builtins::formatNumberWithLocale, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="rand", .returnType=LT::Number, .params=RandRangeParams, .sharedImpl=&builtins::randRange, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="fetch", .returnType=LT::Number, .params=FetchTwoParams, .sharedImpl=nullptr, .description="", .detail="" },
 
     // Internal list operations
-    StdlibDescriptor { .userFacingName="", .vmName="list_concat", .returnType=LT::Number, .params=listConcatParams, .sharedImpl=&builtins::listConcat, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="list_sort_pairs", .returnType=LT::Number, .params=pairsNumberParam, .sharedImpl=&builtins::listSortPairs, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="list_group_pairs", .returnType=LT::Number, .params=pairsNumberParam, .sharedImpl=&builtins::listGroupPairs, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="list_char_range", .returnType=LT::Number, .params=listCharRangeParams, .sharedImpl=&builtins::listCharRange, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="list_range", .returnType=LT::Number, .params=listRangeParams, .sharedImpl=&builtins::listRange, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="list_concat", .returnType=LT::Number, .params=ListConcatParams, .sharedImpl=&builtins::listConcat, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="list_sort_pairs", .returnType=LT::Number, .params=PairsNumberParam, .sharedImpl=&builtins::listSortPairs, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="list_group_pairs", .returnType=LT::Number, .params=PairsNumberParam, .sharedImpl=&builtins::listGroupPairs, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="list_char_range", .returnType=LT::Number, .params=ListCharRangeParams, .sharedImpl=&builtins::listCharRange, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="list_range", .returnType=LT::Number, .params=ListRangeParams, .sharedImpl=&builtins::listRange, .description="", .detail="" },
 
     // Internal string operations
-    StdlibDescriptor { .userFacingName="", .vmName="string_repeat", .returnType=LT::String, .params=stringRepeatParams, .sharedImpl=&builtins::stringRepeat, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="string_repeat", .returnType=LT::String, .params=StringRepeatParams, .sharedImpl=&builtins::stringRepeat, .description="", .detail="" },
 
     // FileMode operations
-    StdlibDescriptor { .userFacingName="", .vmName="filemode_from_bits", .returnType=LT::Number, .params=nNumberParam, .sharedImpl=&builtins::fileModeFromBits, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="filemode_is_readable", .returnType=LT::Boolean, .params=objNumberParam, .sharedImpl=&builtins::fileModeIsReadable, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="filemode_is_writable", .returnType=LT::Boolean, .params=objNumberParam, .sharedImpl=&builtins::fileModeIsWritable, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="filemode_is_executable", .returnType=LT::Boolean, .params=objNumberParam, .sharedImpl=&builtins::fileModeIsExecutable, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="filemode_owner", .returnType=LT::Number, .params=objNumberParam, .sharedImpl=&builtins::fileModeOwner, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="filemode_group", .returnType=LT::Number, .params=objNumberParam, .sharedImpl=&builtins::fileModeGroup, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="filemode_other", .returnType=LT::Number, .params=objNumberParam, .sharedImpl=&builtins::fileModeOther, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="filemode_from_bits", .returnType=LT::Number, .params=NNumberParam, .sharedImpl=&builtins::fileModeFromBits, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="filemode_is_readable", .returnType=LT::Boolean, .params=ObjNumberParam, .sharedImpl=&builtins::fileModeIsReadable, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="filemode_is_writable", .returnType=LT::Boolean, .params=ObjNumberParam, .sharedImpl=&builtins::fileModeIsWritable, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="filemode_is_executable", .returnType=LT::Boolean, .params=ObjNumberParam, .sharedImpl=&builtins::fileModeIsExecutable, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="filemode_owner", .returnType=LT::Number, .params=ObjNumberParam, .sharedImpl=&builtins::fileModeOwner, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="filemode_group", .returnType=LT::Number, .params=ObjNumberParam, .sharedImpl=&builtins::fileModeGroup, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="filemode_other", .returnType=LT::Number, .params=ObjNumberParam, .sharedImpl=&builtins::fileModeOther, .description="", .detail="" },
 
     // TimeSpan operations
-    StdlibDescriptor { .userFacingName="", .vmName="timespan_from_ms", .returnType=LT::Number, .params=nNumberParam, .sharedImpl=&builtins::timespanFromMs, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="timespan_from_seconds", .returnType=LT::Number, .params=nNumberParam, .sharedImpl=&builtins::timespanFromSeconds, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="timespan_from_minutes", .returnType=LT::Number, .params=nNumberParam, .sharedImpl=&builtins::timespanFromMinutes, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="timespan_from_hours", .returnType=LT::Number, .params=nNumberParam, .sharedImpl=&builtins::timespanFromHours, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="timespan_from_days", .returnType=LT::Number, .params=nNumberParam, .sharedImpl=&builtins::timespanFromDays, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="sleep", .vmName="timespan_sleep", .returnType=LT::Number, .params=objNumberParam, .sharedImpl=&builtins::timespanSleep,
+    StdlibDescriptor { .userFacingName="", .vmName="timespan_from_ms", .returnType=LT::Number, .params=NNumberParam, .sharedImpl=&builtins::timespanFromMs, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="timespan_from_seconds", .returnType=LT::Number, .params=NNumberParam, .sharedImpl=&builtins::timespanFromSeconds, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="timespan_from_minutes", .returnType=LT::Number, .params=NNumberParam, .sharedImpl=&builtins::timespanFromMinutes, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="timespan_from_hours", .returnType=LT::Number, .params=NNumberParam, .sharedImpl=&builtins::timespanFromHours, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="timespan_from_days", .returnType=LT::Number, .params=NNumberParam, .sharedImpl=&builtins::timespanFromDays, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="sleep", .vmName="timespan_sleep", .returnType=LT::Number, .params=ObjNumberParam, .sharedImpl=&builtins::timespanSleep,
         .description="sleep ts -> unit",
         .detail="**sleep** `TimeSpan -> unit`\n\nPauses execution for the given TimeSpan duration." },
-    StdlibDescriptor { .userFacingName="formatTimeSpan", .vmName="format_timespan", .returnType=LT::String, .params=objNumberParam, .sharedImpl=&builtins::formatTimeSpan,
+    StdlibDescriptor { .userFacingName="formatTimeSpan", .vmName="format_timespan", .returnType=LT::String, .params=ObjNumberParam, .sharedImpl=&builtins::formatTimeSpan,
         .description="formatTimeSpan ts -> string",
         .detail="**formatTimeSpan** `TimeSpan -> string`\n\nFormats a TimeSpan as a human-readable duration string." },
 
     // Size operations
-    StdlibDescriptor { .userFacingName="", .vmName="size_from_bytes", .returnType=LT::Number, .params=nNumberParam, .sharedImpl=&builtins::sizeFromBytes, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="size_from_kb", .returnType=LT::Number, .params=nNumberParam, .sharedImpl=&builtins::sizeFromKB, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="size_from_mb", .returnType=LT::Number, .params=nNumberParam, .sharedImpl=&builtins::sizeFromMB, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="size_from_gb", .returnType=LT::Number, .params=nNumberParam, .sharedImpl=&builtins::sizeFromGB, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="size_from_tb", .returnType=LT::Number, .params=nNumberParam, .sharedImpl=&builtins::sizeFromTB, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="size_from_bytes", .returnType=LT::Number, .params=NNumberParam, .sharedImpl=&builtins::sizeFromBytes, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="size_from_kb", .returnType=LT::Number, .params=NNumberParam, .sharedImpl=&builtins::sizeFromKB, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="size_from_mb", .returnType=LT::Number, .params=NNumberParam, .sharedImpl=&builtins::sizeFromMB, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="size_from_gb", .returnType=LT::Number, .params=NNumberParam, .sharedImpl=&builtins::sizeFromGB, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="size_from_tb", .returnType=LT::Number, .params=NNumberParam, .sharedImpl=&builtins::sizeFromTB, .description="", .detail="" },
 
     // Timing
     StdlibDescriptor { .userFacingName="", .vmName="__monotonic_ms", .returnType=LT::Number, .params={}, .sharedImpl=&builtins::monotonicMs, .description="", .detail="" },
@@ -387,19 +387,19 @@ static const std::array descriptors = {
 
     // DateTime operations
     StdlibDescriptor { .userFacingName="", .vmName="datetime_now", .returnType=LT::Number, .params={}, .sharedImpl=&builtins::dateTimeNow, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="datetime_from_epoch", .returnType=LT::Number, .params=epochNumberParam, .sharedImpl=&builtins::dateTimeFromEpoch, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="datetime_from_epoch", .returnType=LT::Number, .params=EpochNumberParam, .sharedImpl=&builtins::dateTimeFromEpoch, .description="", .detail="" },
 
     // Markdown operations
-    StdlibDescriptor { .userFacingName="markdown", .vmName="markdown_create", .returnType=LT::Number, .params=textStringParam, .sharedImpl=&builtins::markdownCreate,
+    StdlibDescriptor { .userFacingName="markdown", .vmName="markdown_create", .returnType=LT::Number, .params=TextStringParam, .sharedImpl=&builtins::markdownCreate,
         .description="markdown text -> Markdown",
         .detail="**markdown** `text -> Markdown`\n\nCreates a Markdown object from a string." },
-    StdlibDescriptor { .userFacingName="", .vmName="markdown_to_html", .returnType=LT::String, .params=mdNumberParam, .sharedImpl=&builtins::markdownToHtml, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="markdown_to_text", .returnType=LT::String, .params=mdNumberParam, .sharedImpl=&builtins::markdownToText, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="markdown_content", .returnType=LT::String, .params=mdNumberParam, .sharedImpl=&builtins::markdownContent, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="markdown_render", .returnType=LT::Void, .params=mdNumberParam, .sharedImpl=nullptr, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="markdown_to_html", .returnType=LT::String, .params=MdNumberParam, .sharedImpl=&builtins::markdownToHtml, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="markdown_to_text", .returnType=LT::String, .params=MdNumberParam, .sharedImpl=&builtins::markdownToText, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="markdown_content", .returnType=LT::String, .params=MdNumberParam, .sharedImpl=&builtins::markdownContent, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="markdown_render", .returnType=LT::Void, .params=MdNumberParam, .sharedImpl=nullptr, .description="", .detail="" },
 
     // Json operations
-    StdlibDescriptor { .userFacingName="", .vmName="json_query", .returnType=LT::Number, .params=jsonQueryParams, .sharedImpl=&builtins::jsonQuery,
+    StdlibDescriptor { .userFacingName="", .vmName="json_query", .returnType=LT::Number, .params=JsonQueryParams, .sharedImpl=&builtins::jsonQuery,
         .description="Json.query path json -> list<string>",
         .detail="**Json.query** `path json -> list<string>`\n\n"
         "Extracts values from a JSON string using a dotted path.\n\n"
@@ -410,22 +410,22 @@ static const std::array descriptors = {
     StdlibDescriptor { .userFacingName="", .vmName="path_temporary_directory", .returnType=LT::String, .params={}, .sharedImpl=&builtins::pathTemporaryDirectory, .description="", .detail="" },
 
     // File I/O operations
-    StdlibDescriptor { .userFacingName="", .vmName="file_open", .returnType=LT::Number, .params=fileOpenParams, .sharedImpl=&builtins::fileOpen, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="file_close", .returnType=LT::Void, .params=fdNumberParam, .sharedImpl=&builtins::fileClose, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="file_read_line", .returnType=LT::Number, .params=fdNumberParam, .sharedImpl=&builtins::fileReadLine, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="file_read_all", .returnType=LT::Number, .params=pathStringParam, .sharedImpl=&builtins::fileReadAll, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="file_write_all", .returnType=LT::Number, .params=fileWriteParams, .sharedImpl=&builtins::fileWriteAll, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="file_append_all", .returnType=LT::Number, .params=fileWriteParams, .sharedImpl=&builtins::fileAppendAll, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="file_size", .returnType=LT::Number, .params=pathStringParam, .sharedImpl=&builtins::fileSize, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="file_exists", .returnType=LT::Boolean, .params=pathStringParam, .sharedImpl=&builtins::fileExists, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="file_delete", .returnType=LT::Number, .params=pathStringParam, .sharedImpl=&builtins::fileDelete, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="file_open", .returnType=LT::Number, .params=FileOpenParams, .sharedImpl=&builtins::fileOpen, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="file_close", .returnType=LT::Void, .params=FdNumberParam, .sharedImpl=&builtins::fileClose, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="file_read_line", .returnType=LT::Number, .params=FdNumberParam, .sharedImpl=&builtins::fileReadLine, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="file_read_all", .returnType=LT::Number, .params=PathStringParam, .sharedImpl=&builtins::fileReadAll, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="file_write_all", .returnType=LT::Number, .params=FileWriteParams, .sharedImpl=&builtins::fileWriteAll, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="file_append_all", .returnType=LT::Number, .params=FileWriteParams, .sharedImpl=&builtins::fileAppendAll, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="file_size", .returnType=LT::Number, .params=PathStringParam, .sharedImpl=&builtins::fileSize, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="file_exists", .returnType=LT::Boolean, .params=PathStringParam, .sharedImpl=&builtins::fileExists, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="file_delete", .returnType=LT::Number, .params=PathStringParam, .sharedImpl=&builtins::fileDelete, .description="", .detail="" },
 
     // Process signal operations
-    StdlibDescriptor { .userFacingName="", .vmName="process_kill", .returnType=LT::Number, .params=processPidParam, .sharedImpl=&builtins::processKill, .description="", .detail="" },
-    StdlibDescriptor { .userFacingName="", .vmName="process_signal", .returnType=LT::Number, .params=processSignalParams, .sharedImpl=&builtins::processSignal, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="process_kill", .returnType=LT::Number, .params=ProcessPidParam, .sharedImpl=&builtins::processKill, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="process_signal", .returnType=LT::Number, .params=ProcessSignalParams, .sharedImpl=&builtins::processSignal, .description="", .detail="" },
 
     // Ref cell write barrier
-    StdlibDescriptor { .userFacingName="", .vmName="ref_write_barrier", .returnType=LT::Void, .params=refObjParam, .sharedImpl=&builtins::refWriteBarrier, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="ref_write_barrier", .returnType=LT::Void, .params=RefObjParam, .sharedImpl=&builtins::refWriteBarrier, .description="", .detail="" },
 };
 // clang-format on
 

--- a/src/endo-language/codegen/IRGenerator.cpp
+++ b/src/endo-language/codegen/IRGenerator.cpp
@@ -10661,10 +10661,10 @@ void IRGenerator::visit(ast::FieldAccessExpr const& node)
         }
         if (modIdent->name == "File")
         {
-            static constexpr std::string_view fileMethods[] = {
+            static constexpr std::string_view FileMethods[] = {
                 "open", "close", "readLine", "readAll", "writeAll", "appendAll", "size", "exists", "delete",
             };
-            for (auto const& m: fileMethods)
+            for (auto const& m: FileMethods)
             {
                 if (node.fieldName == m)
                 {
@@ -10678,8 +10678,8 @@ void IRGenerator::visit(ast::FieldAccessExpr const& node)
         }
         if (modIdent->name == "Process")
         {
-            static constexpr std::string_view processMethods[] = { "kill", "signal" };
-            for (auto const& m: processMethods)
+            static constexpr std::string_view ProcessMethods[] = { "kill", "signal" };
+            for (auto const& m: ProcessMethods)
             {
                 if (node.fieldName == m)
                 {
@@ -10692,10 +10692,10 @@ void IRGenerator::visit(ast::FieldAccessExpr const& node)
         }
         if (modIdent->name == "Completion")
         {
-            static constexpr std::string_view completionMethods[] = {
+            static constexpr std::string_view CompletionMethods[] = {
                 "register", "entry", "described", "detailed", "text"
             };
-            for (auto const& m: completionMethods)
+            for (auto const& m: CompletionMethods)
             {
                 if (node.fieldName == m)
                 {

--- a/src/endo-language/format/SourceFormatter.cpp
+++ b/src/endo-language/format/SourceFormatter.cpp
@@ -361,8 +361,8 @@ namespace
 {
     /// Directive markers recognized in shell-style (`#`) comments to delimit verbatim regions.
     /// Data-driven so the spelling lives in one place rather than scattered string literals.
-    constexpr std::string_view formatOffDirective = "endo format off";
-    constexpr std::string_view formatOnDirective = "endo format on";
+    constexpr std::string_view FormatOffDirective = "endo format off";
+    constexpr std::string_view FormatOnDirective = "endo format on";
 
     /// Returns the comment body with the leading `#` / `//` marker and surrounding ASCII
     /// whitespace stripped, so it can be matched against a directive string.
@@ -390,13 +390,13 @@ std::vector<SourceFormatter::VerbatimRegion> SourceFormatter::collectVerbatimReg
     for (auto const& comment: comments)
     {
         auto const body = stripCommentMarker(comment.text);
-        if (body == formatOffDirective)
+        if (body == FormatOffDirective)
         {
             // Nested `off` is ignored: the first `off` wins until the next `on`.
             if (!openLine)
                 openLine = comment.location.begin.line;
         }
-        else if (body == formatOnDirective)
+        else if (body == FormatOnDirective)
         {
             if (openLine)
             {

--- a/src/endo-language/ide/DiagnosticsCollector.cpp
+++ b/src/endo-language/ide/DiagnosticsCollector.cpp
@@ -45,7 +45,7 @@ namespace
             return false;
 
 #if defined(_WIN32)
-        constexpr char pathSeparator = ';';
+        constexpr char PathSeparator = ';';
 #else
         constexpr char pathSeparator = ':';
 #endif
@@ -54,7 +54,7 @@ namespace
         size_t start = 0;
         while (start < pathStr.size())
         {
-            auto const end = pathStr.find(pathSeparator, start);
+            auto const end = pathStr.find(PathSeparator, start);
             auto const dir = pathStr.substr(start, end == std::string_view::npos ? end : end - start);
 
             if (!dir.empty())
@@ -63,8 +63,8 @@ namespace
                 // On Windows, check the bare name and common executable extensions.
                 // Windows does not have Unix-style execute permission bits, so
                 // file existence with a known extension is sufficient.
-                static constexpr std::string_view extensions[] = { "", ".exe", ".cmd", ".bat" };
-                for (auto const ext: extensions)
+                static constexpr std::string_view Extensions[] = { "", ".exe", ".cmd", ".bat" };
+                for (auto const ext: Extensions)
                 {
                     auto const candidate = std::filesystem::path(dir) / std::string(program).append(ext);
                     std::error_code ec;
@@ -249,9 +249,9 @@ std::vector<DiagnosticMessage> collectDiagnostics(std::string const& source,
                 continue;
 
             // Suppress "Undefined variable" false positives for names persisted from prior REPL prompts
-            if (auto constexpr prefix = std::string_view("Undefined variable: ");
-                msg.text.starts_with(prefix)
-                && knownNames.contains(std::string(msg.text.substr(prefix.size()))))
+            if (auto constexpr Prefix = std::string_view("Undefined variable: ");
+                msg.text.starts_with(Prefix)
+                && knownNames.contains(std::string(msg.text.substr(Prefix.size()))))
                 continue;
 
             auto severity = DiagnosticSeverity::Error;

--- a/src/endo-language/ide/DiagnosticsCollector.cpp
+++ b/src/endo-language/ide/DiagnosticsCollector.cpp
@@ -47,7 +47,7 @@ namespace
 #if defined(_WIN32)
         constexpr char PathSeparator = ';';
 #else
-        constexpr char pathSeparator = ':';
+        constexpr char PathSeparator = ':';
 #endif
 
         auto const pathStr = std::string_view(pathEnv);

--- a/src/endo-language/parser/Parser.cpp
+++ b/src/endo-language/parser/Parser.cpp
@@ -2727,7 +2727,7 @@ namespace
     /// Single source of truth for directive builtin overloads. One row per
     /// runtime-registered (name, signature) pair. Resolution: see
     /// Parser::tryConvertToDirectiveBuiltin.
-    inline constexpr std::array<DirectiveOverload, 20> kDirectiveOverloads { {
+    inline constexpr std::array<DirectiveOverload, 20> DirectiveOverloads { {
         { .name = "cd", .arity = 0, .variadic = false, .signature = "cd()B", .build = &buildCd },
         { .name = "cd", .arity = 1, .variadic = false, .signature = "cd(S)B", .build = &buildCd },
         { .name = "exit", .arity = 0, .variadic = false, .signature = "exit(I)V", .build = &buildExit },
@@ -2753,7 +2753,7 @@ namespace
     /// Returns the subrange of overloads matching the given builtin name.
     [[nodiscard]] auto overloadsFor(std::string_view name)
     {
-        return kDirectiveOverloads
+        return DirectiveOverloads
                | std::views::filter([name](DirectiveOverload const& o) { return o.name == name; });
     }
 

--- a/src/endo-test/TestExecutor.cpp
+++ b/src/endo-test/TestExecutor.cpp
@@ -173,11 +173,11 @@ namespace
     [[nodiscard]] std::optional<std::string> evaluateExpectExpr(std::string_view expr,
                                                                 std::string_view actualOutput)
     {
-        constexpr std::string_view outputVar = "__endoTestActual";
+        constexpr std::string_view OutputVar = "__endoTestActual";
         auto const trimmedOutput = rtrimNewlines(actualOutput);
         auto const escaped = escapeForEndoString(trimmedOutput);
-        auto const rewritten = rewriteUnderscoreTokens(expr, outputVar);
-        auto const program = std::format("let {} = \"{}\"\nprint ({})", outputVar, escaped, rewritten);
+        auto const rewritten = rewriteUnderscoreTokens(expr, OutputVar);
+        auto const program = std::format("let {} = \"{}\"\nprint ({})", OutputVar, escaped, rewritten);
 
         TestExecutionSuccess evalExec;
         try

--- a/src/endo-test/TestReporter.cpp
+++ b/src/endo-test/TestReporter.cpp
@@ -22,12 +22,12 @@ namespace
     }
 
     // ANSI color codes
-    constexpr auto kReset = "\033[0m";
-    constexpr auto kGreen = "\033[32m";
-    constexpr auto kRed = "\033[31m";
-    constexpr auto kYellow = "\033[33m";
-    constexpr auto kBold = "\033[1m";
-    constexpr auto kDim = "\033[2m";
+    constexpr auto Reset = "\033[0m";
+    constexpr auto Green = "\033[32m";
+    constexpr auto Red = "\033[31m";
+    constexpr auto Yellow = "\033[33m";
+    constexpr auto Bold = "\033[1m";
+    constexpr auto Dim = "\033[2m";
 
 } // namespace
 
@@ -69,24 +69,24 @@ void TestReporter::reportPrettyResult(TestResult const& result) const
     {
         case TestOutcome::Pass:
             std::cout << std::format(
-                "  {}PASS{}  {} {}{}{}\n", kGreen, kReset, relPath, kDim, "(" + durationStr + ")", kReset);
+                "  {}PASS{}  {} {}{}{}\n", Green, Reset, relPath, Dim, "(" + durationStr + ")", Reset);
             if (_verbose && !result.actualOutput.empty())
                 std::cout << std::format("        Output: \"{}\"\n", result.actualOutput);
             break;
 
         case TestOutcome::Fail:
             std::cout << std::format(
-                "  {}FAIL{}  {} {}{}{}\n", kRed, kReset, relPath, kDim, "(" + durationStr + ")", kReset);
+                "  {}FAIL{}  {} {}{}{}\n", Red, Reset, relPath, Dim, "(" + durationStr + ")", Reset);
             if (!result.failureMessage.empty())
                 std::cout << std::format("        {}\n", result.failureMessage);
             break;
 
         case TestOutcome::Skip:
-            std::cout << std::format("  {}SKIP{}  {}", kYellow, kReset, relPath);
+            std::cout << std::format("  {}SKIP{}  {}", Yellow, Reset, relPath);
             if (result.testFile->skipReason.has_value())
-                std::cout << std::format(" {}{}{}", kDim, "(", kReset)
+                std::cout << std::format(" {}{}{}", Dim, "(", Reset)
                           << std::format("{}", *result.testFile->skipReason)
-                          << std::format("{}{}{}", kDim, ")", kReset);
+                          << std::format("{}{}{}", Dim, ")", Reset);
             std::cout << '\n';
             break;
     }
@@ -133,21 +133,21 @@ void TestReporter::reportPrettySummary(std::vector<TestResult> const& results,
 
     if (failed > 0)
         std::cout << std::format("{}Results:{} {}{} passed{}, {}{} failed{}",
-                                 kBold,
-                                 kReset,
-                                 kGreen,
+                                 Bold,
+                                 Reset,
+                                 Green,
                                  passed,
-                                 kReset,
-                                 kRed,
+                                 Reset,
+                                 Red,
                                  failed,
-                                 kReset);
+                                 Reset);
     else
-        std::cout << std::format("{}Results:{} {}{} passed{}", kBold, kReset, kGreen, passed, kReset);
+        std::cout << std::format("{}Results:{} {}{} passed{}", Bold, Reset, Green, passed, Reset);
 
     if (skipped > 0)
-        std::cout << std::format(", {}{} skipped{}", kYellow, skipped, kReset);
+        std::cout << std::format(", {}{} skipped{}", Yellow, skipped, Reset);
 
-    std::cout << std::format(" {}{}{}\n", kDim, "(" + formatDuration(totalDuration) + ")", kReset);
+    std::cout << std::format(" {}{}{}\n", Dim, "(" + formatDuration(totalDuration) + ")", Reset);
 }
 
 void TestReporter::reportTAPSummary(std::vector<TestResult> const& results,

--- a/src/lsp/OnTypeFormattingProvider.cpp
+++ b/src/lsp/OnTypeFormattingProvider.cpp
@@ -32,8 +32,8 @@ namespace
     /// Checks if a line ends with a block-opening construct.
     [[nodiscard]] bool endsWithBlockOpener(std::string const& trimmedLine)
     {
-        static constexpr std::string_view openers[] = { "=", "->", "then", "do", "with" };
-        for (auto const opener: openers)
+        static constexpr std::string_view Openers[] = { "=", "->", "then", "do", "with" };
+        for (auto const opener: Openers)
         {
             if (trimmedLine.ends_with(opener))
             {

--- a/src/platform/SignalHandler.cpp
+++ b/src/platform/SignalHandler.cpp
@@ -332,9 +332,9 @@ bool SignalHandler::isInterruptCtrlEvent(unsigned long ctrlType) noexcept
 #else
     // Mirror the Win32 CTRL_C_EVENT (0) and CTRL_BREAK_EVENT (1) values so the
     // interrupt policy can be unit-tested on any platform.
-    constexpr unsigned long kCtrlCEvent = 0;
-    constexpr unsigned long kCtrlBreakEvent = 1;
-    return ctrlType == kCtrlCEvent || ctrlType == kCtrlBreakEvent;
+    constexpr unsigned long CtrlCEvent = 0;
+    constexpr unsigned long CtrlBreakEvent = 1;
+    return ctrlType == CtrlCEvent || ctrlType == CtrlBreakEvent;
 #endif
 }
 

--- a/src/platform/linux/ProcStatusParser.hpp
+++ b/src/platform/linux/ProcStatusParser.hpp
@@ -14,10 +14,10 @@ namespace endo::platform
 /// Returns the first (real) UID, or std::nullopt on parse failure.
 inline std::optional<int> parseUidFromStatusLine(std::string_view line)
 {
-    constexpr auto prefix = std::string_view("Uid:");
-    if (!line.starts_with(prefix))
+    constexpr auto Prefix = std::string_view("Uid:");
+    if (!line.starts_with(Prefix))
         return std::nullopt;
-    line.remove_prefix(prefix.size());
+    line.remove_prefix(Prefix.size());
     while (!line.empty() && (line.front() == '\t' || line.front() == ' '))
         line.remove_prefix(1);
     if (line.empty())
@@ -32,10 +32,10 @@ inline std::optional<int> parseUidFromStatusLine(std::string_view line)
 /// Returns the memory value in kilobytes, or std::nullopt on parse failure.
 inline std::optional<int64_t> parseVmRssFromStatusLine(std::string_view line)
 {
-    constexpr auto prefix = std::string_view("VmRSS:");
-    if (!line.starts_with(prefix))
+    constexpr auto Prefix = std::string_view("VmRSS:");
+    if (!line.starts_with(Prefix))
         return std::nullopt;
-    line.remove_prefix(prefix.size());
+    line.remove_prefix(Prefix.size());
     while (!line.empty() && (line.front() == '\t' || line.front() == ' '))
         line.remove_prefix(1);
     if (line.empty())

--- a/src/shell/HelpPrinter.cpp
+++ b/src/shell/HelpPrinter.cpp
@@ -82,9 +82,9 @@ class HelpBuilder
         }
 
         // Pad to alignment column (26 chars from left margin)
-        constexpr int alignCol = 26;
+        constexpr int AlignCol = 26;
         auto const flagsLen = static_cast<int>(flags.size());
-        auto const padding = (flagsLen < alignCol) ? (alignCol - flagsLen) : 2;
+        auto const padding = (flagsLen < AlignCol) ? (AlignCol - flagsLen) : 2;
         _out.append(static_cast<size_t>(padding), ' ');
 
         _out += desc;
@@ -107,9 +107,9 @@ class HelpBuilder
             _out += name;
         }
 
-        constexpr int alignCol = 26;
+        constexpr int AlignCol = 26;
         auto const nameLen = static_cast<int>(name.size());
-        auto const padding = (nameLen < alignCol) ? (alignCol - nameLen) : 2;
+        auto const padding = (nameLen < AlignCol) ? (AlignCol - nameLen) : 2;
         _out.append(static_cast<size_t>(padding), ' ');
 
         _out += desc;

--- a/src/shell/builtins/InlineArgParser_test.cpp
+++ b/src/shell/builtins/InlineArgParser_test.cpp
@@ -22,20 +22,20 @@ CoreVM::CoreStringArray makeArgs(std::initializer_list<std::string_view> items)
 }
 
 // Empty option set
-std::span<InlineOptionDef const> const kNoOptions {};
+std::span<InlineOptionDef const> const NoOptions {};
 
-constexpr InlineOptionDef kSimpleBoolOptions[] = {
+constexpr InlineOptionDef SimpleBoolOptions[] = {
     { .shortFlag = "-r", .longFlag = "--recursive", .description = "Recurse" },
     { .shortFlag = "-v", .longFlag = "--verbose", .description = "Verbose" },
     { .shortFlag = "-f", .longFlag = "--force", .description = "Force" },
 };
 
-constexpr InlineOptionDef kValueOptions[] = {
+constexpr InlineOptionDef ValueOptions[] = {
     { .shortFlag = "-n", .longFlag = {}, .description = "Number of lines", .takesValue = true },
     { .shortFlag = "-d", .longFlag = "--delimiter", .description = "Delimiter", .takesValue = true },
 };
 
-constexpr InlineOptionDef kMixedOptions[] = {
+constexpr InlineOptionDef MixedOptions[] = {
     { .shortFlag = "-r", .longFlag = {}, .description = "Reverse" },
     { .shortFlag = "-n", .longFlag = {}, .description = "Numeric" },
     { .shortFlag = "-k", .longFlag = {}, .description = "Key field", .takesValue = true },
@@ -50,7 +50,7 @@ constexpr InlineOptionDef kMixedOptions[] = {
 TEST_CASE("InlineArgParser.empty_args", "[argparser]")
 {
     auto const args = makeArgs({ "cmd" });
-    auto const result = parseInlineArgs(args, kNoOptions);
+    auto const result = parseInlineArgs(args, NoOptions);
     CHECK_FALSE(result.helpRequested);
     CHECK(result.flags.empty());
     CHECK(result.positionalArgs.empty());
@@ -59,7 +59,7 @@ TEST_CASE("InlineArgParser.empty_args", "[argparser]")
 TEST_CASE("InlineArgParser.positional_only", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "file1.txt", "file2.txt" });
-    auto const result = parseInlineArgs(args, kNoOptions);
+    auto const result = parseInlineArgs(args, NoOptions);
     CHECK_FALSE(result.helpRequested);
     REQUIRE(result.positionalArgs.size() == 2);
     CHECK(result.positionalArgs[0] == "file1.txt");
@@ -69,7 +69,7 @@ TEST_CASE("InlineArgParser.positional_only", "[argparser]")
 TEST_CASE("InlineArgParser.skips_arg0", "[argparser]")
 {
     auto const args = makeArgs({ "head", "-n", "5" });
-    auto const result = parseInlineArgs(args, kValueOptions);
+    auto const result = parseInlineArgs(args, ValueOptions);
     CHECK_FALSE(result.helpRequested);
     // "head" (arg0) should be skipped
     CHECK(result.positionalArgs.empty());
@@ -85,21 +85,21 @@ TEST_CASE("InlineArgParser.skips_arg0", "[argparser]")
 TEST_CASE("InlineArgParser.help_short", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-h" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.helpRequested);
 }
 
 TEST_CASE("InlineArgParser.help_long", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "--help" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.helpRequested);
 }
 
 TEST_CASE("InlineArgParser.help_stops_parsing", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-r", "--help", "-v" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.helpRequested);
     // -r before --help should be parsed, -v after should not
     CHECK(result.flags.size() == 1);
@@ -108,7 +108,7 @@ TEST_CASE("InlineArgParser.help_stops_parsing", "[argparser]")
 TEST_CASE("InlineArgParser.help_always_recognized_even_without_options", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-h" });
-    auto const result = parseInlineArgs(args, kNoOptions);
+    auto const result = parseInlineArgs(args, NoOptions);
     CHECK(result.helpRequested);
 }
 
@@ -119,7 +119,7 @@ TEST_CASE("InlineArgParser.help_always_recognized_even_without_options", "[argpa
 TEST_CASE("InlineArgParser.single_short_flag", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-r" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.hasFlag("-r"));
     CHECK_FALSE(result.hasFlag("-v"));
 }
@@ -127,7 +127,7 @@ TEST_CASE("InlineArgParser.single_short_flag", "[argparser]")
 TEST_CASE("InlineArgParser.multiple_separate_short_flags", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-r", "-v" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.hasFlag("-r"));
     CHECK(result.hasFlag("-v"));
     CHECK_FALSE(result.hasFlag("-f"));
@@ -136,7 +136,7 @@ TEST_CASE("InlineArgParser.multiple_separate_short_flags", "[argparser]")
 TEST_CASE("InlineArgParser.combined_short_flags", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-rfv" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.hasFlag("-r"));
     CHECK(result.hasFlag("-f"));
     CHECK(result.hasFlag("-v"));
@@ -146,7 +146,7 @@ TEST_CASE("InlineArgParser.combined_short_flags", "[argparser]")
 TEST_CASE("InlineArgParser.unknown_short_flag_becomes_positional", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-x" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.flags.empty());
     REQUIRE(result.positionalArgs.size() == 1);
     CHECK(result.positionalArgs[0] == "-x");
@@ -155,7 +155,7 @@ TEST_CASE("InlineArgParser.unknown_short_flag_becomes_positional", "[argparser]"
 TEST_CASE("InlineArgParser.combined_with_unknown_becomes_positional", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-rx" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     // -r is valid but -x is not — entire -rx becomes positional, no flags recorded
     CHECK(result.flags.empty());
     REQUIRE(result.positionalArgs.size() == 1);
@@ -169,7 +169,7 @@ TEST_CASE("InlineArgParser.combined_with_unknown_becomes_positional", "[argparse
 TEST_CASE("InlineArgParser.long_flag", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "--recursive" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     // Canonical flag is the short form
     CHECK(result.hasFlag("-r"));
 }
@@ -177,7 +177,7 @@ TEST_CASE("InlineArgParser.long_flag", "[argparser]")
 TEST_CASE("InlineArgParser.unknown_long_flag_becomes_positional", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "--unknown" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.flags.empty());
     REQUIRE(result.positionalArgs.size() == 1);
     CHECK(result.positionalArgs[0] == "--unknown");
@@ -190,7 +190,7 @@ TEST_CASE("InlineArgParser.unknown_long_flag_becomes_positional", "[argparser]")
 TEST_CASE("InlineArgParser.short_value_separate_arg", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-n", "10" });
-    auto const result = parseInlineArgs(args, kValueOptions);
+    auto const result = parseInlineArgs(args, ValueOptions);
     auto const val = result.getFlagValue("-n");
     REQUIRE(val.has_value());
     CHECK(*val == "10");
@@ -200,7 +200,7 @@ TEST_CASE("InlineArgParser.short_value_attached", "[argparser]")
 {
     // -n10 (value attached to flag in combined form)
     auto const args = makeArgs({ "cmd", "-n10" });
-    auto const result = parseInlineArgs(args, kValueOptions);
+    auto const result = parseInlineArgs(args, ValueOptions);
     auto const val = result.getFlagValue("-n");
     REQUIRE(val.has_value());
     CHECK(*val == "10");
@@ -209,7 +209,7 @@ TEST_CASE("InlineArgParser.short_value_attached", "[argparser]")
 TEST_CASE("InlineArgParser.long_value_equals", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "--delimiter=:" });
-    auto const result = parseInlineArgs(args, kValueOptions);
+    auto const result = parseInlineArgs(args, ValueOptions);
     auto const val = result.getFlagValue("-d");
     REQUIRE(val.has_value());
     CHECK(*val == ":");
@@ -218,7 +218,7 @@ TEST_CASE("InlineArgParser.long_value_equals", "[argparser]")
 TEST_CASE("InlineArgParser.long_value_separate_arg", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "--delimiter", ":" });
-    auto const result = parseInlineArgs(args, kValueOptions);
+    auto const result = parseInlineArgs(args, ValueOptions);
     auto const val = result.getFlagValue("-d");
     REQUIRE(val.has_value());
     CHECK(*val == ":");
@@ -227,7 +227,7 @@ TEST_CASE("InlineArgParser.long_value_separate_arg", "[argparser]")
 TEST_CASE("InlineArgParser.getFlagValue_missing_returns_nullopt", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "file.txt" });
-    auto const result = parseInlineArgs(args, kValueOptions);
+    auto const result = parseInlineArgs(args, ValueOptions);
     CHECK_FALSE(result.getFlagValue("-n").has_value());
 }
 
@@ -239,7 +239,7 @@ TEST_CASE("InlineArgParser.combined_bool_then_value", "[argparser]")
 {
     // -rk 2 — -r is boolean, -k takes value "2"
     auto const args = makeArgs({ "cmd", "-rk", "2" });
-    auto const result = parseInlineArgs(args, kMixedOptions);
+    auto const result = parseInlineArgs(args, MixedOptions);
     CHECK(result.hasFlag("-r"));
     auto const val = result.getFlagValue("-k");
     REQUIRE(val.has_value());
@@ -250,7 +250,7 @@ TEST_CASE("InlineArgParser.combined_value_takes_rest", "[argparser]")
 {
     // -rnk2 — -r bool, -n bool, -k takes "2" (rest of string)
     auto const args = makeArgs({ "cmd", "-rnk2" });
-    auto const result = parseInlineArgs(args, kMixedOptions);
+    auto const result = parseInlineArgs(args, MixedOptions);
     CHECK(result.hasFlag("-r"));
     CHECK(result.hasFlag("-n"));
     auto const val = result.getFlagValue("-k");
@@ -265,7 +265,7 @@ TEST_CASE("InlineArgParser.combined_value_takes_rest", "[argparser]")
 TEST_CASE("InlineArgParser.end_of_options", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "--", "-r", "--verbose" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.flags.empty());
     REQUIRE(result.positionalArgs.size() == 2);
     CHECK(result.positionalArgs[0] == "-r");
@@ -275,7 +275,7 @@ TEST_CASE("InlineArgParser.end_of_options", "[argparser]")
 TEST_CASE("InlineArgParser.flags_before_end_of_options", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-r", "--", "-v" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.hasFlag("-r"));
     CHECK_FALSE(result.hasFlag("-v"));
     REQUIRE(result.positionalArgs.size() == 1);
@@ -285,7 +285,7 @@ TEST_CASE("InlineArgParser.flags_before_end_of_options", "[argparser]")
 TEST_CASE("InlineArgParser.help_after_end_of_options_is_positional", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "--", "--help" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK_FALSE(result.helpRequested);
     REQUIRE(result.positionalArgs.size() == 1);
     CHECK(result.positionalArgs[0] == "--help");
@@ -298,7 +298,7 @@ TEST_CASE("InlineArgParser.help_after_end_of_options_is_positional", "[argparser
 TEST_CASE("InlineArgParser.flags_and_positionals_interleaved", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-r", "file1.txt", "-v", "file2.txt" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.hasFlag("-r"));
     CHECK(result.hasFlag("-v"));
     REQUIRE(result.positionalArgs.size() == 2);
@@ -313,7 +313,7 @@ TEST_CASE("InlineArgParser.flags_and_positionals_interleaved", "[argparser]")
 TEST_CASE("InlineArgParser.hasFlag_false_when_not_present", "[argparser]")
 {
     auto const args = makeArgs({ "cmd", "-r" });
-    auto const result = parseInlineArgs(args, kSimpleBoolOptions);
+    auto const result = parseInlineArgs(args, SimpleBoolOptions);
     CHECK(result.hasFlag("-r"));
     CHECK_FALSE(result.hasFlag("-v"));
     CHECK_FALSE(result.hasFlag("-f"));
@@ -323,7 +323,7 @@ TEST_CASE("InlineArgParser.getFlagValue_returns_last_occurrence", "[argparser]")
 {
     // If -n is given multiple times, getFlagValue returns the first occurrence
     auto const args = makeArgs({ "cmd", "-n", "5", "-n", "10" });
-    auto const result = parseInlineArgs(args, kValueOptions);
+    auto const result = parseInlineArgs(args, ValueOptions);
     auto const val = result.getFlagValue("-n");
     REQUIRE(val.has_value());
     CHECK(*val == "5"); // first occurrence
@@ -339,7 +339,7 @@ TEST_CASE("InlineArgParser.generateHelp_includes_title", "[argparser]")
         .name = "head",
         .briefDescription = "Output the first lines of files.",
         .usageLine = "head [OPTIONS] [FILE...]",
-        .options = kValueOptions,
+        .options = ValueOptions,
     };
     auto const help = generateInlineHelp(desc);
     CHECK(help.find("# head") != std::string::npos);
@@ -351,7 +351,7 @@ TEST_CASE("InlineArgParser.generateHelp_includes_description", "[argparser]")
         .name = "head",
         .briefDescription = "Output the first lines of files.",
         .usageLine = "head [OPTIONS] [FILE...]",
-        .options = kValueOptions,
+        .options = ValueOptions,
     };
     auto const help = generateInlineHelp(desc);
     CHECK(help.find("Output the first lines") != std::string::npos);
@@ -363,7 +363,7 @@ TEST_CASE("InlineArgParser.generateHelp_includes_usage", "[argparser]")
         .name = "head",
         .briefDescription = "Output the first lines of files.",
         .usageLine = "head [OPTIONS] [FILE...]",
-        .options = kValueOptions,
+        .options = ValueOptions,
     };
     auto const help = generateInlineHelp(desc);
     CHECK(help.find("`head [OPTIONS] [FILE...]`") != std::string::npos);
@@ -375,7 +375,7 @@ TEST_CASE("InlineArgParser.generateHelp_includes_options_table", "[argparser]")
         .name = "head",
         .briefDescription = "Output the first lines of files.",
         .usageLine = "head [OPTIONS] [FILE...]",
-        .options = kValueOptions,
+        .options = ValueOptions,
     };
     auto const help = generateInlineHelp(desc);
     CHECK(help.find("## Options") != std::string::npos);
@@ -400,14 +400,14 @@ TEST_CASE("InlineArgParser.generateHelp_always_includes_help_option", "[argparse
 
 TEST_CASE("InlineArgParser.generateHelp_with_options_includes_help_row", "[argparser]")
 {
-    constexpr InlineOptionDef opts[] = {
+    constexpr InlineOptionDef Opts[] = {
         { .shortFlag = "-r", .longFlag = {}, .description = "Reverse" },
     };
     InlineCommandDescriptor desc {
         .name = "sort",
         .briefDescription = "Sort lines.",
         .usageLine = "sort [OPTIONS] [FILE...]",
-        .options = opts,
+        .options = Opts,
     };
     auto const help = generateInlineHelp(desc);
     CHECK(help.find("## Options") != std::string::npos);

--- a/src/shell/builtins/InlineCommandDescriptors.cpp
+++ b/src/shell/builtins/InlineCommandDescriptors.cpp
@@ -14,12 +14,12 @@ namespace endo
 
 // clang-format off
 
-static constexpr InlineOptionDef kEchoOptions[] = {
+static constexpr InlineOptionDef EchoOptions[] = {
     { .shortFlag = "-n", .longFlag = {},    .description = "Do not output the trailing newline" },
     { .shortFlag = "-e", .longFlag = {},    .description = "Enable interpretation of backslash escapes" },
 };
 
-static constexpr InlineOptionDef kRmOptions[] = {
+static constexpr InlineOptionDef RmOptions[] = {
     { .shortFlag = "-r", .longFlag = "--recursive", .description = "Remove directories and their contents recursively" },
     { .shortFlag = "-f", .longFlag = "--force",     .description = "Ignore nonexistent files, never prompt" },
     { .shortFlag = "-i", .longFlag = {},            .description = "Prompt before every removal" },
@@ -27,26 +27,26 @@ static constexpr InlineOptionDef kRmOptions[] = {
     { .shortFlag = "-v", .longFlag = "--verbose",   .description = "Explain what is being done" },
 };
 
-static constexpr InlineOptionDef kMkdirOptions[] = {
+static constexpr InlineOptionDef MkdirOptions[] = {
     { .shortFlag = "-p", .longFlag = "--parents", .description = "Create parent directories as needed" },
     { .shortFlag = "-v", .longFlag = "--verbose", .description = "Print a message for each created directory" },
 };
 
-static constexpr InlineOptionDef kCpOptions[] = {
+static constexpr InlineOptionDef CpOptions[] = {
     { .shortFlag = "-r", .longFlag = "--recursive",  .description = "Copy directories recursively" },
     { .shortFlag = "-f", .longFlag = "--force",      .description = "Force overwrite" },
     { .shortFlag = "-n", .longFlag = "--no-clobber", .description = "Do not overwrite existing files" },
     { .shortFlag = "-v", .longFlag = "--verbose",    .description = "Explain what is being done" },
 };
 
-static constexpr InlineOptionDef kMvOptions[] = {
+static constexpr InlineOptionDef MvOptions[] = {
     { .shortFlag = "-f", .longFlag = "--force",       .description = "Do not prompt before overwriting" },
     { .shortFlag = "-n", .longFlag = "--no-clobber",  .description = "Do not overwrite existing files" },
     { .shortFlag = "-v", .longFlag = "--verbose",     .description = "Explain what is being done" },
     { .shortFlag = "-i", .longFlag = "--interactive", .description = "Prompt before overwrite" },
 };
 
-static constexpr InlineOptionDef calOptions[] = {
+static constexpr InlineOptionDef CalOptions[] = {
     { .shortFlag = "-3", .longFlag = "--three",    .description = "Show previous, current, and next month" },
     { .shortFlag = "-y", .longFlag = "--year",     .description = "Show the entire year" },
     { .shortFlag = "-m", .longFlag = "--monday",   .description = "Start the week on Monday (ISO 8601)" },
@@ -54,7 +54,7 @@ static constexpr InlineOptionDef calOptions[] = {
     { .shortFlag = "-n", .longFlag = "--no-color", .description = "Disable colorized output even on a terminal" },
 };
 
-static constexpr InlineOptionDef kDateOptions[] = {
+static constexpr InlineOptionDef DateOptions[] = {
     { .shortFlag = "-u", .longFlag = "--utc",    .description = "Use UTC instead of local time" },
     { .shortFlag = {},   .longFlag = "--epoch",  .description = "Print seconds since Unix epoch" },
     { .shortFlag = {},   .longFlag = "--iso",    .description = "Print in ISO 8601 format" },
@@ -62,7 +62,7 @@ static constexpr InlineOptionDef kDateOptions[] = {
     { .shortFlag = "-d", .longFlag = "--date",   .description = "Display given date instead of now", .takesValue = true },
 };
 
-static constexpr InlineOptionDef kUnameOptions[] = {
+static constexpr InlineOptionDef UnameOptions[] = {
     { .shortFlag = "-s", .longFlag = {}, .description = "Print kernel name" },
     { .shortFlag = "-n", .longFlag = {}, .description = "Print network node hostname" },
     { .shortFlag = "-r", .longFlag = {}, .description = "Print kernel release" },
@@ -70,70 +70,70 @@ static constexpr InlineOptionDef kUnameOptions[] = {
     { .shortFlag = "-a", .longFlag = {}, .description = "Print all information" },
 };
 
-static constexpr InlineOptionDef kNprocOptions[] = {
+static constexpr InlineOptionDef NprocOptions[] = {
     { .shortFlag = {}, .longFlag = "--all",    .description = "Print the number of installed processors" },
     { .shortFlag = {}, .longFlag = "--ignore", .description = "Exclude N processing units", .takesValue = true },
 };
 
-static constexpr InlineOptionDef kTouchOptions[] = {
+static constexpr InlineOptionDef TouchOptions[] = {
     { .shortFlag = "-c", .longFlag = "--no-create", .description = "Do not create files" },
 };
 
-static constexpr InlineOptionDef kLnOptions[] = {
+static constexpr InlineOptionDef LnOptions[] = {
     { .shortFlag = "-s", .longFlag = {}, .description = "Create symbolic link" },
     { .shortFlag = "-f", .longFlag = {}, .description = "Remove existing destination files" },
     { .shortFlag = "-v", .longFlag = {}, .description = "Explain what is being done" },
 };
 
-static constexpr InlineOptionDef kMktempOptions[] = {
+static constexpr InlineOptionDef MktempOptions[] = {
     { .shortFlag = "-d", .longFlag = {}, .description = "Create a directory instead of a file" },
     { .shortFlag = "-p", .longFlag = {}, .description = "Use DIR as the base directory", .takesValue = true },
 };
 
-static constexpr InlineOptionDef kHeadOptions[] = {
+static constexpr InlineOptionDef HeadOptions[] = {
     { .shortFlag = "-n", .longFlag = {}, .description = "Number of lines (default: 10)", .takesValue = true },
 };
 
-static constexpr InlineOptionDef kTailOptions[] = {
+static constexpr InlineOptionDef TailOptions[] = {
     { .shortFlag = "-n", .longFlag = {}, .description = "Number of lines (default: 10)", .takesValue = true },
     { .shortFlag = "-f", .longFlag = {}, .description = "Follow: output appended data as file grows" },
 };
 
-static constexpr InlineOptionDef kWcOptions[] = {
+static constexpr InlineOptionDef WcOptions[] = {
     { .shortFlag = "-l", .longFlag = {}, .description = "Print line count" },
     { .shortFlag = "-w", .longFlag = {}, .description = "Print word count" },
     { .shortFlag = "-c", .longFlag = {}, .description = "Print character count" },
 };
 
-static constexpr InlineOptionDef kSortOptions[] = {
+static constexpr InlineOptionDef SortOptions[] = {
     { .shortFlag = "-r", .longFlag = {}, .description = "Reverse sort order" },
     { .shortFlag = "-n", .longFlag = {}, .description = "Compare according to numerical value" },
     { .shortFlag = "-u", .longFlag = {}, .description = "Output only unique lines" },
     { .shortFlag = "-k", .longFlag = {}, .description = "Sort by key field number", .takesValue = true },
 };
 
-static constexpr InlineOptionDef kUniqOptions[] = {
+static constexpr InlineOptionDef UniqOptions[] = {
     { .shortFlag = "-c", .longFlag = {}, .description = "Prefix lines with occurrence count" },
     { .shortFlag = "-d", .longFlag = {}, .description = "Only print duplicate lines" },
     { .shortFlag = "-i", .longFlag = {}, .description = "Ignore case when comparing" },
 };
 
-static constexpr InlineOptionDef kCutOptions[] = {
+static constexpr InlineOptionDef CutOptions[] = {
     { .shortFlag = "-d", .longFlag = {}, .description = "Field delimiter (default: tab)", .takesValue = true },
     { .shortFlag = "-f", .longFlag = {}, .description = "Select fields (e.g., 1, 1-3, 1,3)", .takesValue = true },
     { .shortFlag = "-c", .longFlag = {}, .description = "Select characters (e.g., 1-5, 3)", .takesValue = true },
 };
 
-static constexpr InlineOptionDef kTrOptions[] = {
+static constexpr InlineOptionDef TrOptions[] = {
     { .shortFlag = "-d", .longFlag = {}, .description = "Delete characters in SET1" },
     { .shortFlag = "-s", .longFlag = {}, .description = "Squeeze repeated output characters" },
 };
 
-static constexpr InlineOptionDef kTeeOptions[] = {
+static constexpr InlineOptionDef TeeOptions[] = {
     { .shortFlag = "-a", .longFlag = "--append", .description = "Append to files instead of overwriting" },
 };
 
-static constexpr InlineOptionDef kPkillOptions[] = {
+static constexpr InlineOptionDef PkillOptions[] = {
     { .shortFlag = "-s", .longFlag = {}, .description = "Signal to send (name or number)", .takesValue = true },
     { .shortFlag = "-f", .longFlag = {}, .description = "Match against the full command line" },
     { .shortFlag = "-x", .longFlag = {}, .description = "Require exact (anchored) match" },
@@ -169,7 +169,7 @@ std::span<InlineCommandDescriptor const> Shell::inlineCommandDescriptors()
           .noStdinFn = &Shell::executeInlineBasename },
         { .name = "cal",       .briefDescription = "Display a colorful calendar for a month or year.",
           .usageLine = "cal [OPTIONS] [[MONTH] YEAR]",
-          .options = calOptions,
+          .options = CalOptions,
           .noStdinFn = &Shell::executeInlineCal },
         { .name = "cat",       .briefDescription = "Concatenate and display files.",
           .usageLine = "cat [OPTIONS] [FILE...]",
@@ -177,15 +177,15 @@ std::span<InlineCommandDescriptor const> Shell::inlineCommandDescriptors()
           .withStdinFn = &Shell::executeInlineCat },
         { .name = "cp",        .briefDescription = "Copy files and directories.",
           .usageLine = "cp [OPTIONS] SOURCE... DEST",
-          .options = kCpOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = CpOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .noStdinFn = &Shell::executeInlineCp },
         { .name = "cut",       .briefDescription = "Extract fields or characters from lines.",
           .usageLine = "cut [OPTIONS] [FILE...]",
-          .options = kCutOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = CutOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .withStdinFn = &Shell::executeInlineCut },
         { .name = "date",      .briefDescription = "Print or format the current date and time.",
           .usageLine = "date [OPTIONS]",
-          .options = kDateOptions,
+          .options = DateOptions,
           .noStdinFn = &Shell::executeInlineDate },
         { .name = "dirconfig", .briefDescription = "Manage per-directory configuration.",
           .usageLine = "dirconfig SUBCOMMAND [PATH]",
@@ -196,7 +196,7 @@ std::span<InlineCommandDescriptor const> Shell::inlineCommandDescriptors()
           .noStdinFn = &Shell::executeInlineDirname },
         { .name = "echo",      .briefDescription = "Write arguments to standard output.",
           .usageLine = "echo [OPTIONS] [STRING...]",
-          .options = kEchoOptions,
+          .options = EchoOptions,
           .noStdinFn = &Shell::executeInlineEcho },
         { .name = "find",      .briefDescription = "Search for files in directory hierarchies.",
           .usageLine = "find [PATH...] [EXPRESSION]",
@@ -208,7 +208,7 @@ std::span<InlineCommandDescriptor const> Shell::inlineCommandDescriptors()
           .withStdinFn = &Shell::executeInlineGrep },
         { .name = "head",      .briefDescription = "Output the first lines of files.",
           .usageLine = "head [OPTIONS] [FILE...]",
-          .options = kHeadOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = HeadOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .withStdinFn = &Shell::executeInlineHead },
         { .name = "history",   .briefDescription = "Display or manage command history.",
           .usageLine = "history [N | search PATTERN | clear]",
@@ -221,27 +221,27 @@ std::span<InlineCommandDescriptor const> Shell::inlineCommandDescriptors()
           .noStdinFn = &Shell::executeInlineKill },
         { .name = "ln",        .briefDescription = "Create hard or symbolic links.",
           .usageLine = "ln [OPTIONS] TARGET LINK_NAME",
-          .options = kLnOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = LnOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .noStdinFn = &Shell::executeInlineLn },
         { .name = "mkdir",     .briefDescription = "Create directories.",
           .usageLine = "mkdir [OPTIONS] DIRECTORY...",
-          .options = kMkdirOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = MkdirOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .noStdinFn = &Shell::executeInlineMkdir },
         { .name = "mktemp",    .briefDescription = "Create a temporary file or directory.",
           .usageLine = "mktemp [OPTIONS]",
-          .options = kMktempOptions,
+          .options = MktempOptions,
           .noStdinFn = &Shell::executeInlineMktemp },
         { .name = "mv",        .briefDescription = "Move or rename files and directories.",
           .usageLine = "mv [OPTIONS] SOURCE... DEST",
-          .options = kMvOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = MvOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .noStdinFn = &Shell::executeInlineMv },
         { .name = "nproc",    .briefDescription = "Print the number of available processing units.",
           .usageLine = "nproc [OPTIONS]",
-          .options = kNprocOptions,
+          .options = NprocOptions,
           .noStdinFn = &Shell::executeInlineNproc },
         { .name = "pkill",     .briefDescription = "Send signals to processes matched by name or command-line pattern.",
           .usageLine = "pkill [OPTIONS] [-SIGNAL] PATTERN",
-          .options = kPkillOptions,
+          .options = PkillOptions,
           .noStdinFn = &Shell::executeInlinePkill },
         { .name = "pwd",      .briefDescription = "Print the current working directory.",
           .usageLine = "pwd",
@@ -253,14 +253,14 @@ std::span<InlineCommandDescriptor const> Shell::inlineCommandDescriptors()
           .noStdinFn = &Shell::executeInlineRealpath },
         { .name = "rm",        .briefDescription = "Remove files and directories.",
           .usageLine = "rm [OPTIONS] FILE...",
-          .options = kRmOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = RmOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .noStdinFn = &Shell::executeInlineRm },
         { .name = "sleep",     .briefDescription = "Pause execution for a specified duration.",
           .usageLine = "sleep DURATION",
           .noStdinFn = &Shell::executeInlineSleep },
         { .name = "sort",      .briefDescription = "Sort lines of text.",
           .usageLine = "sort [OPTIONS] [FILE...]",
-          .options = kSortOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = SortOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .withStdinFn = &Shell::executeInlineSort },
         { .name = "source",    .briefDescription = "Execute a script in the current shell context.",
           .usageLine = "source FILE [ARGS...]",
@@ -272,34 +272,34 @@ std::span<InlineCommandDescriptor const> Shell::inlineCommandDescriptors()
           .noStdinFn = &Shell::executeInlineSourceEnv },
         { .name = "tail",      .briefDescription = "Output the last lines of files.",
           .usageLine = "tail [OPTIONS] [FILE...]",
-          .options = kTailOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = TailOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .withStdinFn = &Shell::executeInlineTail },
         { .name = "tee",       .briefDescription = "Read stdin, write to stdout and files.",
           .usageLine = "tee [OPTIONS] [FILE...]",
-          .options = kTeeOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = TeeOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .withStdinFn = &Shell::executeInlineTee },
         { .name = "timeout",   .briefDescription = "Run a command with a time limit.",
           .usageLine = "timeout [OPTIONS] DURATION COMMAND [ARG...]",
           .noStdinFn = &Shell::executeInlineTimeout },
         { .name = "touch",     .briefDescription = "Create files or update timestamps.",
           .usageLine = "touch [OPTIONS] FILE...",
-          .options = kTouchOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = TouchOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .noStdinFn = &Shell::executeInlineTouch },
         { .name = "tr",        .briefDescription = "Translate or delete characters.",
           .usageLine = "tr [OPTIONS] SET1 [SET2]",
-          .options = kTrOptions,
+          .options = TrOptions,
           .withStdinFn = &Shell::executeInlineTr },
         { .name = "uname",     .briefDescription = "Print system information.",
           .usageLine = "uname [OPTIONS]",
-          .options = kUnameOptions,
+          .options = UnameOptions,
           .noStdinFn = &Shell::executeInlineUname },
         { .name = "uniq",      .briefDescription = "Filter adjacent duplicate lines.",
           .usageLine = "uniq [OPTIONS] [FILE]",
-          .options = kUniqOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = UniqOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .withStdinFn = &Shell::executeInlineUniq },
         { .name = "wc",        .briefDescription = "Count lines, words, and characters.",
           .usageLine = "wc [OPTIONS] [FILE...]",
-          .options = kWcOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
+          .options = WcOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .withStdinFn = &Shell::executeInlineWc },
         { .name = "whoami",    .briefDescription = "Print the current username.",
           .usageLine = "whoami",

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -2681,14 +2681,14 @@ int Shell::executeInlineKill(CoreVM::CoreStringArray const& args, NativeHandle o
     if (opts.listSignals)
     {
         // clang-format off
-        static constexpr std::pair<int, std::string_view> signals[] = {
+        static constexpr std::pair<int, std::string_view> Signals[] = {
             {  1, "HUP" }, {  2, "INT"  }, {  3, "QUIT" }, {  4, "ILL"  }, {  5, "TRAP" },
             {  6, "ABRT"}, {  7, "BUS"  }, {  8, "FPE"  }, {  9, "KILL" }, { 10, "USR1" },
             { 11, "SEGV"}, { 12, "USR2" }, { 13, "PIPE" }, { 14, "ALRM" }, { 15, "TERM" },
         };
         // clang-format on
         std::string output;
-        for (auto const& [num, name]: signals)
+        for (auto const& [num, name]: Signals)
             output += std::format("{:2}) {:<8}", num, name);
 
         output += '\n';
@@ -3286,7 +3286,7 @@ namespace
         std::string_view today;      ///< Highlight for the current day
     };
 
-    constexpr CalSgr calStyled = {
+    constexpr CalSgr CalStyled = {
         .reset = "\x1b[0m",
         .title = "\x1b[1;38;5;220m", // bold gold
         .weekdayRow = "\x1b[1;2m",
@@ -3294,7 +3294,7 @@ namespace
         .today = "\x1b[1;7;38;5;226m", // bold + reverse + yellow
     };
 
-    constexpr CalSgr calPlain = {
+    constexpr CalSgr CalPlain = {
         .reset = "",
         .title = "",
         .weekdayRow = "",
@@ -3304,13 +3304,13 @@ namespace
 
     /// English fallback month names. `std::chrono::format` is locale-aware, but
     /// for wide portability we build the header from a static table.
-    constexpr std::array<std::string_view, 12> calMonthNames = {
+    constexpr std::array<std::string_view, 12> CalMonthNames = {
         "January", "February", "March",     "April",   "May",      "June",
         "July",    "August",   "September", "October", "November", "December",
     };
 
     /// Short weekday labels starting with Monday (index 0). Locale-independent.
-    constexpr std::array<std::string_view, 7> calWeekdayShort = {
+    constexpr std::array<std::string_view, 7> CalWeekdayShort = {
         "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su",
     };
 
@@ -3338,7 +3338,7 @@ namespace
         bool startMonday = true;
     };
 
-    constexpr size_t calBlockWidth = 20; ///< 7 columns * 2 chars + 6 gutters = 20.
+    constexpr size_t CalBlockWidth = 20; ///< 7 columns * 2 chars + 6 gutters = 20.
 
     /// Centers @p text within @p width, padding with spaces.
     std::string centerText(std::string_view text, size_t width)
@@ -3357,7 +3357,7 @@ namespace
                                                  std::chrono::year_month_day today,
                                                  CalStyle const& style)
     {
-        auto const& sgr = style.useColor ? calStyled : calPlain;
+        auto const& sgr = style.useColor ? CalStyled : CalPlain;
         auto const firstDay = style.startMonday ? std::chrono::Monday : std::chrono::Sunday;
 
         std::vector<std::string> lines;
@@ -3365,12 +3365,12 @@ namespace
 
         // Title: "April 2026"
         auto const monthIdx = static_cast<unsigned>(ym.month()) - 1u;
-        auto const titleText = std::format("{} {}", calMonthNames.at(monthIdx), static_cast<int>(ym.year()));
-        lines.push_back(std::format("{}{}{}", sgr.title, centerText(titleText, calBlockWidth), sgr.reset));
+        auto const titleText = std::format("{} {}", CalMonthNames.at(monthIdx), static_cast<int>(ym.year()));
+        lines.push_back(std::format("{}{}{}", sgr.title, centerText(titleText, CalBlockWidth), sgr.reset));
 
         // Weekday header row (e.g., "Mo Tu We Th Fr Sa Su").
         std::string header;
-        header.reserve(calBlockWidth + 16);
+        header.reserve(CalBlockWidth + 16);
         header += sgr.weekdayRow;
         for (auto const col: std::views::iota(0uz, 7uz))
         {
@@ -3383,13 +3383,13 @@ namespace
             {
                 header += sgr.reset;
                 header += sgr.weekend;
-                header += calWeekdayShort.at(static_cast<size_t>(labelIdx));
+                header += CalWeekdayShort.at(static_cast<size_t>(labelIdx));
                 header += sgr.reset;
                 header += sgr.weekdayRow;
             }
             else
             {
-                header += calWeekdayShort.at(static_cast<size_t>(labelIdx));
+                header += CalWeekdayShort.at(static_cast<size_t>(labelIdx));
             }
         }
         header += sgr.reset;
@@ -3407,7 +3407,7 @@ namespace
         for (auto const week: std::views::iota(0, 6))
         {
             std::string row;
-            row.reserve(calBlockWidth + 64);
+            row.reserve(CalBlockWidth + 64);
             for (auto const col: std::views::iota(0uz, 7uz))
             {
                 if (col > 0)
@@ -3451,7 +3451,7 @@ namespace
         }
         // Ensure we always have 8 lines so horizontal composition aligns cleanly.
         while (lines.size() < 8)
-            lines.emplace_back(calBlockWidth, ' ');
+            lines.emplace_back(CalBlockWidth, ' ');
         return lines;
     }
 
@@ -3460,7 +3460,7 @@ namespace
     {
         if (blocks.empty())
             return {};
-        constexpr std::string_view gutter = "  ";
+        constexpr std::string_view Gutter = "  ";
         std::string out;
         size_t const rows = blocks.front().size();
         for (auto const row: std::views::iota(0uz, rows))
@@ -3468,7 +3468,7 @@ namespace
             for (auto const bi: std::views::iota(0uz, blocks.size()))
             {
                 if (bi > 0)
-                    out += gutter;
+                    out += Gutter;
                 out += blocks[bi].at(row);
             }
             out += '\n';
@@ -3630,9 +3630,9 @@ int Shell::executeInlineCal(CoreVM::CoreStringArray const& args, NativeHandle ou
 
     if (showYear)
     {
-        auto const& headerSgr = useColor ? calStyled.title : calPlain.title;
-        auto const& resetSgr = useColor ? calStyled.reset : calPlain.reset;
-        auto const yearTitle = std::format("{:^{}}", static_cast<int>(targetYear), (calBlockWidth * 3) + 4);
+        auto const& headerSgr = useColor ? CalStyled.title : CalPlain.title;
+        auto const& resetSgr = useColor ? CalStyled.reset : CalPlain.reset;
+        auto const yearTitle = std::format("{:^{}}", static_cast<int>(targetYear), (CalBlockWidth * 3) + 4);
         output += std::format("{}{}{}\n\n", headerSgr, yearTitle, resetSgr);
 
         for (auto const bandIdx: std::views::iota(0, 4))
@@ -4145,15 +4145,15 @@ int Shell::executeInlineMktemp(CoreVM::CoreStringArray const& args, NativeHandle
         basedir.empty() ? std::filesystem::temp_directory_path() : std::filesystem::path(basedir);
 
     // Generate random suffix
-    static constexpr std::string_view chars =
+    static constexpr std::string_view Chars =
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     std::string suffix = "tmp.";
     std::mt19937 rng(static_cast<unsigned>(std::chrono::steady_clock::now().time_since_epoch().count()));
-    std::uniform_int_distribution<size_t> dist(0, chars.size() - 1);
+    std::uniform_int_distribution<size_t> dist(0, Chars.size() - 1);
     for (auto const _: std::views::iota(0, 10))
     {
         (void) _;
-        suffix += chars[dist(rng)];
+        suffix += Chars[dist(rng)];
     }
 
     auto const path = tmpdir / suffix;

--- a/src/shell/completion/BuiltinArgumentCompleter.cpp
+++ b/src/shell/completion/BuiltinArgumentCompleter.cpp
@@ -117,7 +117,7 @@ namespace
     std::vector<CompletionCandidate> bindFlagCandidates(std::string_view prefix)
     {
         using Flag = std::pair<std::string_view, std::string_view>;
-        static constexpr std::array<Flag, 7> flags = { {
+        static constexpr std::array<Flag, 7> Flags = { {
             { "-r", "Remove a keybinding" },
             { "--remove", "Remove a keybinding" },
             { "-l", "List all keybindings" },
@@ -128,7 +128,7 @@ namespace
         } };
 
         std::vector<CompletionCandidate> results;
-        for (auto const& [flag, desc]: flags)
+        for (auto const& [flag, desc]: Flags)
         {
             if (flag.starts_with(prefix))
                 results.push_back(CompletionCandidate {

--- a/src/shell/completion/CommandCompleter.cpp
+++ b/src/shell/completion/CommandCompleter.cpp
@@ -6,8 +6,6 @@
 #include <endo-language/builtins/BuiltinSignatures.hpp>
 #include <endo-language/ide/CompletionCandidates.hpp>
 
-#include <platform/PathUtils.hpp>
-
 #include <crispy/utils.h>
 
 #include <algorithm>
@@ -16,6 +14,8 @@
 #include <map>
 #include <set>
 #include <unordered_map>
+
+#include <platform/PathUtils.hpp>
 
 namespace endo
 {
@@ -77,7 +77,7 @@ std::vector<CompletionItem> CommandCompleter::complete(CompletionContext const& 
     auto const total = static_cast<int>(historyEntries.size());
     if (total > 0)
     {
-        constexpr auto maxBonus = 200;
+        constexpr auto MaxBonus = 200;
         auto recencyMap = std::unordered_map<std::string, int> {};
         for (auto i = total - 1; i >= 0; --i)
         {
@@ -86,7 +86,7 @@ std::vector<CompletionItem> CommandCompleter::complete(CompletionContext const& 
             auto const spacePos = entry.find(' ');
             auto const cmd = entry.substr(0, spacePos);
             if (!cmd.empty())
-                recencyMap.try_emplace(cmd, maxBonus * (i + 1) / total);
+                recencyMap.try_emplace(cmd, MaxBonus * (i + 1) / total);
         }
         for (auto& item: results)
         {

--- a/src/shell/completion/CommandSpecCompleter.cpp
+++ b/src/shell/completion/CommandSpecCompleter.cpp
@@ -31,10 +31,10 @@ void CommandSpecCompleter::registerCommand(CommandSpec spec,
                 if (entry.text != alias)
                     continue;
                 // Description format: "alias: <command> [args...]"
-                static constexpr std::string_view prefix = "alias: ";
-                if (!entry.description.starts_with(prefix))
+                static constexpr std::string_view Prefix = "alias: ";
+                if (!entry.description.starts_with(Prefix))
                     return std::nullopt;
-                auto const rest = std::string_view(entry.description).substr(prefix.size());
+                auto const rest = std::string_view(entry.description).substr(Prefix.size());
                 // Shell aliases (starting with '!') are not subcommand mappings
                 if (rest.starts_with('!'))
                     return std::nullopt;

--- a/src/shell/completion/GitSpec.cpp
+++ b/src/shell/completion/GitSpec.cpp
@@ -1105,8 +1105,8 @@ std::vector<QueryResult> GitQueryProvider::queryBranches(bool localOnly, bool re
     auto seen = std::set<std::string> {};
 
 #if defined(_WIN32)
-    static constexpr auto localCmd = "git branch --format=\"%(refname:short)\" 2>NUL";
-    static constexpr auto remoteCmd = "git branch -r --format=\"%(refname:short)\" 2>NUL";
+    static constexpr auto LocalCmd = "git branch --format=\"%(refname:short)\" 2>NUL";
+    static constexpr auto RemoteCmd = "git branch -r --format=\"%(refname:short)\" 2>NUL";
 #else
     static constexpr auto localCmd = "git branch --format='%(refname:short)' 2>/dev/null";
     static constexpr auto remoteCmd = "git branch -r --format='%(refname:short)' 2>/dev/null";
@@ -1114,7 +1114,7 @@ std::vector<QueryResult> GitQueryProvider::queryBranches(bool localOnly, bool re
 
     if (!remoteOnly)
     {
-        for (auto const& branch: runCommand(localCmd))
+        for (auto const& branch: runCommand(LocalCmd))
         {
             if (seen.insert(branch).second)
                 results.push_back(QueryResult { .text = branch, .description = "local branch" });
@@ -1123,7 +1123,7 @@ std::vector<QueryResult> GitQueryProvider::queryBranches(bool localOnly, bool re
 
     if (!localOnly)
     {
-        for (auto const& branch: runCommand(remoteCmd))
+        for (auto const& branch: runCommand(RemoteCmd))
         {
             auto stripped = branch;
             if (auto const slash = branch.find('/'); slash != std::string::npos)

--- a/src/shell/completion/GitSpec.cpp
+++ b/src/shell/completion/GitSpec.cpp
@@ -1108,8 +1108,8 @@ std::vector<QueryResult> GitQueryProvider::queryBranches(bool localOnly, bool re
     static constexpr auto LocalCmd = "git branch --format=\"%(refname:short)\" 2>NUL";
     static constexpr auto RemoteCmd = "git branch -r --format=\"%(refname:short)\" 2>NUL";
 #else
-    static constexpr auto localCmd = "git branch --format='%(refname:short)' 2>/dev/null";
-    static constexpr auto remoteCmd = "git branch -r --format='%(refname:short)' 2>/dev/null";
+    static constexpr auto LocalCmd = "git branch --format='%(refname:short)' 2>/dev/null";
+    static constexpr auto RemoteCmd = "git branch -r --format='%(refname:short)' 2>/dev/null";
 #endif
 
     if (!remoteOnly)

--- a/src/shell/completion/ScriptedCompleter.cpp
+++ b/src/shell/completion/ScriptedCompleter.cpp
@@ -45,7 +45,7 @@ std::vector<CompletionItem> ScriptedCompleter::complete(CompletionContext const&
     auto const now = std::chrono::steady_clock::now();
     if (auto it = _cache.find(cacheKey); it != _cache.end())
     {
-        if (now - it->second.timestamp < cacheTTL)
+        if (now - it->second.timestamp < CacheTtl)
         {
             // Reuse cached results with current prefix for fuzzy scoring
             std::vector<CompletionCandidate> candidates;
@@ -60,8 +60,8 @@ std::vector<CompletionItem> ScriptedCompleter::complete(CompletionContext const&
     }
 
     // Evict expired entries when cache exceeds size threshold
-    if (_cache.size() > maxCacheEntries)
-        std::erase_if(_cache, [now](auto const& entry) { return now - entry.second.timestamp >= cacheTTL; });
+    if (_cache.size() > MaxCacheEntries)
+        std::erase_if(_cache, [now](auto const& entry) { return now - entry.second.timestamp >= CacheTtl; });
 
     // Execute the completer function
     auto result = _callback(*funcName, args, context.prefix);

--- a/src/shell/completion/ScriptedCompleter.hpp
+++ b/src/shell/completion/ScriptedCompleter.hpp
@@ -72,8 +72,8 @@ class ScriptedCompleter: public CompletionProvider
         std::chrono::steady_clock::time_point timestamp;
     };
 
-    static constexpr auto cacheTTL = std::chrono::milliseconds { 2000 };
-    static constexpr size_t maxCacheEntries = 32;
+    static constexpr auto CacheTtl = std::chrono::milliseconds { 2000 };
+    static constexpr size_t MaxCacheEntries = 32;
     mutable std::unordered_map<std::string, CacheEntry> _cache;
 
     /// @brief Builds a cache key from function name and args.

--- a/src/shell/history/PersistentHistory.cpp
+++ b/src/shell/history/PersistentHistory.cpp
@@ -315,9 +315,9 @@ std::vector<History::FuzzySearchResult> PersistentHistory::searchFuzzy(
 
     // CWD ranking bonuses — exact must outrank maxRecencyBonus so same-CWD entries
     // beat fresh unrelated ones; ancestor is a gentler tiebreaker.
-    constexpr auto maxRecencyBonus = 200;
-    constexpr auto exactCwdBonus = 300;
-    constexpr auto ancestorCwdBonus = 150;
+    constexpr auto MaxRecencyBonus = 200;
+    constexpr auto ExactCwdBonus = 300;
+    constexpr auto AncestorCwdBonus = 150;
 
     // Canonicalize the current CWD once; comparison against stored cwd stays a cheap string op.
     auto const currentCwdCanonical = options.currentCwd.empty()
@@ -365,7 +365,7 @@ std::vector<History::FuzzySearchResult> PersistentHistory::searchFuzzy(
         }
 
         // Recency bonus: scaled to fixed range [0, maxRecencyBonus], newest gets highest
-        auto const recencyBonus = total > 0 ? maxRecencyBonus * (total - position) / total : 0;
+        auto const recencyBonus = total > 0 ? MaxRecencyBonus * (total - position) / total : 0;
 
         // Frequency bonus: small tiebreaker, recency dominates
         auto const frequencyBonus =
@@ -376,9 +376,9 @@ std::vector<History::FuzzySearchResult> PersistentHistory::searchFuzzy(
         if (!currentCwdCanonical.empty() && !it->cwd.empty())
         {
             if (it->cwd == currentCwdCanonical)
-                cwdBonus = exactCwdBonus;
+                cwdBonus = ExactCwdBonus;
             else if (pathIsAncestor(it->cwd, currentCwdCanonical))
-                cwdBonus = ancestorCwdBonus;
+                cwdBonus = AncestorCwdBonus;
         }
 
         auto score = 0;

--- a/src/shell/history/RequiredPaths.cpp
+++ b/src/shell/history/RequiredPaths.cpp
@@ -136,7 +136,7 @@ std::vector<std::string> collectRequiredPaths(std::span<std::string const> argv,
 
     for (auto const& arg: argv.subspan(1))
     {
-        if (result.size() >= maxRequiredPaths)
+        if (result.size() >= MaxRequiredPaths)
             break;
         if (!looksLikePath(arg))
             continue;

--- a/src/shell/history/RequiredPaths.hpp
+++ b/src/shell/history/RequiredPaths.hpp
@@ -25,7 +25,7 @@ namespace endo
 ///
 /// Caps cost of per-entry existence checks during completion and keeps
 /// storage compact for commands that expand into many path-like args.
-inline constexpr size_t maxRequiredPaths = 8;
+inline constexpr size_t MaxRequiredPaths = 8;
 
 /// Canonicalizes an absolute path into a home-relative form for portable storage.
 ///

--- a/src/shell/history/RequiredPaths_test.cpp
+++ b/src/shell/history/RequiredPaths_test.cpp
@@ -134,7 +134,7 @@ TEST_CASE("collectRequiredPaths.caps_at_max", "[history][required-paths]")
         argv.push_back("/tmp/f" + std::to_string(i));
 
     auto const paths = collectRequiredPaths(argv, "/home/u", "/home/u");
-    CHECK(paths.size() == maxRequiredPaths);
+    CHECK(paths.size() == MaxRequiredPaths);
 }
 
 TEST_CASE("collectRequiredPaths.skips_urls", "[history][required-paths]")

--- a/src/shell/output/FileTypeStyle.cpp
+++ b/src/shell/output/FileTypeStyle.cpp
@@ -292,7 +292,7 @@ std::string colorizePermissions(std::string_view perms)
     static auto const sgrWrite = sgrSequence({ .fg = PermWriteColor });
     static auto const sgrExec = sgrSequence({ .fg = PermExecColor });
     static auto const sgrNone = sgrSequence({ .fg = PermNoneColor });
-    static constexpr auto sgrReset = "\033[m";
+    static constexpr auto SgrReset = "\033[m";
 
     std::string result;
     result.reserve(perms.size() * 20); // pre-allocate for SGR overhead
@@ -307,7 +307,7 @@ std::string colorizePermissions(std::string_view perms)
             default: break;
         }
         result += c;
-        result += sgrReset;
+        result += SgrReset;
     }
     return result;
 }

--- a/src/shell/platform/WindowsTestPTY.cpp
+++ b/src/shell/platform/WindowsTestPTY.cpp
@@ -226,8 +226,8 @@ std::string_view WindowsTestPTY::output() const noexcept
 
 void WindowsTestPTY::outputCaptureLoop()
 {
-    constexpr DWORD bufferSize = 1024;
-    char buffer[bufferSize];
+    constexpr DWORD BufferSize = 1024;
+    char buffer[BufferSize];
 
     while (!_closed)
     {
@@ -248,7 +248,7 @@ void WindowsTestPTY::outputCaptureLoop()
 
         DWORD bytesRead = 0;
         BOOL const success =
-            ReadFile(_readOutputHandle, buffer, std::min(bufferSize, bytesAvailable), &bytesRead, nullptr);
+            ReadFile(_readOutputHandle, buffer, std::min(BufferSize, bytesAvailable), &bytesRead, nullptr);
 
         if (!success || bytesRead == 0)
             break; // EOF or error

--- a/src/shell/ui/Prompt.cpp
+++ b/src/shell/ui/Prompt.cpp
@@ -172,8 +172,8 @@ coro::Task<std::string> Prompt::read(tui::runtime::TuiRuntime* runtime)
         // resume on non-input activity (focus change, a finished background job),
         // which arrives as a std::nullopt wake; nextEvent() cannot represent "no
         // event", so use nextEventFor with a long sentinel for the blocking case.
-        constexpr auto idleSentinel = std::chrono::milliseconds { 60'000 };
-        auto const waitFor = (timeout < 0) ? idleSentinel : std::chrono::milliseconds { timeout };
+        constexpr auto IdleSentinel = std::chrono::milliseconds { 60'000 };
+        auto const waitFor = (timeout < 0) ? IdleSentinel : std::chrono::milliseconds { timeout };
         auto event = std::optional<tui::InputEvent> {};
         try
         {
@@ -685,8 +685,8 @@ void emitPartialLineIndicator(NativeHandle handle, int cursorColumn)
         return;
 
     // SGR 2 (dim) + U+23CE (return symbol) + SGR 0 (reset) + CSI K (clear to EOL) + CR LF
-    static constexpr std::string_view indicator = "\033[2m\u23CE\033[0m\033[K\r\n";
-    platformWrite(handle, indicator.data(), indicator.size());
+    static constexpr std::string_view Indicator = "\033[2m\u23CE\033[0m\033[K\r\n";
+    platformWrite(handle, Indicator.data(), Indicator.size());
 }
 
 } // namespace endo

--- a/src/shell/ui/modules/ToolchainModule.cpp
+++ b/src/shell/ui/modules/ToolchainModule.cpp
@@ -34,7 +34,7 @@ namespace
         };
 
         // clang-format off
-        static constexpr auto detections = std::array<Detection, 8> {{
+        static constexpr auto Detections = std::array<Detection, 8> {{
             { .file="Cargo.toml",      .icon="\xf0\x9f\xa6\x80", .name="rust" },      // U+1F980 crab
             { .file="package.json",    .icon="\xf0\x9f\x9f\xa9", .name="node" },      // U+1F7E9 green square
             { .file="go.mod",          .icon="\xf0\x9f\x90\xbf", .name="go" },        // U+1F43F chipmunk
@@ -46,7 +46,7 @@ namespace
         }};
         // clang-format on
 
-        for (auto const& [file, icon, name]: detections)
+        for (auto const& [file, icon, name]: Detections)
         {
             if (std::filesystem::exists(dir / file))
                 return { .icon = std::string(icon), .name = std::string(name), .valid = true };

--- a/src/tui/CommandPalettePopup.cpp
+++ b/src/tui/CommandPalettePopup.cpp
@@ -22,7 +22,7 @@ void CommandPalettePopup::render(Canvas& canvas)
 
     auto const& theme = canvas.theme();
 
-    auto const visibleCount = std::min(maxVisibleItems, _filteredItems.size());
+    auto const visibleCount = std::min(MaxVisibleItems, _filteredItems.size());
     auto const paletteWidth = calculateWidth(canvas.width());
     auto const paletteHeight = static_cast<int>(visibleCount) + 4;
 
@@ -129,9 +129,9 @@ Size CommandPalettePopup::preferredSize() const
     if (!visible())
         return { .width = 0, .height = 0 };
 
-    auto const visibleCount = std::min(maxVisibleItems, _filteredItems.size());
+    auto const visibleCount = std::min(MaxVisibleItems, _filteredItems.size());
     auto const height = static_cast<int>(visibleCount) + 4;
-    return { .width = maxPaletteWidth, .height = height };
+    return { .width = MaxPaletteWidth, .height = height };
 }
 
 // ============================================================================
@@ -323,7 +323,7 @@ void CommandPalettePopup::refilter()
 
 int CommandPalettePopup::calculateWidth(int maxWidth) const
 {
-    auto width = minPaletteWidth;
+    auto width = MinPaletteWidth;
 
     for (auto const& item: _filteredItems)
     {
@@ -340,7 +340,7 @@ int CommandPalettePopup::calculateWidth(int maxWidth) const
         width = std::max(width, itemWidth);
     }
 
-    return std::min({ width, maxPaletteWidth, maxWidth });
+    return std::min({ width, MaxPaletteWidth, maxWidth });
 }
 
 void CommandPalettePopup::executeSelected()

--- a/src/tui/CommandPalettePopup.hpp
+++ b/src/tui/CommandPalettePopup.hpp
@@ -98,15 +98,15 @@ class CommandPalettePopup: public Component
     InputField _filterField;                            ///< Text input for filtering.
     std::vector<CommandEntry> _allItems;                ///< All available commands (snapshot).
     std::vector<FilteredItem> _filteredItems;           ///< Filtered and sorted commands.
-    ScrollableSelection _selection { maxVisibleItems }; ///< Selection and scroll state.
+    ScrollableSelection _selection { MaxVisibleItems }; ///< Selection and scroll state.
     bool _visible = false;                              ///< Whether the palette is shown.
     int _renderedHeight = 0;                            ///< Last rendered height.
     int _renderedWidth = 0;                             ///< Last rendered width.
     std::string _title;                                 ///< Optional title for sub-menus.
 
-    static constexpr size_t maxVisibleItems = 12; ///< Maximum number of visible items.
-    static constexpr int minPaletteWidth = 50;    ///< Minimum palette width.
-    static constexpr int maxPaletteWidth = 80;    ///< Maximum palette width.
+    static constexpr size_t MaxVisibleItems = 12; ///< Maximum number of visible items.
+    static constexpr int MinPaletteWidth = 50;    ///< Minimum palette width.
+    static constexpr int MaxPaletteWidth = 80;    ///< Maximum palette width.
 
     /// @brief Recomputes _filteredItems from _allItems and current filter text.
     void refilter();

--- a/src/tui/CompletionPopup.cpp
+++ b/src/tui/CompletionPopup.cpp
@@ -23,8 +23,8 @@ namespace tui
 
 namespace
 {
-    constexpr int detailMaxWidth = 40; ///< Maximum detail panel width.
-    constexpr int detailMinWidth = 20; ///< Minimum detail panel width.
+    constexpr int DetailMaxWidth = 40; ///< Maximum detail panel width.
+    constexpr int DetailMinWidth = 20; ///< Minimum detail panel width.
 
     /// @brief Truncates a string to fit within a given width, adding ellipsis.
     /// @return A pair of (truncated string, display width).
@@ -207,7 +207,7 @@ void CompletionPopup::render(Canvas& canvas)
     auto const detailWidth = detailPanelWidth();
     auto const availableForDetail = canvas.width() - menuWidth;
 
-    if (!_detailContent.empty() && detailWidth > 0 && availableForDetail >= detailMinWidth)
+    if (!_detailContent.empty() && detailWidth > 0 && availableForDetail >= DetailMinWidth)
     {
         auto const panelWidth = std::min(detailWidth, availableForDetail);
         auto const border = BorderChars::fromStyle(BorderStyle::Single);
@@ -545,7 +545,7 @@ void CompletionPopup::updateDetailContent()
     }
 
     // Parse markdown with width clamped to detail panel max
-    _detailContent = StyledText::fromMarkdown(detail, detailMaxWidth - 2);
+    _detailContent = StyledText::fromMarkdown(detail, DetailMaxWidth - 2);
 }
 
 int CompletionPopup::detailPanelWidth() const
@@ -554,8 +554,8 @@ int CompletionPopup::detailPanelWidth() const
         return 0;
 
     // Content width + 2 (shared left border + right border)
-    auto const contentWidth = std::min(_detailContent.maxLineWidth(), detailMaxWidth - 2);
-    return std::clamp(contentWidth + 2, detailMinWidth, detailMaxWidth);
+    auto const contentWidth = std::min(_detailContent.maxLineWidth(), DetailMaxWidth - 2);
+    return std::clamp(contentWidth + 2, DetailMinWidth, DetailMaxWidth);
 }
 
 } // namespace tui

--- a/src/tui/FuzzyPickerPopup.cpp
+++ b/src/tui/FuzzyPickerPopup.cpp
@@ -26,7 +26,7 @@ void FuzzyPickerPopup::render(Canvas& canvas)
 
     // Clamp visible items to what fits in the canvas (4 rows for borders, filter, separator).
     auto const maxByCanvas = canvas.height() >= 5 ? static_cast<size_t>(canvas.height() - 4) : size_t { 1 };
-    auto const visibleCount = std::min({ maxVisibleItems, _filteredItems.size(), maxByCanvas });
+    auto const visibleCount = std::min({ MaxVisibleItems, _filteredItems.size(), maxByCanvas });
     _selection.setMaxVisible(visibleCount);
     _selection.ensureSelectedVisible(_filteredItems.size());
     auto const pickerWidth = calculateWidth(canvas.width());
@@ -113,9 +113,9 @@ Size FuzzyPickerPopup::preferredSize() const
     if (!visible())
         return { .width = 0, .height = 0 };
 
-    auto const visibleCount = std::min(maxVisibleItems, _filteredItems.size());
+    auto const visibleCount = std::min(MaxVisibleItems, _filteredItems.size());
     auto const height = static_cast<int>(visibleCount) + 4; // borders + filter + separator
-    return { .width = maxPickerWidth, .height = height };
+    return { .width = MaxPickerWidth, .height = height };
 }
 
 // ============================================================================
@@ -284,8 +284,8 @@ void FuzzyPickerPopup::refilter()
 
 int FuzzyPickerPopup::calculateWidth(int maxWidth) const
 {
-    auto const clampedMax = std::min(maxPickerWidth, maxWidth);
-    auto width = minPickerWidth;
+    auto const clampedMax = std::min(MaxPickerWidth, maxWidth);
+    auto width = MinPickerWidth;
 
     for (auto const& item: _filteredItems)
     {

--- a/src/tui/FuzzyPickerPopup.hpp
+++ b/src/tui/FuzzyPickerPopup.hpp
@@ -98,14 +98,14 @@ class FuzzyPickerPopup: public Component
     InputField _filterField;                            ///< Text input for filtering.
     std::vector<std::string> _allItems;                 ///< All available items (owned).
     std::vector<FilteredItem> _filteredItems;           ///< Filtered and sorted items.
-    ScrollableSelection _selection { maxVisibleItems }; ///< Selection and scroll state.
+    ScrollableSelection _selection { MaxVisibleItems }; ///< Selection and scroll state.
     int _renderedHeight = 0;                            ///< Last rendered height.
     int _renderedWidth = 0;                             ///< Last rendered width.
     std::string _title;                                 ///< Optional title for the filter prompt.
 
-    static constexpr size_t maxVisibleItems = 15; ///< Maximum number of visible items.
-    static constexpr int minPickerWidth = 50;     ///< Minimum picker width.
-    static constexpr int maxPickerWidth = 100;    ///< Maximum picker width.
+    static constexpr size_t MaxVisibleItems = 15; ///< Maximum number of visible items.
+    static constexpr int MinPickerWidth = 50;     ///< Minimum picker width.
+    static constexpr int MaxPickerWidth = 100;    ///< Maximum picker width.
 
     /// @brief Recomputes _filteredItems from _allItems and current filter text.
     void refilter();

--- a/src/tui/GenericSyntaxHighlighter.cpp
+++ b/src/tui/GenericSyntaxHighlighter.cpp
@@ -57,7 +57,7 @@ namespace
     // -------------------------------------------------------------------------
 
     // C++ keywords (sorted)
-    constexpr auto cppKeywords = std::to_array<std::string_view>({
+    constexpr auto CppKeywords = std::to_array<std::string_view>({
         "alignas",
         "alignof",
         "and",
@@ -155,7 +155,7 @@ namespace
     });
 
     // C++ standard library types (sorted)
-    constexpr auto cppTypes = std::to_array<std::string_view>({
+    constexpr auto CppTypes = std::to_array<std::string_view>({
         "array",      "atomic",   "basic_string", "deque",      "expected",      "function",      "future",
         "int16_t",    "int32_t",  "int64_t",      "int8_t",     "list",          "map",           "monostate",
         "multimap",   "multiset", "optional",     "pair",       "promise",       "ptrdiff_t",     "set",
@@ -165,7 +165,7 @@ namespace
     });
 
     // Python keywords (sorted)
-    constexpr auto pythonKeywords = std::to_array<std::string_view>({
+    constexpr auto PythonKeywords = std::to_array<std::string_view>({
         "False", "None",     "True",  "and",    "as",   "assert", "async",  "await",    "break",
         "class", "continue", "def",   "del",    "elif", "else",   "except", "finally",  "for",
         "from",  "global",   "if",    "import", "in",   "is",     "lambda", "nonlocal", "not",
@@ -173,7 +173,7 @@ namespace
     });
 
     // Python builtin functions (sorted)
-    constexpr auto pythonBuiltins = std::to_array<std::string_view>({
+    constexpr auto PythonBuiltins = std::to_array<std::string_view>({
         "abs",     "all",       "any",        "bin",          "bool",    "bytes",    "callable", "chr",
         "dict",    "dir",       "divmod",     "enumerate",    "eval",    "exec",     "filter",   "float",
         "format",  "frozenset", "getattr",    "globals",      "hasattr", "hash",     "hex",      "id",
@@ -185,7 +185,7 @@ namespace
     });
 
     // Bash keywords (sorted)
-    constexpr auto bashKeywords = std::to_array<std::string_view>({
+    constexpr auto BashKeywords = std::to_array<std::string_view>({
         "case",
         "do",
         "done",
@@ -204,7 +204,7 @@ namespace
     });
 
     // Bash builtin commands (sorted)
-    constexpr auto bashBuiltins = std::to_array<std::string_view>({
+    constexpr auto BashBuiltins = std::to_array<std::string_view>({
         "alias", "bg",       "bind",   "break",  "cd",      "command", "continue", "declare", "echo",
         "eval",  "exec",     "exit",   "export", "fg",      "getopts", "hash",     "help",    "history",
         "jobs",  "kill",     "let",    "local",  "logout",  "printf",  "pushd",    "popd",    "pwd",
@@ -213,7 +213,7 @@ namespace
     });
 
     // CMake commands (sorted)
-    constexpr auto cmakeKeywords = std::to_array<std::string_view>({
+    constexpr auto CmakeKeywords = std::to_array<std::string_view>({
         "add_compile_definitions",
         "add_compile_options",
         "add_custom_command",
@@ -280,7 +280,7 @@ namespace
     });
 
     // CMake variables/properties keywords (sorted)
-    constexpr auto cmakeTypes = std::to_array<std::string_view>({
+    constexpr auto CmakeTypes = std::to_array<std::string_view>({
         "AND",          "BOOL",     "CACHE",  "COMMAND",  "DEFINED",      "EXISTS",   "FATAL_ERROR",
         "FALSE",        "FILEPATH", "FORCE",  "IMPORTED", "INTERFACE",    "INTERNAL", "MATCHES",
         "NOT",          "OFF",      "ON",     "OR",       "PARENT_SCOPE", "PATH",     "PRIVATE",
@@ -289,14 +289,14 @@ namespace
     });
 
     // JSON keywords (sorted)
-    constexpr auto jsonKeywords = std::to_array<std::string_view>({
+    constexpr auto JsonKeywords = std::to_array<std::string_view>({
         "false",
         "null",
         "true",
     });
 
     // YAML keywords (sorted)
-    constexpr auto yamlKeywords = std::to_array<std::string_view>({
+    constexpr auto YamlKeywords = std::to_array<std::string_view>({
         "False",
         "No",
         "Null",
@@ -315,7 +315,7 @@ namespace
     });
 
     // x86 assembly instructions (sorted, lowercase)
-    constexpr auto asmInstructions = std::to_array<std::string_view>({
+    constexpr auto AsmInstructions = std::to_array<std::string_view>({
         "adc",    "add",    "and",    "bsf",     "bsr",    "bt",      "call",     "cbw",     "cdq",
         "cdqe",   "clc",    "cld",    "cli",     "cmova",  "cmovae",  "cmovb",    "cmovbe",  "cmovc",
         "cmove",  "cmovg",  "cmovge", "cmovl",   "cmovle", "cmovna",  "cmovnae",  "cmovnb",  "cmovnbe",
@@ -339,7 +339,7 @@ namespace
     });
 
     // x86 registers (sorted, lowercase — matching is case-insensitive)
-    constexpr auto asmRegisters = std::to_array<std::string_view>({
+    constexpr auto AsmRegisters = std::to_array<std::string_view>({
         "ah",    "al",     "ax",    "bh",    "bl",    "bp",    "bpl",   "bx",    "ch",    "cl",     "cr0",
         "cr2",   "cr3",    "cr4",   "cs",    "cx",    "dh",    "di",    "dil",   "dl",    "dr0",    "dr1",
         "dr2",   "dr3",    "dr6",   "dr7",   "ds",    "dx",    "eax",   "ebp",   "ebx",   "ecx",    "edi",
@@ -357,21 +357,21 @@ namespace
     });
 
     // x86 assembly directives — NASM/MASM style (sorted)
-    constexpr auto asmDirectives = std::to_array<std::string_view>({
+    constexpr auto AsmDirectives = std::to_array<std::string_view>({
         "align", "bits",   "byte",    "common",  "db",      "dd",    "dq",    "dw",    "dword",
         "equ",   "extern", "global",  "incbin",  "include", "org",   "qword", "resb",  "resd",
         "resq",  "resw",   "section", "segment", "times",   "use16", "use32", "use64", "word",
     });
 
     // AT&T/GAS directives (stored without leading dot, sorted)
-    constexpr auto asmGasDirectives = std::to_array<std::string_view>({
+    constexpr auto AsmGasDirectives = std::to_array<std::string_view>({
         "align",  "ascii", "asciz",        "bss",    "byte",  "comm",    "data", "endm",    "extern", "file",
         "global", "globl", "intel_syntax", "long",   "macro", "p2align", "quad", "section", "set",    "short",
         "size",   "skip",  "space",        "string", "text",  "type",    "weak", "word",    "zero",
     });
 
     // PowerShell keywords (sorted, lowercase — matched case-insensitively)
-    constexpr auto powershellKeywords = std::to_array<std::string_view>({
+    constexpr auto PowershellKeywords = std::to_array<std::string_view>({
         "begin",        "break",   "catch",   "class",    "continue", "data",   "define",   "do",
         "dynamicparam", "else",    "elseif",  "end",      "enum",     "exit",   "filter",   "finally",
         "for",          "foreach", "from",    "function", "hidden",   "if",     "in",       "inlinescript",
@@ -380,7 +380,7 @@ namespace
     });
 
     // PowerShell word operators (sorted, lowercase, stored without the leading dash)
-    constexpr auto powershellOperators = std::to_array<std::string_view>({
+    constexpr auto PowershellOperators = std::to_array<std::string_view>({
         "and",      "as",        "band",     "bnot",        "bor",    "bxor",    "ccontains", "ceq",
         "cge",      "cgt",       "cle",      "clike",       "clt",    "cmatch",  "cne",       "cnotcontains",
         "cnotlike", "cnotmatch", "contains", "creplace",    "csplit", "eq",      "f",         "ge",
@@ -390,7 +390,7 @@ namespace
     });
 
     // Windows CMD / batch keywords (sorted, lowercase — matched case-insensitively)
-    constexpr auto cmdKeywords = std::to_array<std::string_view>({
+    constexpr auto CmdKeywords = std::to_array<std::string_view>({
         "assoc",    "break",  "call",  "cd",    "chdir",  "cls",      "color",  "copy",   "date",
         "defined",  "del",    "dir",   "echo",  "else",   "endlocal", "equ",    "erase",  "errorlevel",
         "exist",    "exit",   "for",   "ftype", "geq",    "goto",     "gtr",    "if",     "in",
@@ -678,9 +678,9 @@ namespace
                     ++pos;
                 auto const word = line.substr(start, pos - start);
 
-                if (isInSortedArray(cppKeywords, word))
+                if (isInSortedArray(CppKeywords, word))
                     fillRange(map, start, pos - start, HighlightCategory::Keyword);
-                else if (isInSortedArray(cppTypes, word))
+                else if (isInSortedArray(CppTypes, word))
                     fillRange(map, start, pos - start, HighlightCategory::Type);
                 else if (word.starts_with("std"))
                     fillRange(map, start, pos - start, HighlightCategory::Type);
@@ -838,9 +838,9 @@ namespace
                     ++pos;
                 auto const word = line.substr(start, pos - start);
 
-                if (isInSortedArray(pythonKeywords, word))
+                if (isInSortedArray(PythonKeywords, word))
                     fillRange(map, start, pos - start, HighlightCategory::Keyword);
-                else if (isInSortedArray(pythonBuiltins, word))
+                else if (isInSortedArray(PythonBuiltins, word))
                     fillRange(map, start, pos - start, HighlightCategory::Function);
                 continue;
             }
@@ -982,9 +982,9 @@ namespace
                     ++pos;
                 auto const word = line.substr(start, pos - start);
 
-                if (isInSortedArray(bashKeywords, word))
+                if (isInSortedArray(BashKeywords, word))
                     fillRange(map, start, pos - start, HighlightCategory::Keyword);
-                else if (isInSortedArray(bashBuiltins, word))
+                else if (isInSortedArray(BashBuiltins, word))
                     fillRange(map, start, pos - start, HighlightCategory::Function);
                 continue;
             }
@@ -1091,9 +1091,9 @@ namespace
                     ++pos;
                 auto const word = line.substr(start, pos - start);
 
-                if (isInSortedArray(cmakeKeywords, word))
+                if (isInSortedArray(CmakeKeywords, word))
                     fillRange(map, start, pos - start, HighlightCategory::Keyword);
-                else if (isInSortedArray(cmakeTypes, word))
+                else if (isInSortedArray(CmakeTypes, word))
                     fillRange(map, start, pos - start, HighlightCategory::Type);
                 continue;
             }
@@ -1252,7 +1252,7 @@ namespace
                 while (pos < len && (line[pos] >= 'a' && line[pos] <= 'z'))
                     ++pos;
                 auto const word = line.substr(start, pos - start);
-                if (isInSortedArray(jsonKeywords, word))
+                if (isInSortedArray(JsonKeywords, word))
                     fillRange(map, start, pos - start, HighlightCategory::Keyword);
                 continue;
             }
@@ -1344,7 +1344,7 @@ namespace
                         while (!trimmed.empty() && (trimmed.back() == ' ' || trimmed.back() == '\t'))
                             trimmed.remove_suffix(1);
 
-                        if (isInSortedArray(yamlKeywords, trimmed))
+                        if (isInSortedArray(YamlKeywords, trimmed))
                             fillRange(map, pos, valueEnd - pos, HighlightCategory::Keyword);
                         else if (!trimmed.empty()
                                  && (isDigit(trimmed[0])
@@ -1365,7 +1365,7 @@ namespace
                 }
                 // Not a key, check if it's a keyword value
                 auto const word = line.substr(start, pos - start);
-                if (isInSortedArray(yamlKeywords, word))
+                if (isInSortedArray(YamlKeywords, word))
                     fillRange(map, start, pos - start, HighlightCategory::Keyword);
                 continue;
             }
@@ -1575,7 +1575,7 @@ namespace
                 auto const directive = line.substr(start + 1, pos - start - 1);
                 char lowerBuf[64];
                 auto const lowerDirective = toLowerInto(directive, lowerBuf);
-                if (isInSortedArray(asmGasDirectives, lowerDirective))
+                if (isInSortedArray(AsmGasDirectives, lowerDirective))
                     fillRange(map, start, pos - start, HighlightCategory::Preprocessor);
                 continue;
             }
@@ -1592,7 +1592,7 @@ namespace
                 auto const regName = line.substr(start + 1, pos - start - 1);
                 char lowerBuf[64];
                 auto const lowerReg = toLowerInto(regName, lowerBuf);
-                if (isInSortedArray(asmRegisters, lowerReg))
+                if (isInSortedArray(AsmRegisters, lowerReg))
                     fillRange(map, start, pos - start, HighlightCategory::Variable);
                 continue;
             }
@@ -1646,19 +1646,19 @@ namespace
                 auto const lower = toLowerInto(word, lowerBuf);
 
                 // Check instructions, including AT&T suffix stripping (b/w/l/q)
-                auto isInstruction = isInSortedArray(asmInstructions, lower);
+                auto isInstruction = isInSortedArray(AsmInstructions, lower);
                 if (!isInstruction && lower.size() > 1)
                 {
                     auto const lastCh = lower.back();
                     if (lastCh == 'b' || lastCh == 'w' || lastCh == 'l' || lastCh == 'q')
-                        isInstruction = isInSortedArray(asmInstructions, lower.substr(0, lower.size() - 1));
+                        isInstruction = isInSortedArray(AsmInstructions, lower.substr(0, lower.size() - 1));
                 }
 
                 if (isInstruction)
                     fillRange(map, start, pos - start, HighlightCategory::Keyword);
-                else if (isInSortedArray(asmRegisters, lower))
+                else if (isInSortedArray(AsmRegisters, lower))
                     fillRange(map, start, pos - start, HighlightCategory::Variable);
-                else if (isInSortedArray(asmDirectives, lower))
+                else if (isInSortedArray(AsmDirectives, lower))
                     fillRange(map, start, pos - start, HighlightCategory::Preprocessor);
                 continue;
             }
@@ -1782,7 +1782,7 @@ namespace
                 auto const word = line.substr(wordStart, pos - wordStart);
                 std::array<char, 64> buf {};
                 auto const lower = word.size() <= buf.size() ? toLowerInto(word, buf.data()) : word;
-                if (isInSortedArray(powershellOperators, lower))
+                if (isInSortedArray(PowershellOperators, lower))
                     fillRange(map, start, pos - start, HighlightCategory::Operator);
                 // Otherwise a parameter name like -Path — left as default text.
                 continue;
@@ -1853,7 +1853,7 @@ namespace
                 auto const word = line.substr(start, pos - start);
                 std::array<char, 64> buf {};
                 auto const lower = word.size() <= buf.size() ? toLowerInto(word, buf.data()) : word;
-                if (isInSortedArray(powershellKeywords, lower))
+                if (isInSortedArray(PowershellKeywords, lower))
                     fillRange(map, start, pos - start, HighlightCategory::Keyword);
                 else if (word.find('-') != std::string_view::npos)
                     fillRange(map, start, pos - start, HighlightCategory::Function);
@@ -2006,7 +2006,7 @@ namespace
                 auto const word = line.substr(start, pos - start);
                 std::array<char, 32> buf {};
                 auto const lower = word.size() <= buf.size() ? toLowerInto(word, buf.data()) : word;
-                if (isInSortedArray(cmdKeywords, lower))
+                if (isInSortedArray(CmdKeywords, lower))
                     fillRange(map, start, pos - start, HighlightCategory::Keyword);
                 continue;
             }

--- a/src/tui/HoverState.hpp
+++ b/src/tui/HoverState.hpp
@@ -37,10 +37,10 @@ class HoverState
     using LeaveCallback = std::function<void()>;
 
     /// @brief Default hover delay (500ms).
-    static constexpr auto defaultHoverDelay = std::chrono::milliseconds(500);
+    static constexpr auto DefaultHoverDelay = std::chrono::milliseconds(500);
 
     /// @brief Constructs HoverState with the specified delay.
-    explicit HoverState(std::chrono::milliseconds delay = defaultHoverDelay);
+    explicit HoverState(std::chrono::milliseconds delay = DefaultHoverDelay);
 
     /// @brief Called when the mouse moves.
     /// @param x Mouse X position (1-based).

--- a/src/tui/ImageLoader.cpp
+++ b/src/tui/ImageLoader.cpp
@@ -193,7 +193,7 @@ auto readClipboardImage() -> std::optional<ClipboardImage>
         char const* mediaType;
     };
 
-    static constexpr auto queries = std::array<ClipboardQuery, 3> { {
+    static constexpr auto Queries = std::array<ClipboardQuery, 3> { {
         { .waylandCommand = "wl-paste --no-newline --type image/png 2>/dev/null",
           .x11Command = "xclip -selection clipboard -target image/png -o 2>/dev/null",
           .mediaType = "image/png" },
@@ -207,7 +207,7 @@ auto readClipboardImage() -> std::optional<ClipboardImage>
 
     auto const isWayland = std::getenv("WAYLAND_DISPLAY") != nullptr;
 
-    for (auto const& query: queries)
+    for (auto const& query: Queries)
     {
         auto const* command = isWayland ? query.waylandCommand : query.x11Command;
         auto data = runCommandAndCapture(command);

--- a/src/tui/ImageLoader_test.cpp
+++ b/src/tui/ImageLoader_test.cpp
@@ -264,12 +264,12 @@ TEST_CASE("ImageLoader.loadImage_invalid_data")
 TEST_CASE("ImageLoader.resizeImage_downscale")
 {
     // Create a 100x100 test image
-    auto constexpr srcWidth = 100;
-    auto constexpr srcHeight = 100;
+    auto constexpr SrcWidth = 100;
+    auto constexpr SrcHeight = 100;
     auto image = OwnedImage {
-        .pixels = std::vector<std::uint8_t>(srcWidth * srcHeight * 4, 128),
-        .width = srcWidth,
-        .height = srcHeight,
+        .pixels = std::vector<std::uint8_t>(SrcWidth * SrcHeight * 4, 128),
+        .width = SrcWidth,
+        .height = SrcHeight,
     };
 
     auto const result = resizeImage(image, 50, 50);

--- a/src/tui/KeyBindings.cpp
+++ b/src/tui/KeyBindings.cpp
@@ -34,7 +34,7 @@ namespace
         KeyCode code;
     };
 
-    constexpr std::array<KeyNameMapping, 26> keyNameMappings = { {
+    constexpr std::array<KeyNameMapping, 26> KeyNameMappings = { {
         { .name = "enter", .code = KeyCode::Enter },   { .name = "return", .code = KeyCode::Enter },
         { .name = "tab", .code = KeyCode::Tab },       { .name = "backspace", .code = KeyCode::Backspace },
         { .name = "delete", .code = KeyCode::Delete }, { .name = "del", .code = KeyCode::Delete },
@@ -51,7 +51,7 @@ namespace
     } };
 
     // More function keys
-    constexpr std::array<KeyNameMapping, 3> moreKeyNameMappings = { {
+    constexpr std::array<KeyNameMapping, 3> MoreKeyNameMappings = { {
         { .name = "f10", .code = KeyCode::F10 },
         { .name = "f11", .code = KeyCode::F11 },
         { .name = "f12", .code = KeyCode::F12 },
@@ -59,12 +59,12 @@ namespace
 
     std::optional<KeyCode> parseSpecialKey(std::string_view name)
     {
-        for (auto const& mapping: keyNameMappings)
+        for (auto const& mapping: KeyNameMappings)
         {
             if (equalsIgnoreCase(name, mapping.name))
                 return mapping.code;
         }
-        for (auto const& mapping: moreKeyNameMappings)
+        for (auto const& mapping: MoreKeyNameMappings)
         {
             if (equalsIgnoreCase(name, mapping.name))
                 return mapping.code;
@@ -74,12 +74,12 @@ namespace
 
     std::string_view keyCodeToString(KeyCode code)
     {
-        for (auto const& mapping: keyNameMappings)
+        for (auto const& mapping: KeyNameMappings)
         {
             if (mapping.code == code)
                 return mapping.name;
         }
-        for (auto const& mapping: moreKeyNameMappings)
+        for (auto const& mapping: MoreKeyNameMappings)
         {
             if (mapping.code == code)
                 return mapping.name;
@@ -95,7 +95,7 @@ namespace
         EditAction action;
     };
 
-    constexpr std::array<ActionNameMapping, 41> actionNameMappings = { {
+    constexpr std::array<ActionNameMapping, 41> ActionNameMappings = { {
         // Movement
         { .name = "move-forward-char",
           .description = "Move cursor forward one character",
@@ -346,7 +346,7 @@ bool KeyChord::matches(KeyEvent const& event) const noexcept
 
 std::optional<EditAction> parseEditAction(std::string_view str)
 {
-    for (auto const& mapping: actionNameMappings)
+    for (auto const& mapping: ActionNameMappings)
     {
         if (equalsIgnoreCase(str, mapping.name))
             return mapping.action;
@@ -356,7 +356,7 @@ std::optional<EditAction> parseEditAction(std::string_view str)
 
 std::string_view editActionToString(EditAction action) noexcept
 {
-    for (auto const& mapping: actionNameMappings)
+    for (auto const& mapping: ActionNameMappings)
     {
         if (mapping.action == action)
             return mapping.name;
@@ -367,8 +367,8 @@ std::string_view editActionToString(EditAction action) noexcept
 std::vector<EditActionInfo> allEditActionNames()
 {
     std::vector<EditActionInfo> infos;
-    infos.reserve(actionNameMappings.size());
-    for (auto const& mapping: actionNameMappings)
+    infos.reserve(ActionNameMappings.size());
+    for (auto const& mapping: ActionNameMappings)
         infos.push_back({ .name = mapping.name, .description = mapping.description });
     return infos;
 }
@@ -376,10 +376,10 @@ std::vector<EditActionInfo> allEditActionNames()
 std::vector<std::string_view> allKeyNames()
 {
     std::vector<std::string_view> names;
-    names.reserve(keyNameMappings.size() + moreKeyNameMappings.size());
-    for (auto const& mapping: keyNameMappings)
+    names.reserve(KeyNameMappings.size() + MoreKeyNameMappings.size());
+    for (auto const& mapping: KeyNameMappings)
         names.push_back(mapping.name);
-    for (auto const& mapping: moreKeyNameMappings)
+    for (auto const& mapping: MoreKeyNameMappings)
         names.push_back(mapping.name);
     return names;
 }

--- a/src/tui/MarkdownRenderer.cpp
+++ b/src/tui/MarkdownRenderer.cpp
@@ -810,14 +810,14 @@ void MarkdownRenderer::renderTableCompact(ParsedTable const& table, bool showHea
             widths[static_cast<std::size_t>(lastCol)] = available;
     }
 
-    constexpr auto indent = "  ";
-    constexpr auto gap = "  ";
+    constexpr auto Indent = "  ";
+    constexpr auto Gap = "  ";
 
     // Helper: render a single physical line of a (possibly wrapped) row.
     auto renderPhysicalLine = [&](std::vector<std::string> const& cellTexts,
                                   Style const& cellStyle,
                                   std::size_t rowIdx) {
-        _output.writeRaw(indent);
+        _output.writeRaw(Indent);
         for (std::size_t col = 0; col < table.columnCount; ++col)
         {
             auto const& rawText = (col < cellTexts.size()) ? cellTexts[col] : std::string {};
@@ -852,7 +852,7 @@ void MarkdownRenderer::renderTableCompact(ParsedTable const& table, bool showHea
             renderInline(text, &effectiveStyle);
             _output.writeRaw(std::string(static_cast<std::size_t>(rightPad), ' '));
             if (col + 1 < table.columnCount)
-                _output.writeRaw(gap);
+                _output.writeRaw(Gap);
         }
         _output.writeRaw("\n");
     };
@@ -900,13 +900,13 @@ void MarkdownRenderer::renderTableCompact(ParsedTable const& table, bool showHea
     // Underline separator.
     if (showHeader)
     {
-        _output.writeRaw(indent);
+        _output.writeRaw(Indent);
         for (std::size_t col = 0; col < table.columnCount; ++col)
         {
             auto const underline = std::string(static_cast<std::size_t>(widths[col]), '-');
             _output.writeText(underline, _theme.tableBorder);
             if (col + 1 < table.columnCount)
-                _output.writeRaw(gap);
+                _output.writeRaw(Gap);
         }
         _output.writeRaw("\n");
     }

--- a/src/tui/MarkdownTable.cpp
+++ b/src/tui/MarkdownTable.cpp
@@ -222,7 +222,7 @@ void constrainColumnWidths(std::vector<int>& widths, int maxTableWidth)
 
     // Waterfall algorithm: only shrink the widest columns, preserving narrow ones.
     // Reduced columns merge into the next tier so all equally-wide columns shrink together.
-    auto constexpr minWidth = 3;
+    auto constexpr MinWidth = 3;
     auto excess = totalContent - availableContent;
 
     // Build sorted indices by width descending.
@@ -243,8 +243,8 @@ void constrainColumnWidths(std::vector<int>& widths, int maxTableWidth)
         auto const tierCount = static_cast<int>(j - i);
 
         // Target: next tier's width, or minWidth if this is the last tier.
-        auto const nextTierWidth = (j < indices.size()) ? widths[indices[j]] : minWidth;
-        auto const target = std::max(nextTierWidth, minWidth);
+        auto const nextTierWidth = (j < indices.size()) ? widths[indices[j]] : MinWidth;
+        auto const target = std::max(nextTierWidth, MinWidth);
         auto const reductionPerCol = tierWidth - target;
         auto const maxTierReduction = reductionPerCol * tierCount;
 
@@ -269,7 +269,7 @@ void constrainColumnWidths(std::vector<int>& widths, int maxTableWidth)
                 widths[indices[k]] = target;
             excess -= maxTierReduction;
 
-            if (target <= minWidth)
+            if (target <= MinWidth)
                 break; // Cannot reduce further.
 
             // Don't advance i — reduced columns merge with the next tier.

--- a/src/tui/Tooltip.cpp
+++ b/src/tui/Tooltip.cpp
@@ -102,8 +102,8 @@ void Tooltip::render(Canvas& canvas)
                boxStyle); // U+2518 BOX DRAWINGS LIGHT UP AND LEFT
 
     // Render content
-    auto contentCanvas = canvas.subcanvas(Rect { .x = borderWidth + padding,
-                                                 .y = borderWidth,
+    auto contentCanvas = canvas.subcanvas(Rect { .x = BorderWidth + Padding,
+                                                 .y = BorderWidth,
                                                  .width = contentArea.width,
                                                  .height = contentArea.height });
     _styledContent.renderTo(contentCanvas, _scrollOffset, contentArea.height);
@@ -142,8 +142,8 @@ Size Tooltip::preferredSize() const
     int const contentHeight = _styledContent.lineCount();
 
     // Add border and padding
-    int const totalWidth = contentWidth + (2 * (borderWidth + padding));
-    int const totalHeight = contentHeight + (2 * borderWidth);
+    int const totalWidth = contentWidth + (2 * (BorderWidth + Padding));
+    int const totalHeight = contentHeight + (2 * BorderWidth);
 
     // Clamp to max size
     return { .width = std::min(totalWidth, _maxSize.width),
@@ -159,7 +159,7 @@ void Tooltip::parseContent()
     }
 
     // Calculate content width for wrapping
-    int const wrapWidth = _maxSize.width - (2 * (borderWidth + padding));
+    int const wrapWidth = _maxSize.width - (2 * (BorderWidth + Padding));
 
     if (_contentType == TooltipContentType::Markdown)
     {
@@ -174,8 +174,8 @@ void Tooltip::parseContent()
 Size Tooltip::contentAreaSize() const
 {
     auto const pref = preferredSize();
-    return { .width = std::max(0, pref.width - (2 * (borderWidth + padding))),
-             .height = std::max(0, pref.height - (2 * borderWidth)) };
+    return { .width = std::max(0, pref.width - (2 * (BorderWidth + Padding))),
+             .height = std::max(0, pref.height - (2 * BorderWidth)) };
 }
 
 void Tooltip::renderScrollIndicators(Canvas& canvas) const

--- a/src/tui/Tooltip.hpp
+++ b/src/tui/Tooltip.hpp
@@ -102,8 +102,8 @@ class Tooltip: public Component
     int _scrollOffset = 0;
 
     // Border and padding
-    static constexpr int borderWidth = 1;
-    static constexpr int padding = 1;
+    static constexpr int BorderWidth = 1;
+    static constexpr int Padding = 1;
 
     /// @brief Reparses the content after settings change.
     void parseContent();

--- a/src/tui/TreeTableView.cpp
+++ b/src/tui/TreeTableView.cpp
@@ -220,7 +220,7 @@ EventResult TreeTableView::onEvent(InputEvent const& event)
 
             auto const now = std::chrono::steady_clock::now();
             auto const isDoubleClick =
-                _hadClick && _lastClickRow == *index && (now - _lastClickTime) <= kDoubleClickInterval;
+                _hadClick && _lastClickRow == *index && (now - _lastClickTime) <= DoubleClickInterval;
 
             selectIndex(*index);
 

--- a/src/tui/TreeTableView.hpp
+++ b/src/tui/TreeTableView.hpp
@@ -191,7 +191,7 @@ class TreeTableView: public Component
     std::size_t _lastClickRow = 0;                        ///< Row index of the prior left-press.
     std::chrono::steady_clock::time_point _lastClickTime; ///< When the prior left-press happened.
 
-    static constexpr auto kDoubleClickInterval = std::chrono::milliseconds { 400 };
+    static constexpr auto DoubleClickInterval = std::chrono::milliseconds { 400 };
 };
 
 } // namespace tui

--- a/src/tui/VtParser.cpp
+++ b/src/tui/VtParser.cpp
@@ -1000,9 +1000,9 @@ void VtParser::dispatchCsi(char finalByte, std::vector<InputEvent>& events)
         // VK_SPACE: always emit U+0020 (UC may be 0 with Ctrl held)
         if (vkCode == vk::Space)
         {
-            constexpr auto cp = U' ';
+            constexpr auto Cp = U' ';
             events.emplace_back(
-                KeyEvent { .key = keyCodeFromCodepoint(cp), .modifiers = mods, .codepoint = cp });
+                KeyEvent { .key = keyCodeFromCodepoint(Cp), .modifiers = mods, .codepoint = Cp });
             return;
         }
 

--- a/src/tui/platform/Terminal.cpp
+++ b/src/tui/platform/Terminal.cpp
@@ -93,8 +93,8 @@ auto Terminal::initialize() -> VoidResult
     {
         _output->writeRaw("\033[?996n"); // CSI ? 996 n — query color scheme
         _output->flush();
-        auto constexpr totalTimeout = std::chrono::milliseconds(100);
-        auto const deadline = std::chrono::steady_clock::now() + totalTimeout;
+        auto constexpr TotalTimeout = std::chrono::milliseconds(100);
+        auto const deadline = std::chrono::steady_clock::now() + TotalTimeout;
         while (_colorScheme == ColorScheme::Unknown)
         {
             auto const now = std::chrono::steady_clock::now();
@@ -199,8 +199,8 @@ auto Terminal::queryCursorPosition() -> std::pair<int, int>
 
     // Poll with a deadline loop. The ColorSchemeReport from enableProtocols() may arrive
     // before the CursorPositionReport, so we keep polling until we find a CPR or time out.
-    auto constexpr totalTimeout = std::chrono::milliseconds(100);
-    auto const deadline = std::chrono::steady_clock::now() + totalTimeout;
+    auto constexpr TotalTimeout = std::chrono::milliseconds(100);
+    auto const deadline = std::chrono::steady_clock::now() + TotalTimeout;
 
     while (true)
     {
@@ -242,8 +242,8 @@ auto Terminal::queryCellSize() -> std::pair<int, int>
     _output->requestCellSize();
     _output->flush();
 
-    auto constexpr totalTimeout = std::chrono::milliseconds(100);
-    auto const deadline = std::chrono::steady_clock::now() + totalTimeout;
+    auto constexpr TotalTimeout = std::chrono::milliseconds(100);
+    auto const deadline = std::chrono::steady_clock::now() + TotalTimeout;
 
     while (true)
     {
@@ -285,8 +285,8 @@ auto Terminal::queryDecMode(int mode) -> bool
     _output->requestDecMode(mode);
     _output->flush();
 
-    auto constexpr totalTimeout = std::chrono::milliseconds(100);
-    auto const deadline = std::chrono::steady_clock::now() + totalTimeout;
+    auto constexpr TotalTimeout = std::chrono::milliseconds(100);
+    auto const deadline = std::chrono::steady_clock::now() + TotalTimeout;
 
     while (true)
     {

--- a/src/tui/platform/TerminalWin32.cpp
+++ b/src/tui/platform/TerminalWin32.cpp
@@ -69,8 +69,8 @@ auto Terminal::initialize() -> VoidResult
     {
         _output->writeRaw("\033[?996n"); // CSI ? 996 n — query color scheme
         _output->flush();
-        auto constexpr totalTimeout = std::chrono::milliseconds(100);
-        auto const deadline = std::chrono::steady_clock::now() + totalTimeout;
+        auto constexpr TotalTimeout = std::chrono::milliseconds(100);
+        auto const deadline = std::chrono::steady_clock::now() + TotalTimeout;
         while (_colorScheme == ColorScheme::Unknown)
         {
             auto const now = std::chrono::steady_clock::now();
@@ -168,8 +168,8 @@ auto Terminal::queryCursorPosition() -> std::pair<int, int>
     _output->requestCursorPosition();
     _output->flush();
 
-    auto constexpr totalTimeout = std::chrono::milliseconds(100);
-    auto const deadline = std::chrono::steady_clock::now() + totalTimeout;
+    auto constexpr TotalTimeout = std::chrono::milliseconds(100);
+    auto const deadline = std::chrono::steady_clock::now() + TotalTimeout;
 
     while (true)
     {
@@ -207,8 +207,8 @@ auto Terminal::queryCellSize() -> std::pair<int, int>
     _output->requestCellSize();
     _output->flush();
 
-    auto constexpr totalTimeout = std::chrono::milliseconds(100);
-    auto const deadline = std::chrono::steady_clock::now() + totalTimeout;
+    auto constexpr TotalTimeout = std::chrono::milliseconds(100);
+    auto const deadline = std::chrono::steady_clock::now() + TotalTimeout;
 
     while (true)
     {

--- a/src/tui/runtime/TuiRuntime_test.cpp
+++ b/src/tui/runtime/TuiRuntime_test.cpp
@@ -234,10 +234,10 @@ TEST_CASE("Interrupt cancels a flow parked on input", "[TuiRuntime]")
     source.pushInterrupt();
     auto runtime = TuiRuntime { source };
 
-    constexpr auto sentinel = -99;
-    auto const result = runtime.blockOn(awaitKeyOrCancel(&runtime, sentinel));
+    constexpr auto Sentinel = -99;
+    auto const result = runtime.blockOn(awaitKeyOrCancel(&runtime, Sentinel));
 
-    REQUIRE(result == sentinel);
+    REQUIRE(result == Sentinel);
 }
 
 TEST_CASE("delay(0) resumes without waiting", "[TuiRuntime]")
@@ -257,10 +257,10 @@ TEST_CASE("A pending delay bounds the wait timeout", "[TuiRuntime]")
     source.pushInterrupt(); // end the test before the 500ms elapses
     auto runtime = TuiRuntime { source };
 
-    constexpr auto sentinel = -7;
-    auto const result = runtime.blockOn(awaitDelayOrCancel(&runtime, sentinel));
+    constexpr auto Sentinel = -7;
+    auto const result = runtime.blockOn(awaitDelayOrCancel(&runtime, Sentinel));
 
-    REQUIRE(result == sentinel);
+    REQUIRE(result == Sentinel);
     REQUIRE(source.waitCount() >= 1);
     // The first wait is bounded by the pending timer, not an indefinite (-1) block.
     auto const firstTimeout = source.recordedTimeouts().front();


### PR DESCRIPTION
## What

Removes the `k`-prefix convention for constants and enforces `CamelCase` (PascalCase) for both
file-scope constexpr variables and static class constants, project-wide (only the vendored
`crispy` library is excluded).

## How

- **`.clang-tidy`**: two new `readability-identifier-naming` rules —
  `ConstexprVariableCase: CamelCase` and `ClassConstantCase: CamelCase`. `HeaderFilterRegex` is
  widened to cover every first-party source dir (`coro`, `testing`, `endo-test`, `vtparser`, … —
  everything except `crispy`), so the convention is enforced in all our headers.
- The renames (e.g. `kCpOptions` → `CpOptions`, `maxVisibleItems` → `MaxVisibleItems`,
  `kCtrlBreakEvent` → `CtrlBreakEvent`) were applied **semantically via `clang-tidy --fix`**, so
  constexpr *functions* and *operators* are untouched — only variables/constants are renamed.

## Sync with tuidu

This mirrors the identical change in the sibling **tuidu** project. The shared vendored
`coro` / `platform` / `tui` sources remain **byte-for-byte in sync** between the two repos
(verified: all 218 shared files content-identical).

## Verification

- `clangcl-debug` build: clean.
- Full test suite: **17/17 test targets pass**.
- `clang-tidy` naming check: 0 remaining violations across all first-party dirs.
- Widening `HeaderFilterRegex` surfaces no new non-naming findings in the newly-covered dirs.
- `clang-format` 21 gate: passes.

---
Companion PR (the source of this change, in the sibling project): contour-terminal/tuidu#4