### PR TITLE
Show user@host in the shell prompt

### DIFF
--- a/docs/shell/configuration.md
+++ b/docs/shell/configuration.md
@@ -97,6 +97,17 @@ Available presets: `minimal-arrow`, `lambda-clean`, `opencode-bar`, `powerline`,
 `transient`, `dashboard`, `boxed-module`, `gradient-glow`, `context-adaptive`,
 `endo-signature`.
 
+### User and host
+
+Most presets begin the info line with the `hostname` module, which renders your
+identity as `user@host` (fish-style) to the left of the working directory --
+for example, `alice@web-prod-01`. It is shown in every session, so when you SSH
+into a remote machine the prompt makes the change of host obvious. The username
+is taken from `USER` (or `LOGNAME`, or `USERNAME` on Windows) and the hostname
+from the local machine. The minimal presets (`minimal-arrow`, `lambda-clean`)
+omit it to stay compact. The user and host portions are colored independently
+via `shell_prompt_color_username` and `shell_prompt_color_hostname`.
+
 ### Layout
 
 ```endo
@@ -343,7 +354,8 @@ shell_prompt_color_duration <- "#FFB86C:#FF5555"
 | `shell_prompt_color_indicator_error` | Indicator when last command failed |
 | `shell_prompt_color_exit_code` | Exit code badge |
 | `shell_prompt_color_duration` | Command duration badge |
-| `shell_prompt_color_hostname` | Hostname (shown in SSH sessions) |
+| `shell_prompt_color_hostname` | Host portion of the `user@host` identity |
+| `shell_prompt_color_username` | User portion of the `user@host` identity |
 | `shell_prompt_color_separator` | Left bar / separator |
 | `shell_prompt_color_badge` | Badge background (F# mode, structured output) |
 | `shell_prompt_color_badge_text` | Badge text |

--- a/src/endo-language/builtins/PropertyDescriptors.cpp
+++ b/src/endo-language/builtins/PropertyDescriptors.cpp
@@ -326,8 +326,18 @@ static constexpr std::array PromptProperties = {
         .name = "shell_prompt_color_hostname",
         .type = CoreVM::LiteralType::String,
         .description = "Hostname text color (#RRGGBB, gradient, or theme)",
-        .detail = "**shell_prompt_color_hostname** -- property\n\nSets the hostname module text color (shown "
-                  "in SSH sessions).",
+        .detail = "**shell_prompt_color_hostname** -- property\n\nSets the host portion of the `user@host` "
+                  "prompt identity.",
+        .readOnly = false,
+        .enumValues = ColorValues,
+        .extraSetterTypes = StringOrFunctionExtraTypes,
+    },
+    PropertyDescriptor {
+        .name = "shell_prompt_color_username",
+        .type = CoreVM::LiteralType::String,
+        .description = "Username text color (#RRGGBB, gradient, or theme)",
+        .detail = "**shell_prompt_color_username** -- property\n\nSets the user portion of the `user@host` "
+                  "prompt identity.",
         .readOnly = false,
         .enumValues = ColorValues,
         .extraSetterTypes = StringOrFunctionExtraTypes,

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -16,6 +16,8 @@ add_library(endo-platform STATIC
     UserPaths.hpp
     PathUtils.hpp
     PathUtils.cpp
+    SystemInfo.hpp
+    SystemInfo.cpp
     ProcessProvider.hpp
     ProcessProvider.cpp
     FileSystem.hpp

--- a/src/platform/EnvironmentProvider.hpp
+++ b/src/platform/EnvironmentProvider.hpp
@@ -84,6 +84,22 @@ class EnvironmentProvider
         return std::nullopt;
     }
 
+    /// @brief Returns the current user's login name.
+    ///
+    /// Tries USER, then LOGNAME (both POSIX), then USERNAME (Windows).
+    ///
+    /// @return The login name, or std::nullopt if none of the variables are set.
+    [[nodiscard]] auto userName() const -> std::optional<std::string>
+    {
+        if (auto user = get("USER"); user && !user->empty())
+            return *user;
+        if (auto logname = get("LOGNAME"); logname && !logname->empty())
+            return *logname;
+        if (auto username = get("USERNAME"); username && !username->empty())
+            return *username;
+        return std::nullopt;
+    }
+
     /// @brief Returns the user's configuration base directory.
     ///
     /// On Unix: XDG_CONFIG_HOME or ~/.config.

--- a/src/platform/EnvironmentProvider_test.cpp
+++ b/src/platform/EnvironmentProvider_test.cpp
@@ -37,6 +37,52 @@ TEST_CASE("TestEnvironmentProvider.keys", "[platform]")
     CHECK(keys.size() == 2);
 }
 
+TEST_CASE("EnvironmentProvider.userName_prefers_USER", "[platform]")
+{
+    TestEnvironmentProvider env;
+    env.set("USER", "alice");
+    env.set("LOGNAME", "bob");
+    env.set("USERNAME", "carol");
+    auto const name = env.userName();
+    REQUIRE(name.has_value());
+    CHECK(*name == "alice");
+}
+
+TEST_CASE("EnvironmentProvider.userName_falls_back_to_LOGNAME", "[platform]")
+{
+    TestEnvironmentProvider env;
+    env.set("LOGNAME", "bob");
+    env.set("USERNAME", "carol");
+    auto const name = env.userName();
+    REQUIRE(name.has_value());
+    CHECK(*name == "bob");
+}
+
+TEST_CASE("EnvironmentProvider.userName_falls_back_to_USERNAME", "[platform]")
+{
+    TestEnvironmentProvider env;
+    env.set("USERNAME", "carol");
+    auto const name = env.userName();
+    REQUIRE(name.has_value());
+    CHECK(*name == "carol");
+}
+
+TEST_CASE("EnvironmentProvider.userName_skips_empty_values", "[platform]")
+{
+    TestEnvironmentProvider env;
+    env.set("USER", "");
+    env.set("USERNAME", "carol");
+    auto const name = env.userName();
+    REQUIRE(name.has_value());
+    CHECK(*name == "carol");
+}
+
+TEST_CASE("EnvironmentProvider.userName_missing", "[platform]")
+{
+    TestEnvironmentProvider env;
+    CHECK(!env.userName().has_value());
+}
+
 TEST_CASE("TestEnvironmentProvider.changeDirectory", "[platform]")
 {
     TestEnvironmentProvider env("/home/user");

--- a/src/platform/SystemInfo.cpp
+++ b/src/platform/SystemInfo.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <array>
+
+#include <platform/SystemInfo.hpp>
+
+#if defined(_WIN32)
+    #include <windows.h>
+#else
+    #include <unistd.h>
+#endif
+
+namespace endo::platform
+{
+
+std::string hostName()
+{
+    auto buf = std::array<char, 256> {};
+#if defined(_WIN32)
+    auto bufLen = static_cast<DWORD>(buf.size());
+    if (GetComputerNameA(buf.data(), &bufLen))
+        return std::string(buf.data(), bufLen);
+#else
+    if (gethostname(buf.data(), buf.size()) == 0)
+        return std::string(buf.data());
+#endif
+    return {};
+}
+
+} // namespace endo::platform

--- a/src/platform/SystemInfo.hpp
+++ b/src/platform/SystemInfo.hpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <string>
+
+namespace endo::platform
+{
+
+/// @brief Returns the local machine's hostname.
+///
+/// Encapsulates the per-platform system call (`GetComputerNameA` on Windows,
+/// `gethostname` on POSIX) so business logic stays free of platform `#ifdef`s.
+///
+/// @return The hostname, or an empty string if it could not be determined.
+[[nodiscard]] std::string hostName();
+
+} // namespace endo::platform

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -285,6 +285,7 @@ if(ENDO_TESTING)
         commands/PkillCommand_test.cpp
         ui/PromptComponent_test.cpp
         ui/modules/GitModule_test.cpp
