### PR TITLE
Improve ln to match GNU semantics and show symlink targets in ls

### DIFF
--- a/docs/language/standard-library.md
+++ b/docs/language/standard-library.md
@@ -1347,6 +1347,12 @@ Lists directory contents as structured records.
 | `mode` | `FileMode` | Unix file permissions |
 | `mtime` | `DateTime` | Last modification time |
 | `isDir` | `bool` | Whether entry is a directory |
+| `isSymlink` | `bool` | Whether entry is a symbolic link |
+| `target` | `str` | Symbolic link target (empty for non-symlinks) |
+
+The `isDir`, `isSymlink`, and `target` fields are available for field access and
+pipelines but are not shown as columns in the default `ls` table; a symlink is
+instead rendered inline as `name -> target`.
 
 <!-- endo-no-check -->
 ```endo
@@ -1361,6 +1367,9 @@ ls |> sortBy _.mtime.epoch
 
 # Filter directories only
 ls |> filter _.isDir |> map _.name
+
+# Show where symbolic links point
+ls |> filter _.isSymlink |> map (fun f -> $"{f.name} -> {f.target}")
 
 # Access nested fields
 match head ls with

--- a/docs/shell/builtins.md
+++ b/docs/shell/builtins.md
@@ -1590,18 +1590,32 @@ Create links between files.
 **Syntax:**
 
 ```
-ln [OPTIONS] TARGET LINK_NAME
+ln [OPTIONS] TARGET                 # link in the current directory, named after TARGET
+ln [OPTIONS] TARGET LINK_NAME       # create LINK_NAME as a link to TARGET
+ln [OPTIONS] TARGET... DIRECTORY    # create links to each TARGET inside DIRECTORY
 ```
 
-**Description:** Creates a link from LINK_NAME to TARGET. By default, creates a hard link.
-Use `-s` for symbolic links.
+**Description:** Creates a link to TARGET. By default, creates a hard link; use `-s` for a
+symbolic link.
+
+Operand handling follows GNU `ln`:
+
+- With a single TARGET, the link is created in the current directory, named after TARGET's
+  basename (e.g. `ln -s build/clang-debug/compile_commands.json` creates
+  `./compile_commands.json`).
+- If LINK_NAME is an existing directory, the link is created inside it, named after TARGET's
+  basename.
+- With more than two operands, the last must be an existing directory and a link to each
+  preceding TARGET is created inside it.
 
 **Options:**
 
 | Option | Description |
 |---|---|
 | `-s` | Create a symbolic link |
-| `-f` | Remove existing destination file |
+| `-f` | Remove an existing destination first (including a dangling symlink) |
+| `-n`, `--no-dereference` | Treat a symlink at the destination as a normal file (replace it rather than follow into it) |
+| `-t`, `--target-directory=DIR` | Create all links inside DIR |
 | `-v` | Explain what is being done |
 | `--help` | Display help |
 
@@ -1611,7 +1625,10 @@ Use `-s` for symbolic links.
 ```endo
 ln -s /usr/bin/python3 python
 ln original.txt hardlink.txt
