### PR TITLE
Fix clang-debug build on Clang 22 and bump CI to Clang 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  LLVM_VERSION: "22"
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -41,7 +44,7 @@ jobs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 21
+        sudo ./llvm.sh ${{ env.LLVM_VERSION }}
 
     - name: Install Homebrew dependencies (macOS)
       if: runner.os == 'macOS'
@@ -71,7 +74,7 @@ jobs:
 
     - name: Configure CMake (Linux)
       if: runner.os == 'Linux'
-      run: cmake --preset clang-release -DCMAKE_C_COMPILER=clang-21 -DCMAKE_CXX_COMPILER=clang++-21
+      run: cmake --preset clang-release -DCMAKE_C_COMPILER=clang-${{ env.LLVM_VERSION }} -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }}
 
     - name: Configure CMake (macOS)
       if: runner.os == 'macOS'
@@ -130,7 +133,7 @@ jobs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 21
+        sudo ./llvm.sh ${{ env.LLVM_VERSION }}
 
     - name: "Get library crispy & vtparser"
       run: python3 scripts/get_contour_dirs.py
@@ -138,8 +141,8 @@ jobs:
     - name: Configure CMake
       run: >
         cmake -B build/static
-        -DCMAKE_CXX_COMPILER=clang++-21
-        -DCMAKE_C_COMPILER=clang-21
+        -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }}
+        -DCMAKE_C_COMPILER=clang-${{ env.LLVM_VERSION }}
         -DCMAKE_BUILD_TYPE=Release
         -DENABLE_STATIC_LINKING=ON
         -GNinja

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -8,6 +8,9 @@ concurrency:
   group: clang-tidy-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  LLVM_VERSION: "22"
+
 jobs:
   clang-tidy-diff:
     runs-on: ubuntu-latest
@@ -33,12 +36,12 @@ jobs:
     - name: Install Ninja
       uses: seanmiddleditch/gha-setup-ninja@master
 
-    - name: Install LLVM 21
+    - name: Install LLVM ${{ env.LLVM_VERSION }}
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 21
-        sudo apt-get install -y clang-tidy-21
+        sudo ./llvm.sh ${{ env.LLVM_VERSION }}
+        sudo apt-get install -y clang-tidy-${{ env.LLVM_VERSION }}
 
     - name: Setup clang-tidy problem matcher
       run: echo "::add-matcher::.github/clang-tidy-matcher.json"
@@ -46,8 +49,8 @@ jobs:
     - name: Configure CMake
       run: >
         cmake -B build
-        -DCMAKE_CXX_COMPILER=clang++-21
-        -DCMAKE_C_COMPILER=clang-21
+        -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }}
+        -DCMAKE_C_COMPILER=clang-${{ env.LLVM_VERSION }}
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -GNinja
         -S ${{ github.workspace }}
@@ -57,7 +60,7 @@ jobs:
 
     - name: Run clang-tidy on PR diff
       run: |
-        CLANG_TIDY_DIFF=$(find /usr/lib/llvm-21 -name 'clang-tidy-diff.py' -print -quit)
+        CLANG_TIDY_DIFF=$(find /usr/lib/llvm-${{ env.LLVM_VERSION }} -name 'clang-tidy-diff.py' -print -quit)
         if [ -z "$CLANG_TIDY_DIFF" ]; then
           echo "::error::clang-tidy-diff.py not found"
           exit 1
@@ -70,6 +73,6 @@ jobs:
           | python3 "$CLANG_TIDY_DIFF" \
               -p1 \
               -path build \
-              -clang-tidy-binary clang-tidy-21 \
+              -clang-tidy-binary clang-tidy-${{ env.LLVM_VERSION }} \
               -j$(nproc) \
               -quiet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ concurrency:
 
 env:
   RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag || github.ref_name }}
+  LLVM_VERSION: "22"
 
 jobs:
   create-release:
@@ -47,8 +48,8 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
 
-      - name: Install Clang 21
-        run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 21
+      - name: Install Clang ${{ env.LLVM_VERSION }}
+        run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- ${{ env.LLVM_VERSION }}
 
       - name: Install system dependencies
         run: sudo apt-get install -y ninja-build libc6-dev
@@ -68,8 +69,8 @@ jobs:
       - name: Configure
         run: >
           cmake --preset clang-release-static
-          -DCMAKE_C_COMPILER=clang-21
-          -DCMAKE_CXX_COMPILER=clang++-21
+          -DCMAKE_C_COMPILER=clang-${{ env.LLVM_VERSION }}
+          -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }}
           -DCMAKE_C_COMPILER_LAUNCHER=ccache
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -2009,7 +2009,7 @@ std::filesystem::path onDiskName(std::filesystem::path const& parent, std::strin
     namespace fs = std::filesystem;
     for (auto const& entry: fs::directory_iterator(parent))
     {
-        auto const candidate = entry.path().filename().string();
+        auto candidate = entry.path().filename().string();
         if (endo::platform::equalsCaseInsensitive(candidate, name))
             return candidate;
     }


### PR DESCRIPTION
After upgrading to Clang 22, `cmake --build --preset clang-debug` fails: the `clang-debug` preset runs clang-tidy with `WarningsAsErrors: *`, and Clang 22's `performance-no-automatic-move` check now flags a pre-existing `const` local in `onDiskName()` that prevents the returned `std::string` from being moved. CI did not catch this because every workflow pinned LLVM 21 while developers now build with Clang 22, hiding checks that are new or stronger in 22.

## Changes

- Drop `const` from the `candidate` local in `onDiskName()` (`src/shell/Shell_test.cpp`) so the return is move-eligible and the clang-tidy error clears.
- Bump every LLVM/Clang reference to 22 across the `build`, `clang-tidy`, and `release` workflows so CI matches the developer toolchain and the diff-based clang-tidy job catches this class of error on the PR that introduces it.
- Route each workflow's version through a single `LLVM_VERSION` env var, so future bumps are a one-line change per file.