+        ui/modules/HostnameModule_test.cpp
         ui/modules/PathModule_test.cpp
         ui/Gradient_test.cpp
         completion/Completer_test.cpp

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -106,6 +106,7 @@
 #include <platform/Pipe.hpp>
 #include <platform/Process.hpp>
 #include <platform/SignalHandler.hpp>
+#include <platform/SystemInfo.hpp>
 #include <platform/Types.hpp>
 #include <platform/UserPaths.hpp>
 #if defined(_WIN32)
@@ -938,17 +939,9 @@ void Shell::emitCurrentWorkingDirectory()
     }
 
     // Get hostname for the file:// URI
-    auto hostname = std::array<char, 256> {};
-#if defined(_WIN32)
-    DWORD hostnameLen = static_cast<DWORD>(hostname.size());
-    if (!GetComputerNameA(hostname.data(), &hostnameLen))
-        hostname[0] = '\0';
-#else
-    if (gethostname(hostname.data(), hostname.size()) != 0)
-        hostname[0] = '\0';
-#endif
+    auto const hostname = platform::hostName();
 
-    _tty.writeToStdout(std::format("\033]7;file://{}{}\033\\", hostname.data(), encoded));
+    _tty.writeToStdout(std::format("\033]7;file://{}{}\033\\", hostname, encoded));
 }
 
 void Shell::emitWindowTitle(std::string_view title)
