### PR TITLE
Fix Windows command resolution preferring extensionless files over .exe

### DIFF
--- a/src/shell/util/CommandResolver.cpp
+++ b/src/shell/util/CommandResolver.cpp
@@ -5,8 +5,7 @@
 
 #include <crispy/utils.h>
 
-#include <algorithm>
-#include <cctype>
+#include <array>
 #include <filesystem>
 
 #include <platform/EnvironmentProvider.hpp>
@@ -55,17 +54,79 @@ CommandInfo CommandResolver::resolve(std::string_view command) const
 
 void CommandResolver::invalidateCache()
 {
-    _cachedPath.clear();
+    _cacheKey.clear();
     _pathCache.clear();
+}
+
+#if defined(_WIN32)
+namespace
+{
+    /// Executable extensions used when %PATHEXT% is unset, empty, or all-blank. Lower-cased
+    /// because Windows path comparison is case-insensitive and isExecutableFile() ignores case.
+    constexpr std::array<std::string_view, 5> DefaultPathExt { ".exe", ".cmd", ".bat", ".com", ".ps1" };
+
+    /// Trims leading/trailing ASCII whitespace from @p value.
+    constexpr std::string_view trim(std::string_view value) noexcept
+    {
+        value = crispy::trimRight(value);
+        while (!value.empty() && std::string_view(" \t\r\n").find(value.front()) != std::string_view::npos)
+            value.remove_prefix(1);
+        return value;
+    }
+
+    /// Returns the PATHEXT extension list, skipping empty/blank tokens (e.g. from a stray
+    /// ";;") and falling back to DefaultPathExt when none remain — an empty token would
+    /// otherwise re-introduce the bare-name probe and let an extensionless shim shadow the
+    /// real executable.
+    std::vector<std::string> pathExtList(EnvironmentProvider const& env)
+    {
+        auto extensions = std::vector<std::string> {};
+        if (auto const pathext = env.get("PATHEXT"))
+            for (auto const& raw: crispy::split(*pathext, ';'))
+                if (auto const ext = trim(raw); !ext.empty())
+                    extensions.emplace_back(ext);
+
+        if (extensions.empty())
+            for (auto const& ext: DefaultPathExt)
+                extensions.emplace_back(ext);
+
+        return extensions;
+    }
+} // namespace
+#endif
+
+std::vector<std::string> CommandResolver::candidateNames([[maybe_unused]] EnvironmentProvider const& env,
+                                                         std::string_view command)
+{
+#if !defined(_WIN32)
+    return { std::string(command) };
+#else
+    // cmd.exe / PowerShell semantics: a name typed *with* an extension is used verbatim and
+    // PATHEXT is not applied; a bare name is expanded only to "command + ext" for each
+    // PATHEXT entry, and the extensionless name itself is never probed. The latter is what
+    // stops an extensionless "docker" shim from shadowing the real "docker.exe".
+    if (std::filesystem::path(command).has_extension())
+        return { std::string(command) };
+
+    auto names = std::vector<std::string> {};
+    for (auto const& ext: pathExtList(env))
+        names.emplace_back(std::string(command) + ext);
+    return names;
+#endif
 }
 
 std::string CommandResolver::findInPath(std::string_view command) const
 {
-    auto const matches = findAllInPath(command);
+    auto const matches = search(command, /*firstOnly=*/true);
     return matches.empty() ? std::string {} : matches.front();
 }
 
 std::vector<std::string> CommandResolver::findAllInPath(std::string_view command) const
