### PR TITLE
feat(win): drive the console in UTF-8 and list filenames losslessly

### DIFF
--- a/src/platform/windows/WindowsFileInfoProvider.cpp
+++ b/src/platform/windows/WindowsFileInfoProvider.cpp
@@ -19,13 +19,27 @@ namespace
 
     namespace fs = std::filesystem;
 
+    /// Losslessly renders a path as a UTF-8 std::string.
+    ///
+    /// path::string() converts to the process's narrow (ANSI) code page and throws
+    /// std::system_error on any character the code page cannot represent — fatal when
+    /// listing a directory that holds such a name. path::u8string() encodes the full
+    /// Unicode path as UTF-8 and never throws, so we use it and reinterpret the bytes.
+    /// @param p The path to convert.
+    /// @return The path encoded as UTF-8.
+    [[nodiscard]] std::string toUtf8(fs::path const& p)
+    {
+        auto const u8 = p.u8string();
+        return std::string { reinterpret_cast<char const*>(u8.data()), u8.size() };
+    }
+
     /// Populates a FileEntry from a filesystem directory_entry.
     /// @return true on success, false if the entry could not be stat'd.
     [[nodiscard]] bool statEntry(fs::directory_entry const& dirEntry, FileEntry& fileEntry)
     {
         std::error_code ec;
 
-        fileEntry.name = dirEntry.path().filename().string();
+        fileEntry.name = toUtf8(dirEntry.path().filename());
 
         // status() follows reparse points. App Execution Aliases (winget, Microsoft Store
         // python, …) are reparse points that cannot be opened or followed through normal

--- a/src/tui/TerminalInput.hpp
+++ b/src/tui/TerminalInput.hpp
@@ -132,6 +132,8 @@ class TerminalInput
     HANDLE _hStdout = INVALID_HANDLE_VALUE;
     DWORD _originalInputMode = 0;
     DWORD _originalOutputMode = 0;
+    UINT _originalOutputCp = 0;    ///< Console output code page to restore on shutdown (0 = not saved).
+    UINT _originalInputCp = 0;     ///< Console input code page to restore on shutdown (0 = not saved).
     HANDLE _resizeEvent = nullptr; ///< Manual-reset event for resize notification.
 #else
     int _fd = 0;    // STDIN_FILENO

--- a/src/tui/platform/TerminalInputWin32.cpp
+++ b/src/tui/platform/TerminalInputWin32.cpp
@@ -37,6 +37,12 @@ auto TerminalInput::initialize() -> VoidResult
     if (!GetConsoleMode(_hStdout, &_originalOutputMode))
         return makeError(ErrorCode::IoError, "Failed to get console output mode");
 
+    // Save the original console code pages so raw mode can switch them to UTF-8 and shutdown
+    // can restore them. We emit UTF-8 throughout, so the console must interpret our output as
+    // UTF-8 (otherwise multibyte sequences render as mojibake under the default OEM code page).
+    _originalOutputCp = GetConsoleOutputCP();
+    _originalInputCp = GetConsoleCP();
+
     // Create a manual-reset event for resize notification
     _resizeEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
     if (_resizeEvent == nullptr)
@@ -230,6 +236,11 @@ void TerminalInput::enableRawMode()
         ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN;
     SetConsoleMode(_hStdout, outputMode);
 
+    // Drive the console in UTF-8 so the UTF-8 bytes we write render correctly and typed
+    // Unicode is delivered as UTF-8.
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
+
     _rawMode = true;
 }
 
@@ -239,6 +250,10 @@ void TerminalInput::disableRawMode()
     {
         SetConsoleMode(_hStdin, _originalInputMode);
         SetConsoleMode(_hStdout, _originalOutputMode);
+        if (_originalOutputCp != 0)
+            SetConsoleOutputCP(_originalOutputCp);
+        if (_originalInputCp != 0)
+            SetConsoleCP(_originalInputCp);
         _rawMode = false;
     }
 }


### PR DESCRIPTION
## Motivation

Two Windows-specific UTF-8 gaps, surfaced while fixing a crash in the sibling `tuidu` project (contour-terminal/tuidu#5):

1. The console **output code page** defaults to the OEM code page, so the UTF-8 bytes the TUI emits render as mojibake.
2. `std::filesystem::path::string()` converts to the legacy **ANSI** code page and throws `std::system_error` (*"No mapping for the Unicode character exists in the target multi-byte code page"*) on any filename it can't represent — which can abort a directory listing.

## Changes

- **`TerminalInput`** — set `SetConsoleOutputCP`/`SetConsoleCP(CP_UTF8)` when entering raw mode and restore the original code pages on shutdown, so the UTF-8 we write to the shell is interpreted correctly. This complements the existing `activeCodePage=UTF-8` process manifest (`endo.manifest`), which forces the *process* ACP; this PR forces the *console* code page.
- **`WindowsFileInfoProvider`** — build entry names via `path::u8string()` (lossless UTF-8, never throws) instead of ANSI `path::string()`.

## Notes

These files are vendored byte-for-byte with tuidu; this PR mirrors the identical change. Windows-only (`#ifdef _WIN32`); POSIX paths untouched.

## Verification

`clangcl-release` full build + test suite green (17/17) on Windows.

## Risk

Low — Windows-only, additive, with save/restore of prior console state.