@@ -1298,19 +1291,10 @@ void Shell::updatePromptContext()
     ctx.lastExitCode = _exitCode;
     ctx.lastDuration = _lastCommandDuration;
     ctx.terminalWidth = prompt.terminal().columns();
-    ctx.isSSH = std::getenv("SSH_CONNECTION") != nullptr;
-    if (ctx.isSSH)
-    {
-        auto buf = std::array<char, 256> {};
-#if defined(_WIN32)
-        DWORD bufLen = static_cast<DWORD>(buf.size());
-        if (GetComputerNameA(buf.data(), &bufLen))
-            ctx.hostname = buf.data();
-#else
-        if (gethostname(buf.data(), buf.size()) == 0)
-            ctx.hostname = buf.data();
-#endif
-    }
+    ctx.isSSH = _env.get("SSH_CONNECTION").has_value();
+    // Populate identity unconditionally so the prompt can show user@host in every session.
+    ctx.hostname = platform::hostName();
+    ctx.username = _env.userName().value_or("");
     ctx.theme = &tui::currentTheme();
     ctx.fsharpState = &_fsharpState;
     ctx.outputDefs = &_outputDefinitions;

--- a/src/shell/builtins/Registration.cpp
+++ b/src/shell/builtins/Registration.cpp
@@ -1182,6 +1182,7 @@ void Shell::registerPromptBuiltins()
     registerColorProp("shell_prompt_color_exit_code",       "exit_code",       &PromptColorOverrides::exitCode);
     registerColorProp("shell_prompt_color_duration",        "duration",        &PromptColorOverrides::duration);
     registerColorProp("shell_prompt_color_hostname",        "hostname",        &PromptColorOverrides::hostname);
+    registerColorProp("shell_prompt_color_username",        "username",        &PromptColorOverrides::username);
     registerColorProp("shell_prompt_color_separator",       "separator",       &PromptColorOverrides::separator);
     registerColorProp("shell_prompt_color_badge",           "badge",           &PromptColorOverrides::badge);
     registerColorProp("shell_prompt_color_badge_text",      "badge_text",      &PromptColorOverrides::badgeText);