+{
+    return search(command, /*firstOnly=*/false);
+}
+
+std::vector<std::string> CommandResolver::search(std::string_view command, bool firstOnly) const
 {
     auto const pathEnv = _env.get("PATH");
     if (!pathEnv)
@@ -77,79 +138,34 @@ std::vector<std::string> CommandResolver::findAllInPath(std::string_view command
     auto const pathSep = ':';
 #endif
 
-    auto const paths = crispy::split(*pathEnv, pathSep);
-
-#if defined(_WIN32)
-    // Build PATHEXT extensions list
-    auto extensions = std::vector<std::string> {};
-    if (auto const pathext = _env.get("PATHEXT"))
-    {
-        auto const exts = crispy::split(*pathext, ';');
-        for (auto const& ext: exts)
-            extensions.emplace_back(ext);
-    }
-    else
-    {
-        extensions = { ".exe", ".cmd", ".bat", ".com", ".ps1" };
-    }
-
-    // Determine whether the typed command already ends with a recognized PATHEXT
-    // extension (case-insensitive), e.g. "docker.exe". If so it is probed verbatim;
-    // otherwise the bare name is only tried with each PATHEXT extension appended.
-    auto const iequals = [](std::string_view lhs, std::string_view rhs) {
-        return std::ranges::equal(
-            lhs, rhs, [](unsigned char a, unsigned char b) { return std::tolower(a) == std::tolower(b); });
-    };
-    auto const commandExtension = std::filesystem::path(command).extension().string();
-    auto const hasPathExtExtension =
-        !commandExtension.empty()
-        && std::ranges::any_of(extensions, [&](auto const& ext) { return iequals(ext, commandExtension); });
-#endif
+    // Candidate file names are independent of the PATH directory, so compute them once.
+    auto const names = candidateNames(_env, command);
 
     auto results = std::vector<std::string> {};
 
-    for (auto const& pathStr: paths)
+    for (auto const& pathStr: crispy::split(*pathEnv, pathSep))
     {
         if (pathStr.empty())
             continue;
 
-        std::filesystem::path dir(pathStr);
-
+        auto const dir = std::filesystem::path(pathStr);
         if (!_fs.exists(dir) || !_fs.isDirectory(dir))
             continue;
 
-        auto const candidate = dir / std::string(command);
-
-#if defined(_WIN32)
-        // On Windows a bare command name is runnable only through a PATHEXT extension;
-        // an extensionless file is never an executable command (cmd.exe / PowerShell
-        // semantics). So:
-        //   - if the typed command already carries a PATHEXT extension (e.g. "docker.exe"),
-        //     probe that exact name only;
-        //   - otherwise (e.g. "docker") probe "command + ext" for each PATHEXT entry, in
-        //     PATHEXT order, and never the bare extensionless name.
-        // Without this, an extensionless "docker" shim shadows the real "docker.exe".
-        auto const candidates = [&]() {
-            auto result = std::vector<std::filesystem::path> {};
-            if (hasPathExtExtension)
-                result.push_back(candidate);
-            else
-                for (auto const& ext: extensions)
-                    result.push_back(std::filesystem::path(candidate.string() + ext));
-            return result;
-        }();
-
-        for (auto const& cand: candidates)
+        for (auto const& name: names)
         {
-            if (!_fs.isExecutableFile(cand))
+            auto const candidate = dir / name;
+            if (!_fs.isExecutableFile(candidate))
                 continue;
-            results.push_back(platform::normalizePath(cand));
-            break; // At most one match per PATH directory
-        }
+#if defined(_WIN32)
+            results.push_back(platform::normalizePath(candidate));
 #else
-        if (_fs.isExecutableFile(candidate))
             results.push_back(candidate.string());
 #endif
+            if (firstOnly)
+                return results;
+            break; // At most one match per PATH directory
+        }
     }
 
     return results;
@@ -157,14 +173,24 @@ std::vector<std::string> CommandResolver::findAllInPath(std::string_view command
 
 void CommandResolver::refreshCacheIfNeeded() const
 {
-    auto const pathEnv = _env.get("PATH");
-    std::string currentPath = pathEnv ? std::string(*pathEnv) : "";
+    auto const currentKey = computeCacheKey();
 
-    if (currentPath != _cachedPath)
+    if (currentKey != _cacheKey)
     {
-        _cachedPath = currentPath;
+        _cacheKey = currentKey;
         _pathCache.clear();
     }
+}
+
+std::string CommandResolver::computeCacheKey() const
+{
+    auto key = _env.get("PATH").value_or(std::string {});
+#if defined(_WIN32)
+    // PATHEXT also governs resolution on Windows, so a change to it must invalidate the
+    // cache too. '\x1f' (unit separator) cannot occur in a PATH/PATHEXT value.
+    key.append("\x1f").append(_env.get("PATHEXT").value_or(std::string {}));
+#endif
+    return key;
 }
 
 std::set<std::string> const& CommandResolver::builtinNames()

--- a/src/shell/util/CommandResolver.cpp
+++ b/src/shell/util/CommandResolver.cpp
@@ -5,6 +5,8 @@
 
 #include <crispy/utils.h>
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 
 #include <platform/EnvironmentProvider.hpp>
@@ -90,6 +92,18 @@ std::vector<std::string> CommandResolver::findAllInPath(std::string_view command
     {
         extensions = { ".exe", ".cmd", ".bat", ".com", ".ps1" };
     }
+
+    // Determine whether the typed command already ends with a recognized PATHEXT
+    // extension (case-insensitive), e.g. "docker.exe". If so it is probed verbatim;
+    // otherwise the bare name is only tried with each PATHEXT extension appended.
+    auto const iequals = [](std::string_view lhs, std::string_view rhs) {
+        return std::ranges::equal(
+            lhs, rhs, [](unsigned char a, unsigned char b) { return std::tolower(a) == std::tolower(b); });
+    };
+    auto const commandExtension = std::filesystem::path(command).extension().string();
+    auto const hasPathExtExtension =
+        !commandExtension.empty()
+        && std::ranges::any_of(extensions, [&](auto const& ext) { return iequals(ext, commandExtension); });
 #endif
 
     auto results = std::vector<std::string> {};
@@ -107,12 +121,21 @@ std::vector<std::string> CommandResolver::findAllInPath(std::string_view command
         auto const candidate = dir / std::string(command);
 
 #if defined(_WIN32)
-        // On Windows, check the exact name first, then try each PATHEXT extension.
+        // On Windows a bare command name is runnable only through a PATHEXT extension;
+        // an extensionless file is never an executable command (cmd.exe / PowerShell
+        // semantics). So:
+        //   - if the typed command already carries a PATHEXT extension (e.g. "docker.exe"),
+        //     probe that exact name only;
+        //   - otherwise (e.g. "docker") probe "command + ext" for each PATHEXT entry, in
+        //     PATHEXT order, and never the bare extensionless name.
+        // Without this, an extensionless "docker" shim shadows the real "docker.exe".
         auto const candidates = [&]() {
             auto result = std::vector<std::filesystem::path> {};
-            result.push_back(candidate);
-            for (auto const& ext: extensions)
-                result.push_back(std::filesystem::path(candidate.string() + ext));
+            if (hasPathExtExtension)
+                result.push_back(candidate);
+            else
+                for (auto const& ext: extensions)
+                    result.push_back(std::filesystem::path(candidate.string() + ext));
             return result;
         }();
 

--- a/src/shell/util/CommandResolver.hpp
+++ b/src/shell/util/CommandResolver.hpp
@@ -62,7 +62,8 @@ class CommandResolver
     /// @brief Searches $PATH for the first executable matching @p command.
     ///
     /// On POSIX, also verifies execute permission bits.
-    /// On Windows, reads PATHEXT and tries each extension.
+    /// On Windows, applies PATHEXT (see @ref candidateNames for the exact rule).
+    /// Stops at the first match.
     ///
     /// @param command  Bare command name (no path separators).
     /// @return Full path string if found, empty string if not found.
@@ -80,12 +81,39 @@ class CommandResolver
     EnvironmentProvider const& _env;
     FileSystem const& _fs;
 
-    // Cache for efficiency
-    mutable std::string _cachedPath;
+    // Cache for efficiency. The key combines $PATH and (on Windows) $PATHEXT, since both
+    // govern resolution; a change to either invalidates the per-command results.
+    mutable std::string _cacheKey;
     mutable std::unordered_map<std::string, std::string> _pathCache; // command -> full path
 
-    /// @brief Refreshes the PATH cache if $PATH has changed.
+    /// @brief Refreshes the PATH cache if $PATH (or, on Windows, $PATHEXT) has changed.
     void refreshCacheIfNeeded() const;
+
+    /// @brief Computes the cache key from the resolution-relevant environment.
+    /// @return $PATH on POSIX; "$PATH\\x1f$PATHEXT" on Windows.
+    [[nodiscard]] std::string computeCacheKey() const;
+
+    /// @brief Searches $PATH for executables matching @p command.
+    /// @param command   Bare command name (no path separators).
+    /// @param firstOnly Stop after the first match (used by findInPath()).
+    /// @return Full path strings for the matches found (may be empty).
+    [[nodiscard]] std::vector<std::string> search(std::string_view command, bool firstOnly) const;
+
+    /// @brief Builds the candidate file names (relative to each PATH directory) for @p command.
+    ///
+    /// POSIX: always just @p command itself.
+    /// Windows (cmd.exe / PowerShell semantics):
+    ///   - if @p command already carries an extension, it is used verbatim and PATHEXT is
+    ///     not applied (an explicitly typed name is never augmented);
+    ///   - otherwise the bare name is expanded to `command + ext` for each PATHEXT entry and
+    ///     the extensionless name is never probed — this is what stops an extensionless
+    ///     `docker` shim from shadowing the real `docker.exe`.
+    ///
+    /// @param env     Environment provider, used to read PATHEXT on Windows (unused on POSIX).
+    /// @param command Bare command name.
+    /// @return Ordered list of candidate file names.
+    [[nodiscard]] static std::vector<std::string> candidateNames(EnvironmentProvider const& env,
+                                                                 std::string_view command);
 };
 
 } // namespace endo

--- a/src/shell/util/CommandResolver_test.cpp
+++ b/src/shell/util/CommandResolver_test.cpp
@@ -138,6 +138,76 @@ TEST_CASE("CommandResolver.findInPath.PATHEXT_resolution")
     REQUIRE(!result.empty());
     CHECK(result.ends_with(".cmd"));
 }
+
+TEST_CASE("CommandResolver.findInPath.prefers_PATHEXT_over_extensionless")
+{
+    // Regression: a bare command name must resolve to its PATHEXT executable, not to an
+    // extensionless shim of the same name that happens to sit earlier in the directory.
+    platform::testing::InMemoryFileSystem fs;
+    fs.addDirectory("/bin");
+    fs.addExecutable("/bin/docker");     // extensionless shim — not a runnable Windows command
+    fs.addExecutable("/bin/docker.exe"); // the real CLI
+
+    platform::TestEnvironmentProvider env;
+    env.set("PATH", "/bin");
+    env.set("PATHEXT", ".exe;.cmd;.bat");
+
+    auto const resolver = CommandResolver(env, fs);
+    auto const result = resolver.findInPath("docker");
+    REQUIRE(!result.empty());
+    CHECK(result.ends_with("docker.exe"));
+}
+
+TEST_CASE("CommandResolver.findInPath.extensionless_only_is_not_found")
+{
+    // On Windows an extensionless file is not a runnable command, so a bare lookup that
+    // can only find one must report not-found rather than returning the unrunnable file.
+    platform::testing::InMemoryFileSystem fs;
+    fs.addDirectory("/bin");
+    fs.addExecutable("/bin/docker");
+
+    platform::TestEnvironmentProvider env;
+    env.set("PATH", "/bin");
+    env.set("PATHEXT", ".exe;.cmd;.bat");
+
+    auto const resolver = CommandResolver(env, fs);
+    CHECK(resolver.findInPath("docker").empty());
+}
+
+TEST_CASE("CommandResolver.findInPath.explicit_extension_resolves")
+{
+    // A command typed with an explicit PATHEXT extension is probed verbatim.
+    platform::testing::InMemoryFileSystem fs;
+    fs.addDirectory("/bin");
+    fs.addExecutable("/bin/docker.exe");
+
+    platform::TestEnvironmentProvider env;
+    env.set("PATH", "/bin");
+    env.set("PATHEXT", ".exe;.cmd;.bat");
+
+    auto const resolver = CommandResolver(env, fs);
+    auto const result = resolver.findInPath("docker.exe");
+    REQUIRE(!result.empty());
+    CHECK(result.ends_with("docker.exe"));
+}
+
+TEST_CASE("CommandResolver.findInPath.honors_PATHEXT_ordering")
+{
+    // When several PATHEXT variants exist, the one earliest in PATHEXT wins.
+    platform::testing::InMemoryFileSystem fs;
+    fs.addDirectory("/bin");
+    fs.addExecutable("/bin/foo.cmd");
+    fs.addExecutable("/bin/foo.exe");
+
+    platform::TestEnvironmentProvider env;
+    env.set("PATH", "/bin");
+    env.set("PATHEXT", ".exe;.cmd");
+
+    auto const resolver = CommandResolver(env, fs);
+    auto const result = resolver.findInPath("foo");
+    REQUIRE(!result.empty());
+    CHECK(result.ends_with("foo.exe"));
+}
 #endif
 
 #if !defined(_WIN32)

--- a/src/shell/util/CommandResolver_test.cpp
+++ b/src/shell/util/CommandResolver_test.cpp
@@ -208,6 +208,101 @@ TEST_CASE("CommandResolver.findInPath.honors_PATHEXT_ordering")
     REQUIRE(!result.empty());
     CHECK(result.ends_with("foo.exe"));
 }
