### PR TITLE
Fix case-insensitive path handling, staged Tab completion, and contiguous-substring fuzzy match

### DIFF
--- a/src/platform/NativeFileSystem.cpp
+++ b/src/platform/NativeFileSystem.cpp
@@ -248,7 +248,8 @@ namespace
             // Second hop failed: restore the original name so the entry is not stranded
             // under the temporary. Best-effort — the reported error stays the second hop's.
             std::error_code rollbackError;
-            fs::rename(candidate, from, rollbackError);
+            auto const& originalName = from;
+            fs::rename(candidate, originalName, rollbackError);
             return false;
         }
         ec = std::make_error_code(std::errc::file_exists);

--- a/src/platform/NativeFileSystem.cpp
+++ b/src/platform/NativeFileSystem.cpp
@@ -5,9 +5,13 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <ranges>
 #include <sstream>
+#include <string>
+#include <system_error>
 
 #include <platform/NativeFileSystem.hpp>
+#include <platform/PathUtils.hpp>
 
 #if !defined(_WIN32)
     #include <unistd.h>
@@ -205,14 +209,75 @@ std::expected<void, std::string> NativeFileSystem::copyFile(fs::path const& from
     return {};
 }
 
+namespace
+{
+
+    /// Renames @p from to @p to in two hops via a unique temporary name in the
+    /// destination's parent directory.
+    ///
+    /// Used to perform a lettercase-only rename (e.g. `foo` -> `Foo`) on case-insensitive
+    /// filesystems, where a direct rename is rejected because source and destination
+    /// resolve to the same entry. A free temporary name is found in the destination's
+    /// directory, the entry is moved there, then moved on to its final name. If the second
+    /// hop fails the entry is rolled back to its original name so it is never stranded under
+    /// the temporary.
+    ///
+    /// @param from The existing source entry.
+    /// @param to The desired destination, in the same directory and differing only in case.
+    /// @param ec Set to the error that aborted the operation; cleared on success.
+    /// @return True on success, false otherwise (with @p ec describing the failure).
+    [[nodiscard]] bool renameViaTemporary(fs::path const& from, fs::path const& to, std::error_code& ec)
+    {
+        auto const parent = to.parent_path();
+        auto const baseName = to.filename().string();
+        for (auto const attempt: std::views::iota(0, 1000))
+        {
+            auto const candidate = parent / (baseName + ".endo-recase-" + std::to_string(attempt));
+            if (fs::exists(candidate, ec))
+                continue;
+            ec.clear();
+
+            fs::rename(from, candidate, ec);
+            if (ec)
+                return false;
+
+            fs::rename(candidate, to, ec);
+            if (!ec)
+                return true;
+
+            // Second hop failed: restore the original name so the entry is not stranded
+            // under the temporary. Best-effort — the reported error stays the second hop's.
+            std::error_code rollbackError;
+            fs::rename(candidate, from, rollbackError);
+            return false;
+        }
+        ec = std::make_error_code(std::errc::file_exists);
+        return false;
+    }
+
+} // namespace
+
 std::expected<void, std::string> NativeFileSystem::rename(fs::path const& from, fs::path const& to) const
 {
     std::error_code ec;
     fs::rename(from, to, ec);
-    if (ec)
-        return std::unexpected(
-            std::format("Cannot rename '{}' to '{}': {}", from.string(), to.string(), ec.message()));
-    return {};
+    if (!ec)
+        return {};
+
+    // On case-insensitive filesystems (Windows, the default macOS volume format) a
+    // rename that changes only the lettercase of the final path component — e.g.
+    // `foo` -> `Foo` — can be rejected because source and destination resolve to the
+    // same entry. Perform such a recase in two hops through a temporary name so the
+    // lettercase change still takes effect.
+    if (isCaseOnlyRename(from, to))
+    {
+        std::error_code recaseError;
+        if (renameViaTemporary(from, to, recaseError))
+            return {};
+    }
+
+    return std::unexpected(
+        std::format("Cannot rename '{}' to '{}': {}", from.string(), to.string(), ec.message()));
 }
 
 std::expected<std::vector<FileSystem::DirectoryEntry>, std::string> NativeFileSystem::listDirectory(

--- a/src/platform/PathUtils.cpp
+++ b/src/platform/PathUtils.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
+#include <string>
+
 #include <platform/PathUtils.hpp>
 
 #if defined(_WIN32)
     #include <cwctype>
     #include <memory>
-    #include <string>
     #include <string_view>
     #include <type_traits>
 
@@ -13,6 +14,33 @@
 
 namespace endo::platform
 {
+
+bool isCaseOnlyRename(std::filesystem::path const& from, std::filesystem::path const& to)
+{
+    // Reduce both paths to their canonical lexical spelling and drop any trailing
+    // separator so that `foo/` and `foo` are treated identically.
+    auto const stripTrailingSeparator = [](std::filesystem::path const& p) {
+        auto text = p.lexically_normal().generic_string();
+        while (text.size() > 1 && text.back() == '/')
+            text.pop_back();
+        return std::filesystem::path(text);
+    };
+
+    auto const source = stripTrailingSeparator(from);
+    auto const dest = stripTrailingSeparator(to);
+
+    auto const sourceName = source.filename().generic_string();
+    auto const destName = dest.filename().generic_string();
+
+    if (sourceName.empty() || destName.empty())
+        return false;
+    if (sourceName == destName)
+        return false; // Identical spelling — a no-op, not a recase.
+    if (source.parent_path() != dest.parent_path())
+        return false;
+
+    return equalsCaseInsensitive(sourceName, destName);
+}
 
 auto canonicalCasePath(std::filesystem::path const& p) -> std::string
 {

--- a/src/platform/PathUtils.hpp
+++ b/src/platform/PathUtils.hpp
@@ -1,12 +1,39 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <string>
 #include <string_view>
 
 namespace endo::platform
 {
+
+/// @brief Compares two strings for equality, ignoring ASCII lettercase.
+///
+/// @param a First string.
+/// @param b Second string.
+/// @return True if @p a and @p b are equal when compared case-insensitively.
+[[nodiscard]] inline bool equalsCaseInsensitive(std::string_view a, std::string_view b) noexcept
+{
+    return std::ranges::equal(
+        a, b, [](unsigned char x, unsigned char y) noexcept { return std::tolower(x) == std::tolower(y); });
+}
+
+/// @brief Whether the host filesystem resolves paths case-insensitively by default.
+///
+/// True on Windows and the default macOS volume format, where `foo` and `FOO` name the
+/// same entry. Path completion and matching consult this so the shell mirrors how the
+/// OS itself resolves names — e.g. completing `Lastrada-to` to the on-disk
+/// `lastrada-tools/`. POSIX (Linux) filesystems are case-sensitive, so it is false there
+/// and smart-case matching is retained.
+inline constexpr bool FilesystemCaseInsensitive =
+#if defined(_WIN32) || defined(__APPLE__)
+    true;
+#else
+    false;
+#endif
 
 /// @brief Normalizes a path string to use forward slashes.
 ///
@@ -52,6 +79,26 @@ namespace endo::platform
 /// @param p The path to canonicalize.
 /// @return The path with on-disk capitalization and forward slashes.
 [[nodiscard]] auto canonicalCasePath(std::filesystem::path const& p) -> std::string;
+
+/// @brief Tests whether two paths name the same directory entry differing only in
+/// the lettercase of their final component.
+///
+/// Returns true when @p from and @p to share an identical parent path and have final
+/// components that compare equal case-insensitively (ASCII) yet differ byte-for-byte —
+/// e.g. `foo` vs `Foo`, or `dir/a` vs `dir/A`. This is the signature of a
+/// rename-to-recase, which case-insensitive filesystems (Windows, the default macOS
+/// volume format) cannot perform with a single rename and which `mv` must route as an
+/// in-place rename rather than a move-into-directory. Returns false when the final
+/// components are byte-identical (a true no-op rename), when either has no final
+/// component, or when the parents differ.
+///
+/// Both paths are lexically normalized and stripped of a trailing separator before
+/// comparison; the check is purely lexical and touches no filesystem.
+///
+/// @param from The source path.
+/// @param to The destination path.
+/// @return True if the rename only changes the lettercase of the final component.
+[[nodiscard]] bool isCaseOnlyRename(std::filesystem::path const& from, std::filesystem::path const& to);
 
 /// @brief Resolves POSIX-style device paths to their platform-native equivalent.
 ///

--- a/src/platform/WindowsPlatform_test.cpp
+++ b/src/platform/WindowsPlatform_test.cpp
@@ -271,3 +271,36 @@ TEST_CASE("platformRead.returns_zero_on_closed_pipe_eof", "[platform]")
     ::close(readH);
 #endif
 }
+
+// ============================================================================
+// isCaseOnlyRename
+// ============================================================================
+
+TEST_CASE("isCaseOnlyRename.detects_final_component_recase", "[platform]")
+{
+    // Same parent, final component differing only in lettercase.
+    CHECK(isCaseOnlyRename("foo", "Foo"));
+    CHECK(isCaseOnlyRename("Foo", "foo"));
+    CHECK(isCaseOnlyRename("dir/a", "dir/A"));
+    CHECK(isCaseOnlyRename("a/b/readme", "a/b/README"));
+    // A trailing separator (e.g. on a directory operand) must not defeat detection.
+    CHECK(isCaseOnlyRename("foo/", "Foo"));
+    CHECK(isCaseOnlyRename("foo", "Foo/"));
+    // A redundant ./ prefix normalizes away before comparison.
+    CHECK(isCaseOnlyRename("./foo", "Foo"));
+}
+
+TEST_CASE("isCaseOnlyRename.rejects_non_recase", "[platform]")
+{
+    // Identical spelling is a no-op, not a recase.
+    CHECK_FALSE(isCaseOnlyRename("foo", "foo"));
+    // Genuinely different names.
+    CHECK_FALSE(isCaseOnlyRename("foo", "bar"));
+    CHECK_FALSE(isCaseOnlyRename("foo", "foobar"));
+    // Same final component but different parent directories: a real move.
+    CHECK_FALSE(isCaseOnlyRename("a/foo", "b/Foo"));
+    CHECK_FALSE(isCaseOnlyRename("foo", "sub/Foo"));
+    // Missing final component on either side.
+    CHECK_FALSE(isCaseOnlyRename("", "Foo"));
+    CHECK_FALSE(isCaseOnlyRename("foo", ""));
+}

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <string_view>
 #include <thread>
 
 #include <platform/PathUtils.hpp>
@@ -1995,6 +1996,70 @@ TEST_CASE("shell.builtin.mv_combined_flags")
     fs::remove_all(base);
 }
 
+namespace
+{
+/// Returns the actual on-disk spelling of the single entry inside @p parent whose
+/// name matches @p name case-insensitively, or an empty path if none exists.
+///
+/// Needed because `fs::exists("Foo")` is true on case-insensitive filesystems even
+/// when the entry is really stored as `foo`, so a recase can only be observed by
+/// reading back the directory entry's exact spelling.
+std::filesystem::path onDiskName(std::filesystem::path const& parent, std::string_view name)
+{
+    namespace fs = std::filesystem;
+    for (auto const& entry: fs::directory_iterator(parent))
+    {
+        auto const candidate = entry.path().filename().string();
+        if (endo::platform::equalsCaseInsensitive(candidate, name))
+            return candidate;
+    }
+    return {};
+}
+} // namespace
+
+TEST_CASE("shell.builtin.mv_case_only_rename_directory")
+{
+    namespace fs = std::filesystem;
+    auto const base = fs::temp_directory_path() / "endo_mv_test_recase_dir";
+    fs::remove_all(base);
+    fs::create_directories(base / "foo");
+    std::ofstream(base / "foo" / "keep.txt") << "data";
+
+    TestShell shell;
+    // Renaming `foo` -> `Foo` must recase the directory itself, not move it into a
+    // `Foo/foo` subdirectory, and must succeed on case-insensitive filesystems.
+    shell(std::format("mv {} {}", (base / "foo").string(), (base / "Foo").string()));
+    CHECK(shell.exitCode == 0);
+    CHECK(onDiskName(base, "foo") == "Foo");
+    CHECK(fs::exists(base / "Foo" / "keep.txt"));
+    CHECK(!fs::exists(base / "Foo" / "foo"));
+
+    fs::remove_all(base);
+}
+
+TEST_CASE("shell.builtin.mv_case_only_rename_file")
+{
+    namespace fs = std::filesystem;
+    auto const base = fs::temp_directory_path() / "endo_mv_test_recase_file";
+    fs::remove_all(base);
+    fs::create_directories(base);
+    std::ofstream(base / "readme.txt") << "hello";
+
+    TestShell shell;
+    shell(std::format("mv {} {}", (base / "readme.txt").string(), (base / "README.txt").string()));
+    CHECK(shell.exitCode == 0);
+    CHECK(onDiskName(base, "readme.txt") == "README.txt");
+
+    {
+        std::ifstream ifs(base / "README.txt");
+        std::string content;
+        std::getline(ifs, content);
+        CHECK(content == "hello");
+    }
+
+    fs::remove_all(base);
+}
+
 // ============================================================================
 // Variable Substitution - $VAR and ${VAR}
 // ============================================================================
@@ -3136,6 +3201,66 @@ TEST_CASE("FileCompleter.relative_prefix_stays_relative")
     REQUIRE(results.size() == 1);
     CHECK(results[0].text == "sub/item.txt"); // Relative, not an absolute path.
 }
+
+#if defined(_WIN32)
+TEST_CASE("FileCompleter.absolute_directory_corrects_case")
+{
+    // On case-insensitive filesystems, completing an absolute directory typed in the
+    // wrong case must echo the on-disk capitalization (".../foo" -> ".../Foo/") rather
+    // than the case the user typed.
+    auto const tempDir = std::filesystem::temp_directory_path() / "endo_case_completion";
+    std::filesystem::remove_all(tempDir);
+    std::filesystem::create_directories(tempDir / "Foo");
+
+    endo::TestEnvironment env;
+    endo::FileCompleter completer(env);
+
+    // Type the directory in lower-case; it resolves case-insensitively to "Foo".
+    auto const typed = endo::platform::normalizePath((tempDir / "foo").string());
+    endo::CompletionContext context {
+        .type = endo::CompletionContextType::FilePath,
+        .prefix = typed,
+        .cursorPosition = typed.size() + 3,
+        .fullInput = "cd " + typed,
+    };
+    auto const results = completer.complete(context);
+
+    std::filesystem::remove_all(tempDir);
+
+    REQUIRE(results.size() == 1);
+    CHECK(results[0].displayText == "Foo/");
+    CHECK(results[0].text.ends_with("/Foo/"));
+    CHECK(results[0].text.find("/foo/") == std::string::npos);
+}
+
+TEST_CASE("FileCompleter.partial_prefix_corrects_case")
+{
+    // A partial directory name typed in the wrong case (even with leading upper-case,
+    // which would otherwise trigger smart-case) must still match and recase on a
+    // case-insensitive filesystem (e.g. "Lastrada-to" -> "lastrada-tools/").
+    auto const tempDir = std::filesystem::temp_directory_path() / "endo_partial_case_completion";
+    std::filesystem::remove_all(tempDir);
+    std::filesystem::create_directories(tempDir / "lastrada-tools");
+
+    endo::TestEnvironment env;
+    endo::FileCompleter completer(env);
+
+    auto const typed = endo::platform::normalizePath((tempDir / "Lastrada-to").string());
+    endo::CompletionContext context {
+        .type = endo::CompletionContextType::FilePath,
+        .prefix = typed,
+        .cursorPosition = typed.size() + 3,
+        .fullInput = "cd " + typed,
+    };
+    auto const results = completer.complete(context);
+
+    std::filesystem::remove_all(tempDir);
+
+    REQUIRE(results.size() == 1);
+    CHECK(results[0].displayText == "lastrada-tools/");
+    CHECK(results[0].text.ends_with("/lastrada-tools/"));
+}
+#endif
 
 // ========================================================================
 // String Interpolation Tests

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -1846,6 +1846,16 @@ int Shell::executeInlineMv(CoreVM::CoreStringArray const& args, NativeHandle out
     auto const sources = std::span(paths.data(), paths.size() - 1);
     auto const destIsDir = _fs.isDirectory(dest);
 
+    // A single-source move whose destination names the very same entry as the source,
+    // differing only in the lettercase of the final path component (e.g. `mv foo Foo`),
+    // is a pure rename-to-recase. On case-insensitive filesystems the destination appears
+    // to already exist (it *is* the source) and isDirectory(dest) reports the source's own
+    // type, so without this guard the move would be misrouted into the directory (target
+    // `Foo/foo`) or rejected as a self-overwrite. Detect it up front so the entry itself
+    // is renamed; NativeFileSystem::rename performs the underlying recase safely.
+    auto const caseOnlyRename =
+        sources.size() == 1 && platform::isCaseOnlyRename(std::filesystem::path(sources.front()), dest);
+
     if (sources.size() > 1 && !destIsDir)
     {
         error("mv: target '{}' is not a directory", platform::normalizePath(dest));
@@ -1864,10 +1874,11 @@ int Shell::executeInlineMv(CoreVM::CoreStringArray const& args, NativeHandle out
             continue;
         }
 
-        auto const target = destIsDir ? dest / srcPath.filename() : dest;
+        auto const target = (destIsDir && !caseOnlyRename) ? dest / srcPath.filename() : dest;
 
-        // Check if target already exists
-        if (_fs.exists(target))
+        // Check if target already exists. A case-only recase necessarily collides with the
+        // source itself on case-insensitive filesystems, so skip the clobber/overwrite gate.
+        if (!caseOnlyRename && _fs.exists(target))
         {
             if (noClobber)
                 continue;

--- a/src/shell/completion/FileCompleter.cpp
+++ b/src/shell/completion/FileCompleter.cpp
@@ -58,6 +58,23 @@ std::vector<CompletionItem> FileCompleter::complete(CompletionContext const& con
         }
     }
 
+    // Returns the on-disk capitalization of an existing absolute path so completions
+    // echo the real case rather than the case the user typed (e.g. "D:/foo" -> "D:/Foo").
+    // Relative and tilde-prefixed paths are left exactly as typed: canonicalCasePath()
+    // resolves to an absolute path and would otherwise rewrite "foo/" into an absolute
+    // path or expand "~/foo" into the literal home directory.
+    auto const caseCorrect = [](std::filesystem::path const& path, std::string_view typed) -> std::string {
+        bool const isTilde = !typed.empty() && typed.front() == '~';
+        return (path.is_absolute() && !isTilde) ? platform::canonicalCasePath(path) : std::string(typed);
+    };
+
+    // Appends a trailing '/' to a non-empty directory prefix so listed children are
+    // joined onto it correctly.
+    auto const ensureTrailingSlash = [](std::string& s) {
+        if (!s.empty() && s.back() != '/')
+            s += '/';
+    };
+
     std::error_code ec;
     std::filesystem::path dir;
     std::string filePrefix;
@@ -69,17 +86,21 @@ std::vector<CompletionItem> FileCompleter::complete(CompletionContext const& con
         {
             dir = expandedPath;
             filePrefix = "";
-            pathPrefix = std::string(prefix);
+            // Echo the directory's real capitalization so listed children carry the
+            // corrected case (e.g. "D:/foo/" -> "D:/Foo/<child>").
+            pathPrefix = caseCorrect(expandedPath, prefix);
+            ensureTrailingSlash(pathPrefix);
         }
         else
         {
             // Path is a directory but doesn't end with /, treat as complete match
-            // and offer trailing slash
+            // and offer trailing slash, correcting the typed case (e.g. "D:/foo" ->
+            // "D:/Foo/").
+            std::string const completedDir = caseCorrect(expandedPath, prefix);
             std::vector<CompletionItem> results;
-            std::string completedPath = std::string(prefix) + "/";
             results.push_back(
-                CompletionItem { .text = completedPath,
-                                 .displayText = std::filesystem::path(prefix).filename().string() + "/",
+                CompletionItem { .text = completedDir + "/",
+                                 .displayText = std::filesystem::path(completedDir).filename().string() + "/",
                                  .description = "directory",
                                  .score = 100 });
             return results;
@@ -117,8 +138,7 @@ std::vector<CompletionItem> FileCompleter::complete(CompletionContext const& con
                 // typed (e.g. "foo/") into an absolute one.
                 pathPrefix =
                     dir.is_absolute() ? platform::canonicalCasePath(dir) : platform::normalizePath(dir);
-                if (!pathPrefix.empty() && pathPrefix.back() != '/')
-                    pathPrefix += '/';
+                ensureTrailingSlash(pathPrefix);
             }
         }
     }
@@ -239,6 +259,13 @@ std::vector<CompletionItem> FileCompleter::listDirectory(std::filesystem::path c
     tui::FuzzyConfig fuzzyConfig;
     double const minThreshold = fuzzyConfig.minMatchThreshold;
 
+    // On case-insensitive filesystems (Windows, default macOS) path matching must ignore
+    // case so a wrong-case prefix still finds — and recases — the real entry (e.g.
+    // "Lastrada-to" -> "lastrada-tools/"). The candidate text is built from the on-disk
+    // filename below, so casing is corrected automatically. POSIX is case-sensitive, so
+    // smart-case matching is kept there.
+    bool const caseInsensitive = platform::FilesystemCaseInsensitive;
+
     for (auto const& entry: std::filesystem::directory_iterator(dir, ec))
     {
         if (ec)
@@ -251,14 +278,17 @@ std::vector<CompletionItem> FileCompleter::listDirectory(std::filesystem::path c
             continue;
 
         // Option C: Check both prefix and fuzzy matches
-        bool isPrefixMatch = tui::SmartCaseMatch::matchesPrefix(filename, prefix);
+        bool isPrefixMatch = caseInsensitive
+                                 ? tui::SmartCaseMatch::matchesPrefixCaseInsensitive(filename, prefix)
+                                 : tui::SmartCaseMatch::matchesPrefix(filename, prefix);
         tui::FuzzyMatchResult fuzzyResult;
         bool isFuzzyMatch = false;
 
         if (!isPrefixMatch && !prefix.empty())
         {
             // Try fuzzy matching only if not a prefix match
-            fuzzyResult = tui::FuzzyMatch::matchSmartCase(filename, prefix);
+            fuzzyResult = caseInsensitive ? tui::FuzzyMatch::match(filename, prefix, /*caseSensitive=*/false)
+                                          : tui::FuzzyMatch::matchSmartCase(filename, prefix);
             size_t textLen = tui::FuzzyMatch::countGraphemes(filename);
             isFuzzyMatch =
                 fuzzyResult.matches

--- a/src/shell/history/PersistentHistory_test.cpp
+++ b/src/shell/history/PersistentHistory_test.cpp
@@ -631,6 +631,29 @@ TEST_CASE("PersistentHistory.required_paths_validation_disabled", "[history][req
     CHECK(results.front().entry == "cat ~/missing.txt");
 }
 
+TEST_CASE("PersistentHistory.fuzzy_finds_substring_after_repeated_grapheme", "[history][fuzzy]")
+{
+    // Regression: Ctrl+R over history failed to surface an entry when the typed
+    // query was a contiguous substring whose leading grapheme also appeared
+    // earlier in the command (the greedy matcher scattered the match and the
+    // long entry fell below the fuzzy quality threshold). The command has no
+    // path arguments, so required-paths validation is not involved here.
+    auto dir = TempDir {};
+    auto history = endo::PersistentHistory { testFs() };
+    history.setFilePath(dir.path / "history.yml");
+
+    history.add("./build/clangcl-debug/src/shell/endo.exe",
+                endo::HistoryAddContext { .cwd = "~/projects/endo", .requiredPaths = {} });
+
+    auto options = endo::FuzzySearchOptions {
+        .currentCwd = "/home/u/projects/endo",
+        .home = "/home/u",
+    };
+    auto const results = history.searchFuzzy("endo.exe", 200, options);
+    REQUIRE(results.size() == 1);
+    CHECK(results.front().entry == "./build/clangcl-debug/src/shell/endo.exe");
+}
+
 TEST_CASE("PersistentHistory.readd_updates_cwd_and_paths", "[history][cwd]")
 {
     auto dir = TempDir {};

--- a/src/shell/ui/PromptComponent.cpp
+++ b/src/shell/ui/PromptComponent.cpp
@@ -1343,6 +1343,29 @@ void PromptComponent::triggerCompletion(bool forceShowPopup)
             updateGhostText();
             return;
         }
+
+        // Several prefix candidates: insert their longest common prefix first (bash-style)
+        // and defer the popup. The popup only appears on the next Tab, once the common
+        // prefix no longer extends the typed word. Fuzzy-only candidates are excluded —
+        // they share no meaningful leading prefix — so an all-fuzzy result shows the popup
+        // immediately.
+        std::vector<tui::CompletionItem> prefixMatches;
+        for (auto const& item: completions)
+            if (isPrefixMatch(item))
+                prefixMatches.push_back(item);
+
+        if (prefixMatches.size() > 1)
+        {
+            auto const ctx = Completer::analyzeContext(text, cursor);
+            auto const commonPrefix = tui::Completer::findCommonPrefix(prefixMatches);
+            if (commonPrefix.size() > ctx.prefix.size())
+            {
+                insertCompletion(commonPrefix);
+                dismissPopup();
+                updateGhostText();
+                return;
+            }
+        }
     }
 
     // Multiple matches (or force-show): populate and show popup

--- a/src/shell/ui/PromptComponent_test.cpp
+++ b/src/shell/ui/PromptComponent_test.cpp
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
+#include <shell/completion/Completer.hpp>
+
 #include <tui/InputEvent.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
 #include <chrono>
+#include <filesystem>
 #include <string_view>
 #include <thread>
 
 #include "PromptComponent.hpp"
+#include <platform/PathUtils.hpp>
+#include <platform/testing/TestEnvironmentProvider.hpp>
 
 using namespace endo;
 
@@ -34,6 +39,12 @@ tui::InputEvent charEvent(char ch)
 tui::InputEvent backspaceEvent()
 {
     return tui::KeyEvent { .key = tui::KeyCode::Backspace, .modifiers = tui::Modifier::None };
+}
+
+/// @brief Creates a Tab key event (triggers completion).
+tui::InputEvent tabEvent()
+{
+    return tui::KeyEvent { .key = tui::KeyCode::Tab, .modifiers = tui::Modifier::None };
 }
 
 /// @brief Creates a Ctrl+E key event (accepts ghost text at end of line).
@@ -86,6 +97,45 @@ TEST_CASE("PromptComponent.ctrl_d_double_press_exits", "[prompt]")
 
     auto const second = comp.processInput(ctrlD());
     CHECK(second == PromptComponent::Action::Eof);
+}
+
+TEST_CASE("PromptComponent.tab_inserts_common_prefix_before_popup", "[prompt]")
+{
+    // Bash-style completion: the first Tab fills in the longest common prefix shared by
+    // all candidates (e.g. "last" -> "lastrada-") without showing the popup; only the
+    // next Tab opens the popup to disambiguate.
+    namespace fs = std::filesystem;
+    auto const base = fs::temp_directory_path() / "endo_prompt_common_prefix";
+    fs::remove_all(base);
+    fs::create_directories(base / "lastrada-tools");
+    fs::create_directories(base / "lastrada-config");
+
+    endo::InMemoryHistory history;
+    endo::TestEnvironment env;
+    endo::FSharpPersistentState fsharpState;
+    endo::Completer completer(env, history, fsharpState);
+
+    // Use an absolute path so only file-path completion applies (mirrors `cd D:/last`).
+    // The inserted prefix carries the directory's real on-disk capitalization, so the
+    // expectation is built from canonicalCasePath(), not the raw (possibly short-name)
+    // temp path.
+    auto const typed = "cd " + endo::platform::normalizePath((base / "last").string());
+    auto const expected = "cd " + endo::platform::canonicalCasePath(base) + "/lastrada-";
+
+    auto comp = PromptComponent();
+    comp.setCompleter(&completer);
+    comp.inputField().setText(typed);
+
+    // First Tab: insert the longest common prefix, no popup yet.
+    comp.processInput(tabEvent());
+    CHECK(comp.text() == expected);
+    CHECK_FALSE(comp.completionVisible());
+
+    // Second Tab: the common prefix no longer extends the word, so show the popup.
+    comp.processInput(tabEvent());
+    CHECK(comp.completionVisible());
+
+    fs::remove_all(base);
 }
 
 TEST_CASE("PromptComponent.ctrl_d_after_timeout_shows_hint_again", "[prompt]")

--- a/src/shell/ui/PromptComponent_test.cpp
+++ b/src/shell/ui/PromptComponent_test.cpp
@@ -127,12 +127,12 @@ TEST_CASE("PromptComponent.tab_inserts_common_prefix_before_popup", "[prompt]")
     comp.inputField().setText(typed);
 
     // First Tab: insert the longest common prefix, no popup yet.
-    comp.processInput(tabEvent());
+    (void) comp.processInput(tabEvent());
     CHECK(comp.text() == expected);
     CHECK_FALSE(comp.completionVisible());
 
     // Second Tab: the common prefix no longer extends the word, so show the popup.
-    comp.processInput(tabEvent());
+    (void) comp.processInput(tabEvent());
     CHECK(comp.completionVisible());
 
     fs::remove_all(base);

--- a/src/tui/FuzzyMatch_test.cpp
+++ b/src/tui/FuzzyMatch_test.cpp
@@ -3,6 +3,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <ranges>
+#include <string_view>
+
 using namespace tui;
 
 // ============================================================================
@@ -11,11 +14,13 @@ using namespace tui;
 
 TEST_CASE("FuzzyMatch.basic_match_ds_downloads")
 {
+    // "ds" occurs verbatim in "Downloa[ds]", so the contiguous substring is
+    // preferred over the scattered D...s subsequence.
     auto result = FuzzyMatch::matchSmartCase("Downloads", "ds");
     CHECK(result.matches);
     CHECK(result.matchedChars == 2);
     REQUIRE(result.positions.size() == 2);
-    CHECK(result.positions[0] == 0); // D
+    CHECK(result.positions[0] == 7); // d
     CHECK(result.positions[1] == 8); // s
 }
 
@@ -346,6 +351,46 @@ TEST_CASE("FuzzyMatchResult.isContiguousSubstring_false_scattered")
     CHECK_FALSE(result.isContiguousSubstring());
 }
 
+TEST_CASE("FuzzyMatchResult.isContiguousSubstring_true_despite_earlier_grapheme")
+{
+    // Regression: pressing Ctrl+R and typing "endo.exe" must match the history
+    // entry "./build/clangcl-debug/src/shell/endo.exe". The leading 'e' of the
+    // pattern also occurs earlier in "...clangcl-debug...", so a greedy matcher
+    // would bind to that 'e' and highlight a stray 'e' plus "ndo.exe". The
+    // substring-first match must instead report the contiguous "endo.exe" block.
+    auto const text = std::string_view { "./build/clangcl-debug/src/shell/endo.exe" };
+    auto result = FuzzyMatch::matchSmartCase(text, "endo.exe");
+    CHECK(result.matches);
+    CHECK(result.isContiguousSubstring());
+
+    // Positions must cover the trailing "endo.exe" block, not the stray 'e' in
+    // "debug" — this is what gets highlighted in the Ctrl+R popup.
+    auto const start = FuzzyMatch::countGraphemes("./build/clangcl-debug/src/shell/");
+    REQUIRE(result.positions.size() == 8);
+    for (auto const i: std::views::iota(size_t { 0 }, result.positions.size()))
+        CHECK(result.positions[i] == start + i);
+
+    // Quality alone does not reliably carry this match: for an entry this long it
+    // sits at/below the default threshold, so isContiguousSubstring() is what
+    // keeps it from being filtered out of history search.
+    auto const threshold = FuzzyConfig {}.minMatchThreshold;
+    CHECK(result.quality(FuzzyMatch::countGraphemes(text)) <= threshold);
+}
+
+TEST_CASE("FuzzyMatchResult.isContiguousSubstring_true_when_first_grapheme_repeats")
+{
+    // "cat" appears contiguously in "con[cat]enate"; the pattern's leading 'c'
+    // also occurs earlier at index 0, so a greedy matcher would scatter the
+    // positions. Substring-first matching must report the contiguous block.
+    auto result = FuzzyMatch::matchSmartCase("concatenate", "cat");
+    CHECK(result.matches);
+    CHECK(result.isContiguousSubstring());
+    REQUIRE(result.positions.size() == 3);
+    CHECK(result.positions[0] == 3); // c in "concat"
+    CHECK(result.positions[1] == 4); // a
+    CHECK(result.positions[2] == 5); // t
+}
+
 TEST_CASE("FuzzyMatchResult.isContiguousSubstring_false_no_match")
 {
     auto result = FuzzyMatch::matchSmartCase("hello", "xyz");
@@ -505,11 +550,12 @@ TEST_CASE("FuzzyMatch.single_char_text")
 TEST_CASE("FuzzyMatch.pattern_at_very_end")
 {
     // "testfile.txt" = t(0), e(1), s(2), t(3), f(4), i(5), l(6), e(7), .(8), t(9), x(10), t(11)
-    // Greedy matching finds first 't' at 0, then 'x' at 10, then 't' at 11
+    // "txt" occurs verbatim as the trailing extension ".[txt]", so the contiguous
+    // substring {9,10,11} is preferred over the scattered greedy match {0,10,11}.
     auto result = FuzzyMatch::matchSmartCase("testfile.txt", "txt");
     CHECK(result.matches);
     REQUIRE(result.positions.size() == 3);
-    CHECK(result.positions[0] == 0);  // first 't'
+    CHECK(result.positions[0] == 9);  // 't' in ".txt"
     CHECK(result.positions[1] == 10); // 'x'
     CHECK(result.positions[2] == 11); // last 't'
 }

--- a/src/tui/FuzzyPickerPopup_test.cpp
+++ b/src/tui/FuzzyPickerPopup_test.cpp
@@ -188,12 +188,14 @@ TEST_CASE("FuzzyPickerPopup.fuzzy_matching")
 TEST_CASE("FuzzyPickerPopup.substring_matches_prioritized")
 {
     FuzzyPickerPopup popup;
-    // "Shell.cpp" has "Shell" as a contiguous substring.
-    // "src/shell/completion/FileCompleter.cpp" also contains "shell" but is a longer path.
-    // The shorter path with higher coverage should rank higher.
+    // Both "shell.cpp" and "src/shell/completion/FileCompleter.cpp" contain "shell"
+    // as an exact-case contiguous substring, so they land in the same match tier.
+    // (Both lowercase so case-sensitivity does not confound the comparison — that
+    // dimension is covered by case_sensitive_substring_ranked_higher.) The shorter
+    // path with higher coverage should then rank higher.
     popup.show({
         "src/shell/completion/FileCompleter.cpp",
-        "Shell.cpp",
+        "shell.cpp",
         "src/tui/FuzzyMatch.hpp",
     });
 
@@ -202,10 +204,10 @@ TEST_CASE("FuzzyPickerPopup.substring_matches_prioritized")
         (void) popup.processEvent(charKey(ch));
     }
 
-    // "Shell.cpp" should rank first (contiguous substring + higher coverage percentage)
+    // "shell.cpp" should rank first (same substring tier, higher coverage percentage)
     auto const* selected = popup.selectedItem();
     REQUIRE(selected != nullptr);
-    CHECK(*selected == "Shell.cpp");
+    CHECK(*selected == "shell.cpp");
 }
 
 TEST_CASE("FuzzyPickerPopup.coverage_affects_ranking")

--- a/src/tui/completer/FuzzyMatch.cpp
+++ b/src/tui/completer/FuzzyMatch.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cctype>
 #include <climits>
+#include <optional>
 #include <ranges>
 #include <string>
 #include <vector>
@@ -91,6 +92,9 @@ double FuzzyMatchResult::quality(size_t graphemeCount) const noexcept
 
 bool FuzzyMatchResult::isContiguousSubstring() const noexcept
 {
+    // match() reports a contiguous block whenever the pattern occurs verbatim, so
+    // the greedy subsequence path can only ever yield longestRun < matchedChars.
+    // A full-length run therefore uniquely identifies a substring match.
     return matches && matchedChars > 0 && longestRun == matchedChars;
 }
 
@@ -167,6 +171,58 @@ FuzzyMatchResult FuzzyMatch::match(std::string_view text,
 
     if (patternGraphemes.size() > textGraphemes.size())
         return result;
+
+    // Substring-first matching: prefer a contiguous occurrence of the pattern
+    // over a greedy subsequence.
+    //
+    // The greedy matcher below binds each pattern grapheme to its first available
+    // occurrence, which scatters the match when an earlier occurrence of the
+    // leading grapheme exists — e.g. matching "endo.exe" against
+    // "./build/clangcl-debug/src/shell/endo.exe" would bind the leading 'e' to
+    // "...clangcl-debug..." and highlight a stray 'e' plus "ndo.exe". When the
+    // pattern occurs verbatim we instead report that contiguous block: it
+    // highlights the run the user actually typed and ranks ahead of a scattered
+    // match (single run, word-start aware). All fuzzy consumers — history search,
+    // ghost text, completion, the fuzzy file finder — share this behavior.
+    //
+    // Case-fold each grapheme once rather than per comparison so the scan stays
+    // cheap on the hot completion/history path — O(textLen + patternLen) folds
+    // instead of O(textLen * patternLen). Case-sensitive matching needs no folds.
+    auto const substringStart = [&]() -> std::optional<size_t> {
+        auto const locate = [](std::vector<std::string> const& haystack,
+                               std::vector<std::string> const& needle) -> std::optional<size_t> {
+            auto const found = std::ranges::search(haystack, needle);
+            if (found.empty())
+                return std::nullopt;
+            return static_cast<size_t>(std::ranges::distance(haystack.begin(), found.begin()));
+        };
+        if (caseSensitive)
+            return locate(textGraphemes, patternGraphemes);
+        auto const fold = [](std::vector<std::string> const& graphemes) {
+            auto folded = std::vector<std::string> {};
+            folded.reserve(graphemes.size());
+            for (auto const& grapheme: graphemes)
+                folded.push_back(casefoldGrapheme(grapheme));
+            return folded;
+        };
+        return locate(fold(textGraphemes), fold(patternGraphemes));
+    }();
+
+    if (substringStart.has_value())
+    {
+        for (auto const offset: std::views::iota(size_t { 0 }, patternGraphemes.size()))
+        {
+            auto const textIdx = *substringStart + offset;
+            result.positions.push_back(textIdx);
+            if (isWordStart(text, textIdx, graphemeByteOffsets))
+                result.wordStartMatches++;
+        }
+        result.matchedChars = patternGraphemes.size();
+        result.longestRun = patternGraphemes.size();
+        result.consecutiveRuns = 1;
+        result.matches = true;
+        return result;
+    }
 
     size_t patternIdx = 0;
     size_t lastMatchIdx = SIZE_MAX;

--- a/src/tui/completer/FuzzyMatch.hpp
+++ b/src/tui/completer/FuzzyMatch.hpp
@@ -43,12 +43,15 @@ struct FuzzyMatchResult
 
 /// @brief Fuzzy string matching with grapheme cluster awareness.
 ///
-/// Matches pattern characters in order but allows gaps between them.
-/// All operations work on Unicode grapheme clusters, not bytes.
+/// When the pattern occurs verbatim as a contiguous substring, that block is
+/// reported (best highlight, ranks ahead of a scattered match). Otherwise the
+/// pattern characters are matched in order with gaps allowed (subsequence /
+/// abbreviation matching). All operations work on Unicode grapheme clusters,
+/// not bytes.
 ///
 /// Examples:
-/// - "ds" matches "Downloads" (D...s) -> positions = {0, 8}
-/// - "dcm" matches "Documents" (D.c.m....)
+/// - "ds" matches "Downloads" as the substring "...loaDS" -> positions = {7, 8}
+/// - "dcm" matches "Documents" (D.c.m...., subsequence) -> positions = {0, 2, 4}
 /// - "📁d" matches "📁Downloads" -> positions = {0, 1}
 ///
 /// Integrates with smart case rules:
@@ -60,7 +63,7 @@ struct FuzzyMatchResult
 ///   auto result = FuzzyMatch::matchSmartCase("Downloads", "ds");
 ///   if (result.matches) {
 ///       int score = FuzzyMatch::calculateScore(50, "Downloads", "ds", result);
-///       // result.positions = {0, 8} for highlighting 'D' and 's'
+///       // result.positions = {7, 8} for highlighting the "ds" in "Downloads"
 ///   }
 /// @endcode
 struct FuzzyMatch


### PR DESCRIPTION
On case-insensitive filesystems (Windows, the default macOS volume format) several path operations mishandled lettercase, and Tab completion did not behave the way users coming from bash expect. This branch fixes the rename/completion casing bugs, adopts readline-style staged completion so the shell mirrors how the OS itself resolves names, and fixes fuzzy matching so a typed fragment reliably finds (and highlights) the right history entry under Ctrl+R.

## Changes

- **`mv foo Foo` (case-only rename).** Previously this failed: the destination appeared to already exist (it *is* the source), so the move was misrouted into a `Foo/foo` subdirectory, and even the correct target was rejected because source and destination resolve to the same entry. `mv` now detects a single-source case-only rename up front and renames the entry directly, and `NativeFileSystem::rename` performs the underlying recase in two hops through a temporary name (with rollback) — keeping the platform quirk in the platform layer.
- **Case-correcting path completion.** `cd D:/foo` now completes to the on-disk `cd D:/Foo/` instead of echoing the typed case, and a wrong-case partial prefix such as `cd D:/Lastrada-to` now matches and recases to `cd D:/lastrada-tools/`. Path matching is case-insensitive on case-insensitive filesystems (gated by a `platform::FilesystemCaseInsensitive` constant) and falls back to smart-case on case-sensitive Linux.
- **Bash-style staged Tab completion.** When several candidates share a longer common base than the typed word, the first Tab fills in that common prefix (`cd D:/last` → `cd D:/lastrada-`) without opening the popup; the next Tab opens the popup to disambiguate. Previously the popup appeared on the first Tab.
- **Contiguous-substring fuzzy matching.** Pressing Ctrl+R and typing a fragment of a previous command — e.g. `endo.exe` for `./build/clangcl-debug/src/shell/endo.exe` — returned nothing. The greedy subsequence matcher bound the leading `e` to an earlier unrelated occurrence (the `e` in `…clangcl-debug…`), scattering the match so `isContiguousSubstring()` reported false; the match then survived only on the quality ratio, which falls below threshold for long entries and dropped it entirely. `FuzzyMatch::match()` is now substring-first: when the pattern occurs verbatim it reports that contiguous block (single run, word-start aware) and returns before the greedy pass — fixing the match, highlighting the run the user actually typed instead of a stray grapheme plus the remainder, and ranking substring matches ahead of scattered ones. The greedy/abbreviation path is unchanged when no contiguous occurrence exists. This applies across all fuzzy consumers (history search, ghost text, completion, fuzzy file finder).
- New shared helper `platform::equalsCaseInsensitive` and `platform::isCaseOnlyRename`, with unit tests, real-filesystem `mv` recase tests, Windows-guarded completion case-correction tests, a prompt-level integration test for the staged-completion flow, and FuzzyMatch/PersistentHistory regression tests for the substring-matching fix.