--- a/src/shell/ui/PromptColorResolver.cpp
+++ b/src/shell/ui/PromptColorResolver.cpp
@@ -62,6 +62,7 @@ ResolvedPromptColors resolvePromptColors(PromptColorOverrides const& overrides,
     resolved.exitCode = resolveField(overrides.exitCode, themeColors.exitCode);
     resolved.duration = resolveField(overrides.duration, themeColors.duration);
     resolved.hostname = resolveField(overrides.hostname, themeColors.hostname);
+    resolved.username = resolveField(overrides.username, themeColors.username);
     resolved.separator = resolveField(overrides.separator, themeColors.separator);
     resolved.badge = resolveField(overrides.badge, themeColors.badge);
     resolved.badgeText = resolveField(overrides.badgeText, themeColors.badgeText);

--- a/src/shell/ui/PromptColorResolver.hpp
+++ b/src/shell/ui/PromptColorResolver.hpp
@@ -27,6 +27,7 @@ struct ResolvedPromptColors
     ColorSpec exitCode;       ///< Exit code badge color.
     ColorSpec duration;       ///< Duration badge color.
     ColorSpec hostname;       ///< Hostname text color.
+    ColorSpec username;       ///< Username text color.
     tui::Color background;    ///< Prompt background (may be monostate for transparent).
     ColorSpec separator;      ///< Separator/bar color.
     ColorSpec badge;          ///< Badge background color.

--- a/src/shell/ui/PromptComponent.cpp
+++ b/src/shell/ui/PromptComponent.cpp
@@ -326,6 +326,7 @@ void PromptComponent::render(tui::Canvas& canvas)
             { "exit_code", &PromptColorOverrides::exitCode },
             { "duration", &PromptColorOverrides::duration },
             { "hostname", &PromptColorOverrides::hostname },
+            { "username", &PromptColorOverrides::username },
             { "separator", &PromptColorOverrides::separator },
             { "badge", &PromptColorOverrides::badge },
             { "badge_text", &PromptColorOverrides::badgeText },

--- a/src/shell/ui/PromptConfig.hpp
+++ b/src/shell/ui/PromptConfig.hpp
@@ -74,6 +74,7 @@ struct PromptColorOverrides
     std::optional<ColorSpec> exitCode;       ///< Exit code badge color.
     std::optional<ColorSpec> duration;       ///< Duration badge color.
     std::optional<ColorSpec> hostname;       ///< Hostname text color.
+    std::optional<ColorSpec> username;       ///< Username text color.
     std::optional<ColorSpec>
         background; ///< Prompt background (solid only; gradient bg uses auroraBackground).
     std::optional<ColorSpec> separator; ///< Separator/bar color.

--- a/src/shell/ui/PromptModule.hpp
+++ b/src/shell/ui/PromptModule.hpp
@@ -73,6 +73,7 @@ struct PromptContext
     int terminalWidth = 80;                       ///< Terminal width in columns.
     bool isSSH = false;                           ///< Whether running inside an SSH session.
     std::string hostname;                         ///< Hostname of the machine.
+    std::string username;                         ///< Current user's login name.
     tui::Theme const* theme = nullptr;            ///< Current TUI theme.
     ResolvedPromptColors const* resolvedColors =
         nullptr; ///< Resolved prompt colors (overrides merged with theme).

--- a/src/shell/ui/PromptPresets.cpp
+++ b/src/shell/ui/PromptPresets.cpp
@@ -34,7 +34,7 @@ static std::vector<PromptConfig> const& presets()
         .layout = PromptLayoutKind::TwoLine,
         .separator = SeparatorStyle::Bar,
         .indicator = "> ",
-        .infoLineModules = { "path", "git" },
+        .infoLineModules = { "hostname", "path", "git" },
         .rightPromptModules = {},
     },
     PromptConfig {
@@ -42,7 +42,7 @@ static std::vector<PromptConfig> const& presets()
         .layout = PromptLayoutKind::Powerline,
         .separator = SeparatorStyle::Powerline,
         .indicator = "\xe2\x9d\xaf ", // ❯
-        .infoLineModules = { "path", "git" },
+        .infoLineModules = { "hostname", "path", "git" },
         .rightPromptModules = {},
     },
     PromptConfig {
@@ -51,7 +51,7 @@ static std::vector<PromptConfig> const& presets()
         .separator = SeparatorStyle::Rounded,
         .transient = TransientMode::Arrow,
         .indicator = "\xe2\x9d\xaf ", // ❯
-        .infoLineModules = { "path", "git" },
+        .infoLineModules = { "hostname", "path", "git" },
         .rightPromptModules = {},
     },
     PromptConfig {
@@ -59,7 +59,7 @@ static std::vector<PromptConfig> const& presets()
         .layout = PromptLayoutKind::TwoLine,
         .separator = SeparatorStyle::None,
         .indicator = "\xe2\x9d\xaf ", // ❯
-        .infoLineModules = { "path", "git" },
+        .infoLineModules = { "hostname", "path", "git" },
         .rightPromptModules = { "duration", "shell_level", "battery", "clock" },
     },
     PromptConfig {
@@ -67,7 +67,7 @@ static std::vector<PromptConfig> const& presets()
         .layout = PromptLayoutKind::Boxed,
         .separator = SeparatorStyle::Boxed,
         .indicator = "\xe2\x9d\xaf\xe2\x9d\xaf ", // ❯❯
-        .infoLineModules = { "path", "git", "toolchain" },
+        .infoLineModules = { "hostname", "path", "git", "toolchain" },
         .rightPromptModules = {},
     },
     PromptConfig {
@@ -75,7 +75,7 @@ static std::vector<PromptConfig> const& presets()
         .layout = PromptLayoutKind::TwoLine,
         .separator = SeparatorStyle::None,
         .indicator = "\xe2\x9e\xa4\xe2\x9e\xa4\xe2\x9e\xa4 ", // ➤➤➤
-        .infoLineModules = { "path", "git" },
+        .infoLineModules = { "hostname", "path", "git" },
         .rightPromptModules = {},
         .colorOverrides = { .path = ColorSpec { { 0x5078FF_rgb, 0x00DCC8_rgb } } }, // Blue → Teal gradient
     },