-ln -sf newtarget existing-link
+ln -sf newtarget existing-link              # replaces existing-link, even if dangling
+ln -sf build/clang-debug/compile_commands.json   # creates ./compile_commands.json
+ln -s target.txt some-directory             # creates some-directory/target.txt
+ln -s -t bin app1 app2 app3                 # links app1..app3 inside bin/
 ```
 
 ---

--- a/src/CoreVM/types/TypeDescriptor.hpp
+++ b/src/CoreVM/types/TypeDescriptor.hpp
@@ -34,6 +34,10 @@ struct FieldInfo
     uint8_t offset {};                      ///< Slot offset within the object's data area
     LiteralType type = LiteralType::Number; ///< The VM type of this field's value
     std::string nestedTypeName; ///< For Object-typed fields, the nested type name (e.g., "Size", "DateTime")
+    bool display = true;        ///< Whether this field is shown as a column in default table output.
+                                ///< Hidden fields remain accessible via field access and completion;
+                                ///< they typically drive presentation (e.g. an isSymlink flag rendered
+                                ///< inline) rather than warranting their own column.
 };
 
 /// Information about a module-level function associated with a type.

--- a/src/CoreVM/types/TypeRegistry.cpp
+++ b/src/CoreVM/types/TypeRegistry.cpp
@@ -154,16 +154,23 @@ void TypeRegistry::registerBuiltins()
     fileInfoType->kind = TypeKind::Product;
     fileInfoType->id = BuiltinTypeId::FileInfo;
     fileInfoType->name = "FileInfo";
-    fileInfoType->slotCount = 5;
+    fileInfoType->slotCount = 7;
     fileInfoType->fields = {
         { .name = "name", .offset = 0, .type = LiteralType::String },
         { .name = "size", .offset = 1, .type = LiteralType::Object, .nestedTypeName = "Size" },
         { .name = "mode", .offset = 2, .type = LiteralType::Object, .nestedTypeName = "FileMode" },
         { .name = "mtime", .offset = 3, .type = LiteralType::Object, .nestedTypeName = "DateTime" },
-        { .name = "isDir", .offset = 4, .type = LiteralType::Boolean },
+        // isDir/isSymlink/target drive presentation (folder slash, symlink icon, "name ->
+        // target" suffix) and are hidden from the default table, but remain field-accessible.
+        { .name = "isDir", .offset = 4, .type = LiteralType::Boolean, .display = false },
+        { .name = "isSymlink", .offset = 5, .type = LiteralType::Boolean, .display = false },
+        { .name = "target", .offset = 6, .type = LiteralType::String, .display = false },
     };
     fileInfoType->producingCommand = "ls";
-    // SlotTraceInfo: slots 1 (Size), 2 (FileMode), 3 (DateTime) are always objects
+    // SlotTraceInfo: slots 1 (Size), 2 (FileMode), 3 (DateTime) are always objects.
+    // Slots 0 (name) and 6 (target) are Strings: CoreString lives in the Runner's
+    // separate string arena (not the GC object pool), so String slots are intentionally
+    // NOT traced and must stay out of fixedObjectSlots.
     fileInfoType->traceInfo.fixedObjectSlots = { 1, 2, 3 };
     addType(std::move(fileInfoType));
 

--- a/src/CoreVM/vm/Runner.hpp
+++ b/src/CoreVM/vm/Runner.hpp
@@ -217,10 +217,13 @@ class Runner
     /// Returns the GC suspects set (for testing/inspection).
     [[nodiscard]] std::unordered_set<TypedObject*> const& gcSuspects() const noexcept { return _gcSuspects; }
 
+    /// Returns the shared, always-allocated empty CoreString sentinel.
+    /// Prefer this over newString("") when storing an empty string value to avoid a
+    /// per-call heap allocation and known-string insertion.
+    [[nodiscard]] const CoreString* emptyString() const { return &*_stringGarbage.begin(); }
+
   private:
     void consume(Opcode op);
-
-    const CoreString* emptyString() const { return &*_stringGarbage.begin(); }
 
     CoreString* catString(const CoreString& a, const CoreString& b);
 

--- a/src/endo-language/TestHelper.cpp
+++ b/src/endo-language/TestHelper.cpp
@@ -16,6 +16,7 @@
 
 #include <bit>
 #include <filesystem>
+#include <ranges>
 
 #include <platform/GlobMatch.hpp>
 #include <platform/NativeFileSystem.hpp>
@@ -79,21 +80,45 @@ namespace
             int64_t mode;
             int64_t mtime;
             bool isDir;
+            bool isSymlink;
+            char const* target;
         };
 
+        // NOTE: many tests/structured/*.endo cases assert the exact count, names, sizes,
+        // and modes of these three entries — do not add/remove rows here without updating
+        // them. Symlink field access (isSymlink/target) is covered by Catch2 tests that
+        // construct FileInfo records directly, so no symlink row is needed in this fixture.
         constexpr MockFile AllFiles[] = {
-            { .name = "docs", .size = 4096, .mode = 0755, .mtime = 1700000000, .isDir = true },
-            { .name = "hello.txt", .size = 42, .mode = 0644, .mtime = 1700001000, .isDir = false },
-            { .name = "script.sh", .size = 256, .mode = 0755, .mtime = 1700002000, .isDir = false },
+            { .name = "docs",
+              .size = 4096,
+              .mode = 0755,
+              .mtime = 1700000000,
+              .isDir = true,
+              .isSymlink = false,
+              .target = "" },
+            { .name = "hello.txt",
+              .size = 42,
+              .mode = 0644,
+              .mtime = 1700001000,
+              .isDir = false,
+              .isSymlink = false,
+              .target = "" },
+            { .name = "script.sh",
+              .size = 256,
+              .mode = 0755,
+              .mtime = 1700002000,
+              .isDir = false,
+              .isSymlink = false,
+              .target = "" },
         };
 
         // Determine which entries to include based on the path argument.
         auto const hasGlob = endo::containsGlobChars(path);
 
         auto* list = runner->makeNilList(CoreVM::LiteralType::Object);
-        for (int i = 2; i >= 0; --i)
+        // Build the cons-list right-to-left so the result keeps AllFiles order.
+        for (auto const& f: std::ranges::reverse_view(AllFiles))
         {
-            auto const& f = AllFiles[i];
 
             // Filter: directory path returns all, glob filters by pattern, else exact name match.
             if (!path.empty() && path != "." && path != "/tmp" && !path.starts_with("/home/testuser"))
@@ -120,6 +145,8 @@ namespace
             auto* mtimeObj = builtins::makeDateTimeFromEpoch(runner, f.mtime);
             record->setSlot(3, reinterpret_cast<uintptr_t>(mtimeObj));
             record->setSlot(4, static_cast<uint64_t>(f.isDir ? 1 : 0));
+            record->setSlot(5, static_cast<uint64_t>(f.isSymlink ? 1 : 0));
+            record->setSlot(6, reinterpret_cast<uintptr_t>(runner->newString(f.target)));
             list =
                 runner->makeConsCell(reinterpret_cast<uintptr_t>(record), list, CoreVM::LiteralType::Object);
         }

--- a/src/endo-language/ide/HoverProvider.cpp
+++ b/src/endo-language/ide/HoverProvider.cpp
@@ -389,7 +389,7 @@ namespace
             { "FileInfo",
               "`FileInfo` \u2014 Record type for file/directory information\n\n"
               "**Fields:** `name: str`, `size: Size`, `mode: FileMode`, `mtime: DateTime`, `isDir: "
