### PR TITLE
feat(packaging): build & test Debian .deb/.ddeb in CI via cpack + Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Keep the Docker build context small. .git is excluded: it is often a worktree
+# pointer file that does not resolve inside the container, and the package version
+# is injected via the ENDO_VERSION build-arg instead (see packaging/deb/Dockerfile).
+.git
+build/
+dist/
+.cache/
+.vscode/
+editors/vscode/node_modules/
+**/*.o
+**/*.obj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,3 +243,24 @@ jobs:
         name: endo-vscode-extension
         path: editors/vscode/*.vsix
         retention-days: 30
+
+  linux-deb:
+    runs-on: ubuntu-latest
+    name: "Linux .deb (Ubuntu 26.04)"
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # full history + tags so the package version is derived correctly
+
+    - name: Build & install-test .deb in Docker
+      run: ./scripts/package-deb.sh dist
+
+    - name: Upload .deb / .ddeb artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: endo-deb-ubuntu-2604
+        path: |
+          dist/*.deb
+          dist/*.ddeb
+        retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,26 @@ jobs:
           cp build/clang-release-static/src/shell/endo endo-${VERSION}-linux-x86_64
           gh release upload ${{ env.RELEASE_TAG }} endo-${VERSION}-linux-x86_64 --clobber
 
+  linux-deb:
+    needs: create-release
+    runs-on: ubuntu-latest
+    name: Linux .deb (Ubuntu 26.04)
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Build & install-test .deb in Docker
+        run: ./scripts/package-deb.sh dist
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload ${{ env.RELEASE_TAG }} dist/*.deb dist/*.ddeb --clobber
+
   macos:
     needs: create-release
     runs-on: macos-14

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _ucd/
 out/
 build/
 target/
+dist/
 
 compile_commands.json
 /src/vtparser/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,6 +72,15 @@
             }
         },
         {
+            "name": "clang-deb",
+            "inherits": "clang-release",
+            "displayName": "Clang Debian Package (RelWithDebInfo)",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_EXE_LINKER_FLAGS": "-Wl,--build-id=sha1"
+            }
+        },
+        {
             "name": "clang-coverage",
             "inherits": "unix-base",
             "displayName": "Clang Coverage",
@@ -211,6 +220,10 @@
         {
             "name": "clang-release-static",
             "configurePreset": "clang-release-static"
+        },
+        {
+            "name": "clang-deb",
+            "configurePreset": "clang-deb"
         },
         {
             "name": "clang-coverage",
@@ -366,6 +379,12 @@
             "name": "clang-release-static-package",
             "configurePreset": "clang-release-static",
             "displayName": "Clang Release Static Package"
+        },
+        {
+            "name": "clang-deb",
+            "configurePreset": "clang-deb",
+            "displayName": "Debian Package (.deb + .ddeb)",
+            "generators": ["DEB"]
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -176,9 +176,26 @@ cmake --build --preset clang-release
 sudo cmake --install build/clang-release
 ```
 
-### Package Managers
+### Debian / Ubuntu (`.deb`)
 
-> Coming soon — Homebrew, Scoop, and distro packages are on the roadmap.
+Each [release](https://github.com/contour-terminal/endo/releases) ships a `.deb`
+built against the latest Ubuntu LTS, plus a matching `.ddeb` with debug symbols:
+
+```bash
+sudo apt install ./endo_<version>_amd64.deb
+# optional, for debugging / crash reports:
+sudo apt install ./endo-dbgsym_<version>_amd64.ddeb
+```
+
+To build the package yourself (requires Docker):
+
+```bash
+./scripts/package-deb.sh dist   # writes dist/endo_<version>_amd64.deb (+ .ddeb)
+```
+
+### Other Package Managers
+
+> Coming soon — Homebrew, Scoop, and RPM packages are on the roadmap.
 
 ## Contributing
 

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -101,6 +101,12 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://endo-lang.org/")
     set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 
+    # Emit a separate debug-symbols package (endo-dbgsym_<ver>_<arch>.ddeb) and ship
+    # a stripped main .deb. This requires the binary to be built unstripped and with
+    # a build-id; the `clang-deb` preset (RelWithDebInfo + -Wl,--build-id) satisfies
+    # both. A plain `-O3` Release build (no -g) would yield an empty debug package.
+    set(CPACK_DEBIAN_DEBUGINFO_PACKAGE ON)
+
     # RPM
     set(CPACK_RPM_PACKAGE_LICENSE "Apache-2.0")
     set(CPACK_RPM_PACKAGE_GROUP "System Environment/Shells")

--- a/packaging/deb/Dockerfile
+++ b/packaging/deb/Dockerfile
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Multi-stage Dockerfile that builds and install-tests the Endo Debian package
+# against a chosen Ubuntu release (default: the latest LTS, 26.04).
+#
+# The same flow runs locally (via scripts/package-deb.sh) and in CI, so the .deb
+# is always produced and verified in an environment identical to the one users
+# install it on — independent of whatever the GitHub-hosted runner happens to be.
+#
+# Targets:
+#   builder  - compile Endo and run cpack to produce /out/*.deb + /out/*.ddeb
+#   tester   - install the .deb into a clean image and run smoke tests
+#   export   - scratch image holding only /out, for `buildx --output type=local`
+
+ARG UBUNTU_VERSION=26.04
+
+# ---------------------------------------------------------------------------
+# Stage 1: build the package
+# ---------------------------------------------------------------------------
+FROM ubuntu:${UBUNTU_VERSION} AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Toolchain and build prerequisites. Clang 21 is installed from apt.llvm.org to
+# match the compiler used by the rest of Endo's CI.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        wget \
+        gnupg \
+        lsb-release \
+        software-properties-common \
+        python3 \
+        git \
+        ninja-build \
+        cmake \
+        file \
+        xz-utils \
+        dpkg-dev \
+        binutils \
+    && wget -qO- https://apt.llvm.org/llvm.sh | bash -s -- 21 \
+    && rm -rf /var/lib/apt/lists/*
+
+# System -dev packages that exist in Ubuntu. find_package() picks these up so the
+# resulting .deb declares proper runtime dependencies (via SHLIBDEPS) instead of
+# statically bundling them. Dependencies that Ubuntu does not package (libunicode,
+# boxed-cpp, reflection-cpp, llama.cpp) are built from source by CPM and linked
+# statically, producing no runtime dependency — this is expected.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libcurl4-openssl-dev \
+        libyaml-cpp-dev \
+        nlohmann-json3-dev \
+        libmsgsl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Package version, supplied by the caller (scripts/package-deb.sh derives it from
+# `git describe`). The repository's .git is excluded from the build context — it is
+# often a worktree pointer that does not resolve inside the container — so the
+# version is injected here instead. cmake/Version.cmake reads version.txt first.
+ARG ENDO_VERSION=0.0.0
+
+WORKDIR /src
+COPY . .
+
+# Record the version for cmake/Version.cmake, then fetch the vendored crispy &
+# vtparser sources. get_contour_dirs.py locates the tree via `git rev-parse`, so a
+# throwaway repo is initialised (the real .git is not in the build context); the
+# script itself clones the sources it needs over the network.
+RUN printf '%s\n' "${ENDO_VERSION}" > version.txt \
+    && git init -q . \
+    && python3 scripts/get_contour_dirs.py
+
+# Configure, build, and package. RelWithDebInfo + --build-id (from the clang-deb
+# preset) are what make the separate .ddeb debug-symbols package possible.
+RUN cmake --preset clang-deb \
+        -DCMAKE_C_COMPILER=clang-21 \
+        -DCMAKE_CXX_COMPILER=clang++-21 \
+    && cmake --build --preset clang-deb \
+    && cpack --preset clang-deb
+
+# Collect the artifacts in a predictable location for the later stages.
+RUN mkdir -p /out \
+    && cp build/clang-deb/*.deb /out/ \
+    && cp build/clang-deb/*.ddeb /out/ \
+    && ls -l /out
+
+# ---------------------------------------------------------------------------
+# Stage 2: install the package into a clean image and smoke-test it
+# ---------------------------------------------------------------------------
+FROM ubuntu:${UBUNTU_VERSION} AS tester
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Both packages are installed so CI proves they are installable, not merely built.
+# apt resolves the .deb's declared dependencies; the -dbgsym .ddeb is installed
+# afterwards because it depends on the exact endo version installed by the .deb.
+COPY --from=builder /out/ /tmp/pkgs/
+RUN apt-get update \
+    && apt-get install -y /tmp/pkgs/endo_*.deb \
+    && apt-get install -y /tmp/pkgs/endo-dbgsym_*.ddeb \
+    && rm -rf /var/lib/apt/lists/*
+
+# Smoke tests — any failure fails the image build.
+RUN set -eux; \
+    endo --version; \
+    test "$(endo -c 'println "hello"')" = "hello"; \
+    test -d /usr/share/endo; \
+    test -d /usr/lib/debug; \
+    dpkg -s endo; \
+    dpkg -s endo-dbgsym
+
+# ---------------------------------------------------------------------------
+# Stage 3: export-only image (artifacts at /), for `buildx --output type=local`
+# ---------------------------------------------------------------------------
+FROM scratch AS export
+COPY --from=builder /out/ /

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build and install-test the Endo Debian package in Docker, then extract the
+# resulting .deb / .ddeb to a host directory.
+#
+# This is the single entry point used by both CI and local development, so the
+# package is produced and verified the same way everywhere.
+#
+# Usage:
+#   scripts/package-deb.sh [OUT_DIR]
+#
+# Environment:
+#   UBUNTU_VERSION   Ubuntu release to build against (default: 26.04)
+#
+# Requires Docker with buildx (Docker Desktop, or `docker buildx` on Linux). On
+# Windows run this from WSL or Git Bash with Docker Desktop in Linux-container mode.
+
+set -euo pipefail
+
+UBUNTU_VERSION="${UBUNTU_VERSION:-26.04}"
+OUT_DIR="${1:-dist}"
+
+# Resolve repository root from this script's location so it works from any CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DOCKERFILE="${REPO_ROOT}/packaging/deb/Dockerfile"
+
+# Derive the version on the host, where git works (the container build context
+# excludes .git — it is often a worktree pointer that does not resolve inside the
+# container). cmake/Version.cmake parses this string from version.txt.
+ENDO_VERSION="$(git -C "${REPO_ROOT}" describe --tags --long --match 'v*' --dirty 2>/dev/null || echo 0.0.0)"
+echo ">>> Endo version: ${ENDO_VERSION}"
+
+echo ">>> Building & install-testing the .deb against Ubuntu ${UBUNTU_VERSION}"
+docker buildx build \
+    --target tester \
+    --build-arg "UBUNTU_VERSION=${UBUNTU_VERSION}" \
+    --build-arg "ENDO_VERSION=${ENDO_VERSION}" \
+    -f "${DOCKERFILE}" \
+    "${REPO_ROOT}"
+
+echo ">>> Extracting packages to ${OUT_DIR}/"
+docker buildx build \
+    --target export \
+    --build-arg "UBUNTU_VERSION=${UBUNTU_VERSION}" \
+    --build-arg "ENDO_VERSION=${ENDO_VERSION}" \
+    --output "type=local,dest=${OUT_DIR}" \
+    -f "${DOCKERFILE}" \
+    "${REPO_ROOT}"
+
+echo ">>> Done. Packages in ${OUT_DIR}/:"
+ls -1 "${OUT_DIR}"


### PR DESCRIPTION
## Summary

Adds Debian packaging to CI, producing a `.deb` (plus a `-dbgsym` `.ddeb`) consumable on the latest Ubuntu LTS (26.04), built with **cpack** inside **Docker** so the build and the install test run in an environment identical to the one users install on — independent of the GitHub-hosted runner image.

The existing static Linux binary is kept; the `.deb` is added alongside.

## What's included

- **`packaging/deb/Dockerfile`** — multi-stage (`builder` / `tester` / `export`), parameterized `ARG UBUNTU_VERSION=26.04`:
  - *builder*: compiles Endo with clang-21 and runs `cpack --preset clang-deb`.
  - *tester*: `apt install`s **both** the `.deb` and the `-dbgsym` `.ddeb` into a clean Ubuntu 26.04, then smoke-tests (`endo --version`, `endo -c 'println "hello"'`, data dir + debug-symbol dir present, `dpkg -s`). Any failure fails the build.
  - *export*: emits the artifacts for `buildx --output`.
- **`scripts/package-deb.sh`** — single entry point for CI and local use (`./scripts/package-deb.sh dist`). Derives the version on the host and injects it via build-arg.
- **`cmake/Packaging.cmake`** — enable `CPACK_DEBIAN_DEBUGINFO_PACKAGE` (the `.ddeb`).
- **`CMakePresets.json`** — `clang-deb` configure/build/package preset (RelWithDebInfo + `-Wl,--build-id` for the debug-symbol split), DEB-only.
- **CI** — new `linux-deb` job in `build.yml` (PRs + master pushes; uploads `.deb`/`.ddeb` as artifacts) and in `release.yml` (uploads them to the GitHub Release).
- **Docs** — README documents `.deb`/`.ddeb` installation.

## Verification

Ran `./scripts/package-deb.sh` locally against `ubuntu:26.04`:
- Produced `endo_0.1.0_amd64.deb` and `endo-dbgsym_0.1.0_amd64.ddeb`.
- `Depends:` resolved via SHLIBDEPS: `libc6, libcurl4t64, libgcc-s1, libstdc++6, libyaml-cpp0.8` (header-only deps correctly produce no dependency).
- Both packages install cleanly in a fresh Ubuntu 26.04 and the binary runs.

## Risk / performance

- No runtime code changes; packaging/CI infrastructure only. The `.deb` is `RelWithDebInfo` (standard for distro packages, required for the `.ddeb` split).
- Adds a Docker-based job to PR CI (full from-scratch build); `buildx` layer caching mitigates within a run. amd64 only, matching the existing static artifact.