@@ -92,7 +92,7 @@ static std::vector<PromptConfig> const& presets()
         .layout = PromptLayoutKind::TwoLine,
         .separator = SeparatorStyle::Rounded,
         .indicator = "|> ",
-        .infoLineModules = { "path", "git", "fsharp_mode", "structured_output" },
+        .infoLineModules = { "hostname", "path", "git", "fsharp_mode", "structured_output" },
         .rightPromptModules = { "duration", "exit_status", "shell_level", "battery", "clock" },
         .auroraBackground = {
             0x252545_rgb, // deep indigo

--- a/src/shell/ui/modules/HostnameModule.cpp
+++ b/src/shell/ui/modules/HostnameModule.cpp
@@ -9,19 +9,36 @@ namespace endo
 
 bool HostnameModule::shouldShow(PromptContext const& ctx) const
 {
-    return ctx.isSSH;
+    return !ctx.username.empty() || !ctx.hostname.empty();
 }
 
 PromptSegments HostnameModule::evaluate(PromptContext const& ctx) const
 {
-    auto style = tui::Style {};
-    if (ctx.resolvedColors)
-        style.fg = ctx.resolvedColors->hostname.solid();
-    else if (ctx.theme)
-        style.fg = ctx.theme->promptColors.hostname;
-    style.bold = true;
+    /// @brief Builds a bold style carrying @p picker's foreground color.
+    auto const styled = [&ctx](auto picker) {
+        auto style = tui::Style {};
+        if (ctx.resolvedColors)
+            style.fg = picker(*ctx.resolvedColors).solid();
+        else if (ctx.theme)
+            style.fg = picker(ctx.theme->promptColors);
+        style.bold = true;
+        return style;
+    };
 
-    return { PromptSegment { .text = ctx.hostname + ":", .style = style } };
+    auto const usernameStyle = styled([](auto const& c) { return c.username; });
+    auto const hostnameStyle = styled([](auto const& c) { return c.hostname; });
+
+    // Fish-style `user@host`, with the user and host parts independently colored and
+    // degrading gracefully when only one part is known. The `@` adopts the host color.
+    auto segments = PromptSegments {};
+    if (!ctx.username.empty())
+        segments.push_back(PromptSegment { .text = ctx.username, .style = usernameStyle });
+    if (!ctx.username.empty() && !ctx.hostname.empty())
+        segments.push_back(PromptSegment { .text = "@", .style = hostnameStyle });
+    if (!ctx.hostname.empty())
+        segments.push_back(PromptSegment { .text = ctx.hostname, .style = hostnameStyle });
+
+    return segments;
 }
 
 } // namespace endo