-              "bool`\n\n"
+              "bool`, `isSymlink: bool`, `target: str`\n\n"
               "Returned by `ls`. Supports dot access and pattern matching.\n\n"
               "```endo\nls |> filter (_.size.bytes > 1024) |> map _.name\n```" },
             { "ProcessInfo",
@@ -407,7 +407,7 @@ namespace
               "`ls` : `list<FileInfo>` | `ls path` : `list<FileInfo>`\n\n"
               "Lists directory contents as structured FileInfo records.\n\n"
               "**Fields:** `name: str`, `size: Size`, `mode: FileMode`, `mtime: DateTime`, `isDir: "
-              "bool`" },
+              "bool`, `isSymlink: bool`, `target: str`" },
             { "ps",
               "`ps` : `list<ProcessInfo>`\n\n"
               "Lists running processes as structured ProcessInfo records.\n\n"

--- a/src/endo-language/sema/TypeRegistry.cpp
+++ b/src/endo-language/sema/TypeRegistry.cpp
@@ -94,6 +94,8 @@ void TypeDefinitionRegistry::registerBuiltins()
             { .name = "mode", .offset = 2, .type = CoreVM::LiteralType::Object },
             { .name = "mtime", .offset = 3, .type = CoreVM::LiteralType::Object },
             { .name = "isDir", .offset = 4, .type = CoreVM::LiteralType::Boolean },
+            { .name = "isSymlink", .offset = 5, .type = CoreVM::LiteralType::Boolean },
+            { .name = "target", .offset = 6, .type = CoreVM::LiteralType::String },
         };
         for (auto const& f: fileInfoType.fields)
             fileInfoType.fieldTypes[f.name] = f.type;

--- a/src/platform/FileInfoProvider.hpp
+++ b/src/platform/FileInfoProvider.hpp
@@ -16,15 +16,17 @@ namespace endo::platform
 /// them leave the documented sentinel defaults (@c blocks = -1, @c dev/@c ino = 0).
 struct FileEntry
 {
-    std::string name;       ///< File name (not full path).
-    int64_t size = 0;       ///< Apparent size in bytes (st_size).
-    int64_t blocks = -1;    ///< Allocated 512-byte blocks (st_blocks); -1 if unknown.
-    int64_t mode = 0;       ///< Permission bits (e.g. 0755).
-    int64_t mtime = 0;      ///< Last modification time as epoch seconds.
-    uint64_t dev = 0;       ///< Device id (st_dev) for cross-filesystem detection; 0 if unknown.
-    uint64_t ino = 0;       ///< Inode number (st_ino) for hardlink dedup; 0 if unknown.
-    bool isDir = false;     ///< Whether this entry is a directory.
-    bool isSymlink = false; ///< Whether this entry is a symbolic link (from lstat, not followed).
+    std::string name;          ///< File name (not full path).
+    int64_t size = 0;          ///< Apparent size in bytes (st_size).
+    int64_t blocks = -1;       ///< Allocated 512-byte blocks (st_blocks); -1 if unknown.
+    int64_t mode = 0;          ///< Permission bits (e.g. 0755).
+    int64_t mtime = 0;         ///< Last modification time as epoch seconds.
+    uint64_t dev = 0;          ///< Device id (st_dev) for cross-filesystem detection; 0 if unknown.
+    uint64_t ino = 0;          ///< Inode number (st_ino) for hardlink dedup; 0 if unknown.
+    bool isDir = false;        ///< Whether this entry is a directory.
+    bool isSymlink = false;    ///< Whether this entry is a symbolic link (from lstat, not followed).
+    std::string symlinkTarget; ///< Target path of a symbolic link (verbatim, possibly relative);
+                               ///< empty if not a symlink or if the target could not be read.
 };
 
 /// Abstract interface for listing directory contents.