+
+TEST_CASE("CommandResolver.findInPath.typed_non_PATHEXT_extension_resolves_verbatim")
+{
+    // A name typed with an extension is used verbatim even when that extension is not in
+    // PATHEXT (cmd.exe semantics: an explicit extension is never augmented). Without this
+    // an explicitly typed "deploy.ps1" would be dropped when ".ps1" is absent from PATHEXT.
+    platform::testing::InMemoryFileSystem fs;
+    fs.addDirectory("/bin");
+    fs.addExecutable("/bin/deploy.ps1");
+
+    platform::TestEnvironmentProvider env;
+    env.set("PATH", "/bin");
+    env.set("PATHEXT", ".exe;.cmd"); // note: no .ps1
+
+    auto const resolver = CommandResolver(env, fs);
+    auto const result = resolver.findInPath("deploy.ps1");
+    REQUIRE(!result.empty());
+    CHECK(result.ends_with("deploy.ps1"));
+}
+
+TEST_CASE("CommandResolver.findInPath.empty_PATHEXT_falls_back_to_defaults")
+{
+    // An empty/blank PATHEXT must not strand bare lookups: fall back to the default
+    // executable extensions so "docker" still resolves to "docker.exe".
+    platform::testing::InMemoryFileSystem fs;
+    fs.addDirectory("/bin");
+    fs.addExecutable("/bin/docker.exe");
+
+    platform::TestEnvironmentProvider env;
+    env.set("PATH", "/bin");
+    env.set("PATHEXT", "");
+
+    auto const resolver = CommandResolver(env, fs);
+    auto const result = resolver.findInPath("docker");
+    REQUIRE(!result.empty());
+    CHECK(result.ends_with("docker.exe"));
+}
+
+TEST_CASE("CommandResolver.findInPath.empty_PATHEXT_token_does_not_reshadow")
+{
+    // A stray empty token (e.g. ".exe;;.cmd") must be skipped — otherwise it would append
+    // nothing and re-probe the bare name, letting the extensionless shim shadow docker.exe.
+    platform::testing::InMemoryFileSystem fs;
+    fs.addDirectory("/bin");
+    fs.addExecutable("/bin/docker");
+    fs.addExecutable("/bin/docker.exe");
+
+    platform::TestEnvironmentProvider env;
+    env.set("PATH", "/bin");
+    env.set("PATHEXT", ".exe;;.cmd");
+
+    auto const resolver = CommandResolver(env, fs);
+    auto const result = resolver.findInPath("docker");
+    REQUIRE(!result.empty());
+    CHECK(result.ends_with("docker.exe"));
+}
+
+TEST_CASE("CommandResolver.findInPath.extensionless_does_not_shadow_later_directory")
+{
+    // The user's real scenario: an extensionless "docker" shim in an earlier PATH directory
+    // must not shadow the real "docker.exe" in a later one.
+    platform::testing::InMemoryFileSystem fs;
+    fs.addDirectory("/a");
+    fs.addDirectory("/b");
+    fs.addExecutable("/a/docker"); // extensionless shim, earlier in PATH
+    fs.addExecutable("/b/docker.exe");
+
+    platform::TestEnvironmentProvider env;
+    env.set("PATH", "/a;/b");
+    env.set("PATHEXT", ".exe;.cmd;.bat");
+
+    auto const resolver = CommandResolver(env, fs);
+    auto const result = resolver.findInPath("docker");
+    REQUIRE(!result.empty());
+    CHECK(result.ends_with("docker.exe"));
+}
+
+TEST_CASE("CommandResolver.resolve.invalidates_cache_on_PATHEXT_change")
+{
+    // resolve() caches per command; since PATHEXT now governs whether anything is found,
+    // a PATHEXT change (with PATH unchanged) must invalidate the cached result.
+    platform::testing::InMemoryFileSystem fs;
+    fs.addDirectory("/bin");
+    fs.addExecutable("/bin/docker.exe");
+
+    platform::TestEnvironmentProvider env;
+    env.set("PATH", "/bin");
+    env.set("PATHEXT", ".cmd"); // no .exe yet → docker.exe unreachable
+
+    auto const resolver = CommandResolver(env, fs);
+    CHECK(resolver.resolve("docker").type == CommandType::NotFound);
+
+    env.set("PATHEXT", ".exe;.cmd"); // now docker.exe is reachable
+    CHECK(resolver.resolve("docker").type == CommandType::External);
+}
 #endif
 
 #if !defined(_WIN32)


### PR DESCRIPTION
On Windows, typing a bare command (e.g. `docker`) could resolve to an extensionless file of that name instead of `docker.exe`. The shell then tried to spawn the extensionless file, which Windows cannot execute as a command, so the command failed — while `docker.exe` typed explicitly worked.

The cause was in `CommandResolver::findAllInPath`, the shared lookup behind execution, the `which` builtin, `which_find`, and prompt tooltips. Its Windows branch probed the bare, extensionless candidate before the PATHEXT variants and returned the first match; because `isExecutableFile()` treats any non-directory entry as runnable on Windows, an extensionless shim shadowed the real executable.

## Changes

- A bare command name now resolves only through `PATHEXT` extensions, in PATHEXT order; the exact name is probed only when it already carries a recognized PATHEXT extension (e.g. `docker.exe`). An extensionless file is no longer treated as a runnable command on Windows, matching cmd.exe/PowerShell semantics.
- Added Windows-guarded unit tests covering preference of `.exe` over an extensionless file, the extensionless-only not-found case, explicit-extension resolution, and PATHEXT ordering.