--- a/src/shell/ui/modules/HostnameModule.hpp
+++ b/src/shell/ui/modules/HostnameModule.hpp
@@ -6,7 +6,12 @@
 namespace endo
 {
 
-/// @brief Prompt module that shows hostname when running under SSH.
+/// @brief Prompt module that shows the current `user@host` identity.
+///
+/// Renders the login name and hostname in fish-style `user@host` form to the left of
+/// the working directory. Shown in every session (local and remote) so the prompt always
+/// conveys who you are and which machine you're on. Hidden only when neither the username
+/// nor the hostname could be determined.
 class HostnameModule final: public PromptModule
 {
   public:

--- a/src/shell/ui/modules/HostnameModule_test.cpp
+++ b/src/shell/ui/modules/HostnameModule_test.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <shell/ui/PromptColorResolver.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <utility>
+
+#include "HostnameModule.hpp"
+
+using namespace endo;
+
+namespace
+{
+
+/// @brief Builds a PromptContext with the given identity for HostnameModule tests.
+[[nodiscard]] PromptContext makeContext(std::string username, std::string hostname)
+{
+    auto ctx = PromptContext {};
+    ctx.username = std::move(username);
+    ctx.hostname = std::move(hostname);
+    return ctx;
+}
+
+/// @brief Renders a HostnameModule and returns the concatenated segment text.
+[[nodiscard]] std::string renderHostname(PromptContext const& ctx)
+{
+    auto text = std::string {};
+    for (auto const& seg: HostnameModule {}.evaluate(ctx))
+        text += seg.text;
+    return text;
+}
+
+} // namespace
+
+TEST_CASE("HostnameModule.renders_user_at_host")
+{
+    auto const ctx = makeContext("alice", "web-prod-01");
+    CHECK(HostnameModule {}.shouldShow(ctx));
+    CHECK(renderHostname(ctx) == "alice@web-prod-01");
+}
+
+TEST_CASE("HostnameModule.username_only_omits_at")
+{
+    auto const ctx = makeContext("alice", "");
+    CHECK(HostnameModule {}.shouldShow(ctx));
+    CHECK(renderHostname(ctx) == "alice");
+}
+
+TEST_CASE("HostnameModule.hostname_only_omits_at")
+{
+    auto const ctx = makeContext("", "web-prod-01");
+    CHECK(HostnameModule {}.shouldShow(ctx));
+    CHECK(renderHostname(ctx) == "web-prod-01");
+}
+
+TEST_CASE("HostnameModule.hidden_when_identity_unknown")
+{
+    auto const ctx = makeContext("", "");
+    CHECK_FALSE(HostnameModule {}.shouldShow(ctx));
+}
+
+TEST_CASE("HostnameModule.colors_user_and_host_independently")
+{
+    auto colors = ResolvedPromptColors {};
+    colors.username = ColorSpec { .colors = { tui::RgbColor { .r = 1, .g = 2, .b = 3 } } };
+    colors.hostname = ColorSpec { .colors = { tui::RgbColor { .r = 4, .g = 5, .b = 6 } } };
+
+    auto ctx = makeContext("alice", "web-prod-01");
+    ctx.resolvedColors = &colors;
+
+    auto const userColor = tui::Color { colors.username.solid() };
+    auto const hostColor = tui::Color { colors.hostname.solid() };
+
+    auto const segments = HostnameModule {}.evaluate(ctx);
+    REQUIRE(segments.size() == 3);
+    CHECK(segments[0].text == "alice");
+    CHECK(segments[0].style.fg == userColor);
+    CHECK(segments[1].text == "@");
+    CHECK(segments[1].style.fg == hostColor);
+    CHECK(segments[2].text == "web-prod-01");
+    CHECK(segments[2].style.fg == hostColor);
+}

--- a/src/tui/Theme.cpp
+++ b/src/tui/Theme.cpp
@@ -97,6 +97,7 @@ auto darkTheme() -> Theme
         .exitCode = 0xFF5555_rgb,       // Red
         .duration = 0xFFB86C_rgb,       // Orange
         .hostname = 0xB482FF_rgb,       // Purple
+        .username = 0x82E0A0_rgb,       // Soft green
         .background = 0x2D3237_rgb,     // Soft gray
         .separator = 0x61AFEF_rgb,      // Soft blue (left bar)
         .badge = 0x3C4148_rgb,          // Dark badge bg
@@ -220,6 +221,7 @@ auto lightTheme() -> Theme
         .exitCode = 0xC83232_rgb,       // Red
         .duration = 0xC88200_rgb,       // Orange
         .hostname = 0x6400B4_rgb,       // Purple
+        .username = 0x008250_rgb,       // Green
         .background = 0xEBEDF0_rgb,     // Light gray
         .separator = 0x0064C8_rgb,      // Blue
         .badge = 0xDCE1E6_rgb,          // Light badge bg
@@ -337,6 +339,7 @@ auto monoTheme() -> Theme
         .exitCode = 0xFFFFFF_rgb,
         .duration = 0xC8C8C8_rgb,
         .hostname = 0xFFFFFF_rgb,
+        .username = 0xFFFFFF_rgb,
         .background = 0x1E1E1E_rgb,
         .separator = 0xC8C8C8_rgb,
         .badge = 0x323232_rgb,

--- a/src/tui/Theme.hpp
+++ b/src/tui/Theme.hpp
@@ -103,6 +103,7 @@ struct Theme
         RgbColor exitCode;       ///< Exit code badge color.
         RgbColor duration;       ///< Duration badge color.
         RgbColor hostname;       ///< Hostname text color.
+        RgbColor username;       ///< Username text color.
         RgbColor background;     ///< Prompt background color.
         RgbColor separator;      ///< Separator/bar color.
         RgbColor badge;          ///< Badge background color.


### PR DESCRIPTION
The prompt never surfaced who you are or which machine you're on, so SSH'ing into a remote host gave no visual cue. This adds a fish-style `user@host` identity to the left of the working directory, shown in every session (local and remote), with the user and host portions colored independently.

## Changes

- Add `platform::hostName()` (encapsulating the `GetComputerNameA`/`gethostname` `#ifdef`) and `EnvironmentProvider::userName()` (`USER` → `LOGNAME` → `USERNAME`), removing platform branches from `Shell.cpp` — both the prompt-context populator and the OSC-7 `file://` emitter now share the helper.
- Populate username/hostname unconditionally in the prompt context and detect SSH via the injected environment provider instead of raw `std::getenv`.
- Render `user@host` in `HostnameModule` (degrading gracefully to just one part), and lead the info line of all path-bearing presets with it; the minimal presets stay compact.
- Color the user and host portions independently: `shell_prompt_color_hostname` is now host-only and a new `shell_prompt_color_username` controls the user portion, wired through the theme palette, override field, resolver, dynamic color-function map, and LSP property descriptor.
- Document the new identity and color properties in the shell configuration guide.