--- a/src/platform/FileInfoProvider_test.cpp
+++ b/src/platform/FileInfoProvider_test.cpp
@@ -257,6 +257,43 @@ TEST_CASE("LinuxFileInfoProvider.marks_symlink", "[platform][linux]")
     CHECK(entries[1].isDir == true);
 }
 
+TEST_CASE("LinuxFileInfoProvider.populates_symlink_target", "[platform][linux]")
+{
+    // A symlink entry must expose its target path verbatim (read via readlink),
+    // while a regular file leaves symlinkTarget empty.
+    TempDir tmp;
+    tmp.createFile("real.txt", "data");
+    fs::create_symlink("real.txt", tmp.path / "link.txt"); // relative target, kept verbatim
+
+    LinuxFileInfoProvider provider;
+    auto entries = provider.listDirectory(tmp.path.string());
+
+    REQUIRE(entries.size() == 2);
+    // Sorted by name: "link.txt" < "real.txt"
+    CHECK(entries[0].name == "link.txt");
+    CHECK(entries[0].isSymlink == true);
+    CHECK(entries[0].symlinkTarget == "real.txt");
+    CHECK(entries[1].name == "real.txt");
+    CHECK(entries[1].isSymlink == false);
+    CHECK(entries[1].symlinkTarget.empty());
+}
+
+TEST_CASE("LinuxFileInfoProvider.populates_dangling_symlink_target", "[platform][linux]")
+{
+    // readlink succeeds for a dangling symlink: the target string is still reported
+    // even though it does not resolve to an existing file.
+    TempDir tmp;
+    fs::create_symlink("missing_target", tmp.path / "broken.lnk");
+
+    LinuxFileInfoProvider provider;
+    auto entries = provider.listDirectory(tmp.path.string());
+
+    REQUIRE(entries.size() == 1);
+    CHECK(entries[0].name == "broken.lnk");
+    CHECK(entries[0].isSymlink == true);
+    CHECK(entries[0].symlinkTarget == "missing_target");
+}
+
 TEST_CASE("LinuxFileInfoProvider.siblings_share_device", "[platform][linux]")
 {
     // Two entries in the same directory live on the same filesystem, so their

--- a/src/platform/linux/LinuxFileInfoProvider.cpp
+++ b/src/platform/linux/LinuxFileInfoProvider.cpp
@@ -37,6 +37,15 @@ namespace
 
         entry.name = std::move(name);
         entry.isSymlink = S_ISLNK(st.st_mode);
+        if (entry.isSymlink)
+        {
+            // Read the link target verbatim (do not canonicalize), matching `ls -l`.
+            // A failure (e.g. permissions) leaves symlinkTarget empty, which is acceptable.
+            std::error_code ec;
+            auto const target = fs::read_symlink(fullPath, ec);
+            if (!ec)
+                entry.symlinkTarget = target.string();
+        }
         entry.mode = static_cast<int64_t>(st.st_mode) & 0777;
         entry.mtime = static_cast<int64_t>(st.st_mtime);
         entry.dev = static_cast<uint64_t>(st.st_dev);

--- a/src/platform/windows/WindowsFileInfoProvider.cpp
+++ b/src/platform/windows/WindowsFileInfoProvider.cpp
@@ -57,6 +57,15 @@ namespace
         fileEntry.isDir = fs::is_directory(status);
         fileEntry.isSymlink = fs::is_symlink(dirEntry.symlink_status(ec));
         ec.clear();
+        if (fileEntry.isSymlink)
+        {
+            // Read the link target verbatim. Reading a reparse point can fail without the
+            // required privilege; on failure leave the target empty (graceful degradation).
+            auto const target = fs::read_symlink(dirEntry.path(), ec);
+            if (!ec)
+                fileEntry.symlinkTarget = toUtf8(target);
+            ec.clear();
+        }
         fileEntry.size = 0;
 
         // Windows std::filesystem does not expose st_blocks/st_dev/st_ino. Leave the

--- a/src/shell/builtins/InlineCommandDescriptors.cpp
+++ b/src/shell/builtins/InlineCommandDescriptors.cpp
@@ -81,7 +81,11 @@ static constexpr InlineOptionDef TouchOptions[] = {
 
 static constexpr InlineOptionDef LnOptions[] = {
     { .shortFlag = "-s", .longFlag = {}, .description = "Create symbolic link" },
-    { .shortFlag = "-f", .longFlag = {}, .description = "Remove existing destination files" },
+    { .shortFlag = "-f", .longFlag = {}, .description = "Remove existing destination (incl. dangling symlink)" },
+    { .shortFlag = "-n", .longFlag = "--no-dereference",
+      .description = "Treat a symlink at the destination as a normal file" },
+    { .shortFlag = "-t", .longFlag = "--target-directory",
+      .description = "Create all links inside the given directory", .takesValue = true },
     { .shortFlag = "-v", .longFlag = {}, .description = "Explain what is being done" },
 };
 
@@ -220,7 +224,7 @@ std::span<InlineCommandDescriptor const> Shell::inlineCommandDescriptors()
           .usageLine = "kill [-SIGNAL] PID|%JOB ...",
           .noStdinFn = &Shell::executeInlineKill },
         { .name = "ln",        .briefDescription = "Create hard or symbolic links.",
-          .usageLine = "ln [OPTIONS] TARGET LINK_NAME",
+          .usageLine = "ln [OPTIONS] TARGET [LINK_NAME] | ln [OPTIONS] TARGET... DIRECTORY",
           .options = LnOptions, .acceptsFileArgs = true, .fileArgsRepeatable = true,
           .noStdinFn = &Shell::executeInlineLn },
         { .name = "mkdir",     .briefDescription = "Create directories.",

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -21,6 +21,7 @@
 #include <format>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <random>
 #include <ranges>
 #include <regex>
@@ -4022,86 +4023,182 @@ int Shell::executeInlineTouch(CoreVM::CoreStringArray const& args, NativeHandle 
 
 int Shell::executeInlineLn(CoreVM::CoreStringArray const& args, NativeHandle outputFd)
 {
+    namespace fs = std::filesystem;
+
     bool symbolic = false;
     bool force = false;
+    bool noDereference = false;
     bool verbose = false;
+    std::optional<std::string> targetDir; // set by -t / --target-directory
+    bool noMoreOptions = false;
     std::vector<std::string> operands;
 
     for (size_t i = 1; i < args.size(); ++i)
     {
         std::string_view arg = args.at(i);
-        if (arg == "--help")
-            return renderMarkdownHelp(outputFd,
-                                      "# ln\n"
-                                      "\n"
-                                      "Create hard or symbolic links.\n"
-                                      "\n"
-                                      "## Usage\n"
-                                      "\n"
-                                      "`ln [OPTIONS] TARGET LINK_NAME`\n"
-                                      "\n"
-                                      "## Options\n"
-                                      "\n"
-                                      "| Option | Description |\n"
-                                      "|--------|-------------|\n"
-                                      "| `-s` | Create symbolic link |\n"
-                                      "| `-f` | Remove existing destination files |\n"
-                                      "| `-v` | Explain what is being done |\n"
-                                      "| `--help` | Display this help |\n");
-        if (arg == "--")
+        if (!noMoreOptions)
         {
-            for (auto const j: std::views::iota(i + 1, args.size()))
-                operands.push_back(args.at(j));
-            break;
-        }
-        if (arg.starts_with("-") && arg.size() > 1 && arg[1] != '-')
-        {
-            for (auto const j: std::views::iota(1uz, arg.size()))
+            if (arg == "--help")
+                return renderMarkdownHelp(
+                    outputFd,
+                    "# ln\n"
+                    "\n"
+                    "Create hard or symbolic links.\n"
+                    "\n"
+                    "## Usage\n"
+                    "\n"
+                    "`ln [OPTIONS] TARGET`            create a link to TARGET in the current directory\n"
+                    "`ln [OPTIONS] TARGET LINK_NAME`  create LINK_NAME as a link to TARGET\n"
+                    "`ln [OPTIONS] TARGET... DIR`     create links to each TARGET inside DIR\n"
+                    "\n"
+                    "If LINK_NAME is an existing directory, the link is created inside it,\n"
+                    "named after TARGET's basename.\n"
+                    "\n"
+                    "## Options\n"
+                    "\n"
+                    "| Option | Description |\n"
+                    "|--------|-------------|\n"
+                    "| `-s` | Create symbolic link |\n"
+                    "| `-f` | Remove existing destination (including a dangling symlink) |\n"
+                    "| `-n`, `--no-dereference` | Treat an existing symlink at the destination as a "
+                    "normal file (replace it rather than follow into it) |\n"
+                    "| `-t`, `--target-directory=DIR` | Create all links inside DIR |\n"
+                    "| `-v` | Explain what is being done |\n"
+                    "| `--help` | Display this help |\n");
+            if (arg == "--")
             {
-                switch (arg[j])
-                {
-                    case 's': symbolic = true; break;
-                    case 'f': force = true; break;
-                    case 'v': verbose = true; break;
-                    default: error("ln: invalid option -- '{}'", arg[j]); return 1;
-                }
+                noMoreOptions = true;
+                continue;
             }
-            continue;
+            if (arg == "--no-dereference")
+            {
+                noDereference = true;
+                continue;
+            }
+            if (arg.starts_with("--target-directory="))
+            {
+                targetDir = std::string(arg.substr(std::string_view("--target-directory=").size()));
+                continue;
+            }
+            if (arg.starts_with("-") && arg.size() > 1 && arg[1] != '-')
+            {
+                for (auto const j: std::views::iota(1uz, arg.size()))
+                {
+                    switch (arg[j])
+                    {
+                        case 's': symbolic = true; break;
+                        case 'f': force = true; break;
+                        case 'n': noDereference = true; break;
+                        case 'v': verbose = true; break;
+                        case 't':
+                            // -t takes the next argument as the target directory.
+                            if (i + 1 >= args.size())
+                            {
+                                error("ln: option requires an argument -- 't'");
+                                return 1;
+                            }
+                            targetDir = args.at(++i);
+                            break;
+                        default: error("ln: invalid option -- '{}'", arg[j]); return 1;
+                    }
+                }
+                continue;
+            }
         }
         operands.emplace_back(arg);
     }
 
-    if (operands.size() < 2)
+    if (operands.empty())
     {
-        error("ln: missing operand");
+        error("ln: missing file operand");
         return 1;
     }
 
-    auto const& target = operands[0];
-    auto const& linkName = operands[1];
+    /// Decides whether @p dest should be treated as a directory to place the link inside.
+    /// With -n, an existing symlink at @p dest is treated as a plain destination so it can
+    /// be replaced rather than dereferenced into.
+    auto const isDirectoryForLinking = [&](std::string const& dest) {
+        std::error_code ec;
+        if (noDereference && fs::is_symlink(fs::symlink_status(dest, ec)))
+            return false;
+        return fs::is_directory(dest, ec);
+    };
 
-    std::error_code ec;
-    if (force && std::filesystem::exists(linkName, ec))
-        std::filesystem::remove(linkName, ec);
+    /// Creates a single link from @p target to @p linkName, honoring -s/-f/-n/-v.
+    /// @return 0 on success, 1 on failure (after reporting the error).
+    auto const createOneLink = [&](std::string const& target, std::string const& linkName) -> int {
+        std::error_code ec;
 
-    if (symbolic)
-        std::filesystem::create_symlink(target, linkName, ec);
-    else
-        std::filesystem::create_hard_link(target, linkName, ec);
+        // lstat-style existence check: symlink_status does not follow the final component,
+        // so a dangling symlink at linkName is detected (and removable) — unlike exists().
+        auto const st = fs::symlink_status(linkName, ec);
+        bool const present = !ec && st.type() != fs::file_type::not_found;
+        if (present && (force || (noDereference && fs::is_symlink(st))))
+        {
+            std::error_code removeEc;
+            fs::remove(linkName, removeEc); // remove the link/file itself, never recurse
+        }
 
-    if (ec)
+        ec.clear();
+        if (symbolic)
+            fs::create_symlink(target, linkName, ec);
+        else
+            fs::create_hard_link(target, linkName, ec);
+
+        if (ec)
+        {
+            error("ln: failed to create link '{}' -> '{}': {}", linkName, target, ec.message());
+            return 1;
+        }
+
+        if (verbose)
+        {
+            auto msg = std::format("'{}' -> '{}'\n", linkName, target);
+            [[maybe_unused]] auto written = platformWrite(outputFd, msg.data(), msg.size());
+        }
+        return 0;
+    };
+
+    auto const linkInDir = [](std::string const& target, std::string const& dir) {
+        return (fs::path(dir) / fs::path(target).filename()).string();
+    };
+
+    /// Creates a link to each target inside @p dir (which must already exist as a directory),
+    /// each named after its target's basename. Used by both -t DIR and the TARGET... DIRECTORY
+    /// form. @return the worst (non-zero on any failure) exit code.
+    auto const linkAllIntoDir = [&](std::string const& dir, std::span<std::string const> targets) -> int {
+        std::error_code ec;
+        if (!fs::is_directory(dir, ec))
+        {
+            error("ln: target directory '{}' is not a directory", dir);
+            return 1;
+        }
+        int rc = 0;
+        for (auto const& target: targets)
+            rc |= createOneLink(target, linkInDir(target, dir));
+        return rc;
+    };
+
+    if (targetDir)
+        return linkAllIntoDir(*targetDir, operands);
+
+    if (operands.size() == 1)
     {
-        error("ln: failed to create link '{}' -> '{}': {}", linkName, target, ec.message());
-        return 1;
+        // Single operand: link in the current directory, named after the target's basename.
+        auto const& target = operands[0];
+        return createOneLink(target, fs::path(target).filename().string());
     }
 
-    if (verbose)
+    if (operands.size() == 2)
     {
-        auto msg = std::format("'{}' -> '{}'\n", linkName, target);
-        [[maybe_unused]] auto written = platformWrite(outputFd, msg.data(), msg.size());
+        auto const& target = operands[0];
+        auto const& dest = operands[1];
+        auto const linkName = isDirectoryForLinking(dest) ? linkInDir(target, dest) : dest;
+        return createOneLink(target, linkName);
     }
 
-    return 0;
+    // More than two operands: the last must be an existing directory.
+    return linkAllIntoDir(operands.back(), std::span(operands).first(operands.size() - 1));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shell/commands/LsCommand.cpp
+++ b/src/shell/commands/LsCommand.cpp
@@ -42,6 +42,13 @@ CoreVM::TypedObject* LsCommand::execute(CoreVM::Runner& runner) const
         auto* mtimeObj = endo::builtins::makeDateTimeFromEpoch(&runner, file.mtime);
         record->setSlot(3, reinterpret_cast<uintptr_t>(mtimeObj));
         record->setSlot(4, static_cast<uint64_t>(file.isDir ? 1 : 0));
+        record->setSlot(5, static_cast<uint64_t>(file.isSymlink ? 1 : 0));
+        // Reuse the shared empty-string sentinel for the common non-symlink case to avoid a
+        // heap allocation + known-string insertion per directory entry on this listing path.
+        record->setSlot(6,
+                        reinterpret_cast<uintptr_t>(file.symlinkTarget.empty()
+                                                        ? runner.emptyString()
+                                                        : runner.newString(file.symlinkTarget)));
 
         // Cons this record onto the list
         auto* cons = runner.allocObject(CoreVM::BuiltinTypeId::List);

--- a/src/shell/output/FileTypeStyle.cpp
+++ b/src/shell/output/FileTypeStyle.cpp
@@ -29,6 +29,7 @@ namespace
     // clang-format off
     constexpr auto DirColor        = rgb(0x5C7AFF); // bold blue
     constexpr auto ExecColor       = rgb(0x50FA7B); // bold green
+    constexpr auto SymlinkColor    = rgb(0x00CDCD); // cyan (GNU ls default for symlinks)
     constexpr auto CppColor        = rgb(0x61AFEF); // blue
     constexpr auto PythonColor     = rgb(0x3776AB); // python blue
     constexpr auto RustColor       = rgb(0xDEA584); // rust orange
@@ -77,6 +78,7 @@ namespace
     constexpr auto IconFolder     = "\xEF\x84\x95"; // U+F115 nf-fa-folder_open
     constexpr auto IconFile       = "\xEF\x80\x96"; // U+F016 nf-fa-file_o
     constexpr auto IconExec       = "\xEF\x80\x93"; // U+F013 nf-fa-cog
+    constexpr auto IconSymlink    = "\xEF\x92\x81"; // U+F481 nf-oct-file_symlink_file
     constexpr auto IconTerminal   = "\xEF\x84\xA0"; // U+F120 nf-fa-terminal
     constexpr auto IconCpp        = "\xEE\x98\x9D"; // U+E61D nf-custom-c
     constexpr auto IconPython     = "\xEE\x9C\xBC"; // U+E73C nf-dev-python
@@ -220,9 +222,22 @@ namespace
     }
 } // namespace
 
-FileDecoration getFileDecoration(std::string_view name, bool isDir, int64_t mode)
+FileDecoration getFileDecoration(std::string_view name, bool isDir, int64_t mode, bool isSymlink)
 {
     auto decoration = FileDecoration {};
+
+    // 0. Symbolic link (takes visual priority over the link's target type)
+    if (isSymlink)
+    {
+        decoration.icon = IconSymlink;
+        decoration.style.fg = SymlinkColor;
+
+        // Hidden links still get the dim attribute (additive).
+        if (!name.empty() && name[0] == '.')
+            decoration.style.dim = true;
+
+        return decoration;
+    }
 
     // 1. Directory
     if (isDir)

--- a/src/shell/output/FileTypeStyle.hpp
+++ b/src/shell/output/FileTypeStyle.hpp
@@ -19,14 +19,18 @@ struct FileDecoration
 
 /// Returns the visual decoration (icon and color) for a file based on its properties.
 ///
-/// Priority chain: directory > executable > extension match > fallback.
+/// Priority chain: symlink > directory > executable > extension match > fallback.
 /// Hidden files (names starting with '.') additionally get the dim attribute.
 ///
-/// @param name  File name (used for extension matching and hidden-file detection).
-/// @param isDir Whether the file is a directory.
-/// @param mode  POSIX permission bits (0777 mask); used to detect executables.
+/// @param name      File name (used for extension matching and hidden-file detection).
+/// @param isDir     Whether the file is a directory.
+/// @param mode      POSIX permission bits (0777 mask); used to detect executables.
+/// @param isSymlink Whether the file is a symbolic link (takes visual priority).
 /// @return FileDecoration with an icon glyph and an SGR style.
-[[nodiscard]] FileDecoration getFileDecoration(std::string_view name, bool isDir, int64_t mode);
+[[nodiscard]] FileDecoration getFileDecoration(std::string_view name,
+                                               bool isDir,
+                                               int64_t mode,
+                                               bool isSymlink = false);
 
 /// Colorizes a permission string (e.g., "rwxr-xr-x") with per-character SGR colors.
 ///

--- a/src/shell/output/TableFormatter.cpp
+++ b/src/shell/output/TableFormatter.cpp
@@ -237,9 +237,23 @@ std::string formatRecordTable(CoreVM::TypedObject* listHead,
         }
     }
 
+    bool const isFileInfo = (recordTypeId == CoreVM::BuiltinTypeId::FileInfo);
+
+    // Hide fields the type marks non-display (FieldInfo::display == false). Such fields stay
+    // accessible via field access/completion but are not rendered as columns — they typically
+    // drive presentation instead (e.g. FileInfo's isDir/isSymlink/target feed the folder slash,
+    // symlink icon, and "name -> target" suffix). Tuples have no hidden fields.
+    if (resolvedFields.empty())
+    {
+        auto const& allFields = records[0]->type->fields;
+        if (std::ranges::any_of(allFields, [](auto const& f) { return !f.display; }))
+            for (auto const& f: allFields)
+                if (f.display)
+                    resolvedFields.push_back(f);
+    }
+
     auto const& fields = resolvedFields.empty() ? records[0]->type->fields : resolvedFields;
     auto const numCols = fields.size();
-    bool const isFileInfo = (recordTypeId == CoreVM::BuiltinTypeId::FileInfo);
     bool const decorateFiles = isFileInfo && config.useColor;
 
     // Determine per-column alignment and FileMode columns from the first record's runtime types
@@ -287,8 +301,9 @@ std::string formatRecordTable(CoreVM::TypedObject* listHead,
         std::vector<std::string> row;
         row.reserve(numCols);
 
-        // Compute file decoration for this row (if applicable)
-        auto const isDir = decorateFiles && record->getSlot(4) != 0;
+        // FileInfo hidden slots that drive visuals: isDir (4), isSymlink (5), target (6).
+        auto const isDir = isFileInfo && record->getSlot(4) != 0;
+        auto const isSymlink = isFileInfo && record->getSlot(5) != 0;
         if (decorateFiles)
         {
             auto const nameSlot = record->getSlot(0);
@@ -304,15 +319,24 @@ std::string formatRecordTable(CoreVM::TypedObject* listHead,
                     mode = static_cast<int64_t>(modeObj->getSlot(0));
             }
             fileDecorations.push_back(
-                getFileDecoration(nameStr ? std::string_view(*nameStr) : "", isDir, mode));
+                getFileDecoration(nameStr ? std::string_view(*nameStr) : "", isDir, mode, isSymlink));
         }
 
         for (size_t col = 0; col < numCols; ++col)
         {
-            auto slotVal = record->getSlot(static_cast<uint8_t>(col));
+            auto slotVal = record->getSlot(fields[col].offset);
             auto cell = fieldValueToString(slotVal, fields[col], runner);
             if (config.showDirectorySlash && col == 0 && isDir)
                 cell += '/';
+            // Append the symlink target to the name cell ("name -> target"), GNU ls -l style.
+            if (isSymlink && col == 0)
+            {
+                auto const targetSlot = record->getSlot(6);
+                auto const* targetStr =
+                    reinterpret_cast<CoreVM::CoreString const*>(static_cast<uintptr_t>(targetSlot));
+                if (targetStr && !targetStr->empty())
+                    cell += " -> " + *targetStr;
+            }
             if (std::cmp_not_equal(col, config.autoGrowColumn))
                 cell = truncate(cell, config.maxColumnWidth);
             auto cellDisplayWidth = displayWidth(cell);


### PR DESCRIPTION
The `ln` builtin diverged from GNU/Linux `ln` in ways that bit common workflows — `ln -sf build/clang-debug/compile_commands.json` errored with "missing operand" instead of creating the link in the current directory, and `-f` failed to replace a dangling symlink because the existence check followed the link. Separately, structured `ls` carried no symlink information, so there was no way to see where a link pointed or filter on link-ness in a pipeline. This PR addresses both.

## Changes

- **`ln` operand resolution** now follows GNU `ln`: a single operand links into the current directory named after the target's basename; an existing-directory destination (or a `TARGET... DIRECTORY` form) places links inside that directory; otherwise the second operand is the link name.
- **`ln -f`** uses an lstat-style `symlink_status` check, so an existing destination — including a dangling symlink — is detected and replaced.
- **New `ln` flags** `-n`/`--no-dereference` and `-t DIR`/`--target-directory`.
- **`FileInfo` gains `isSymlink` and `target` fields**, populated from a new `FileEntry::symlinkTarget` read via `readlink`/`read_symlink` in the Linux and Windows providers. Hard links report an empty target.
- **`ls` rendering** shows a symlink inline as `name -> target` with a link icon. The `isDir`, `isSymlink`, and `target` fields are hidden from the default table while remaining available for field access and completion — implemented via a new data-driven `FieldInfo::display` flag the formatter honors for any record type, rather than a FileInfo-specific special case.