### PR TITLE
Fix inverted truthiness of non-boolean conditions

### DIFF
--- a/src/endo-language/codegen/IRGenerator.cpp
+++ b/src/endo-language/codegen/IRGenerator.cpp
@@ -1858,7 +1858,7 @@ void IRGenerator::visit(ast::LogicalAndStmt const& node)
     auto* leftResult = codegen(node.left.get());
     if (!leftResult)
         leftResult = _builder.createLoad(successStorage, "and.left.ok");
-    auto* leftSuccess = toBool(leftResult);
+    auto* leftSuccess = exitCodeToSuccess(leftResult);
     _builder.createStore(successStorage, leftSuccess);
 
     CoreVM::BasicBlock* evalRight = _builder.createBlock("and.evalRight");
@@ -1869,7 +1869,7 @@ void IRGenerator::visit(ast::LogicalAndStmt const& node)
     _builder.setInsertPoint(evalRight);
     auto* rightResult = codegen(node.right.get());
     if (rightResult)
-        _builder.createStore(successStorage, toBool(rightResult));
+        _builder.createStore(successStorage, exitCodeToSuccess(rightResult));
     _builder.createBr(end);
 
     _builder.setInsertPoint(end);
@@ -1884,19 +1884,19 @@ void IRGenerator::visit(ast::LogicalOrStmt const& node)
     auto* leftResult = codegen(node.left.get());
     if (!leftResult)
         leftResult = _builder.createLoad(successStorage, "or.left.ok");
-    auto* leftSuccess = toBool(leftResult);
+    auto* leftSuccess = exitCodeToSuccess(leftResult);
     _builder.createStore(successStorage, leftSuccess);
 
     CoreVM::BasicBlock* evalRight = _builder.createBlock("or.evalRight");
     CoreVM::BasicBlock* end = _builder.createBlock("or.end");
 
-    // toBool returns true for exit code 0 (success), so we flip the branches
+    // exitCodeToSuccess returns true for exit code 0 (success), so we flip the branches
     _builder.createCondBr(leftSuccess, end, evalRight);
 
     _builder.setInsertPoint(evalRight);
     auto* rightResult = codegen(node.right.get());
     if (rightResult)
-        _builder.createStore(successStorage, toBool(rightResult));
+        _builder.createStore(successStorage, exitCodeToSuccess(rightResult));
     _builder.createBr(end);
 
     _builder.setInsertPoint(end);
@@ -3116,14 +3116,39 @@ void IRGenerator::visit(ast::ContinueExpr const& /*node*/)
     _result = nullptr;
 }
 
+bool IRGenerator::isAlreadyBooleanValue(CoreVM::Value* value) const
+{
+    // A record field access emits an ObjGetSlotInstr typed Void with the real field type
+    // carried in an inner-type annotation, so a boolean field arrives as Void+Boolean-inner.
+    if (value->type() == CoreVM::LiteralType::Boolean)
+        return true;
+    if (value->type() == CoreVM::LiteralType::Void)
+        if (auto const inner = getInnerType(value); inner && *inner == CoreVM::LiteralType::Boolean)
+            return true;
+    return false;
+}
+
 CoreVM::Value* IRGenerator::toBool(CoreVM::Value* value)
 {
-    if (value->type() == CoreVM::LiteralType::Boolean)
+    // Already a 0/1 truth value — JZ/CondBr test non-zero directly; comparing would invert it.
+    if (isAlreadyBooleanValue(value))
         return value;
+    // Truthiness for the remaining types: non-zero / non-empty (true when "set").
     if (value->type() == CoreVM::LiteralType::Float)
-        return _builder.createFCmpEQ(value, _builder.getFloat(0.0));
+        return _builder.createFCmpNE(value, _builder.getFloat(0.0));
     if (value->type() == CoreVM::LiteralType::String)
-        return _builder.createSCmpEQ(value, _builder.get(std::string("")));
+        return _builder.createSCmpNE(value, _builder.get(std::string("")));
+    return _builder.createNCmpNE(value, _builder.get(static_cast<CoreVM::CoreNumber>(0)));
+}
+
+CoreVM::Value* IRGenerator::exitCodeToSuccess(CoreVM::Value* value)
+{
+    // Shell `&&`/`||` chain on command exit status, where 0 means success/true.
+    // A boolean operand (e.g. `true && cmd`) is already a truth value — pass it through,
+    // mirroring toBool, so it never reaches the number-only comparison below.
+    if (isAlreadyBooleanValue(value))
+        return value;
+    // A numeric exit code: success is 0 (the inverse of value truthiness).
     return _builder.createNCmpEQ(value, _builder.get(static_cast<CoreVM::CoreNumber>(0)));
 }
 

--- a/src/endo-language/codegen/IRGenerator.hpp
+++ b/src/endo-language/codegen/IRGenerator.hpp
@@ -325,8 +325,19 @@ class IRGenerator final: public ast::Visitor
     /// Generates code for an arithmetic expression, returning an integer value.
     CoreVM::Value* codegenArith(ast::ArithExpr const* expr);
 
-    /// Converts a value to a boolean for conditional branching.
+    /// True if @p value is already a 0/1 boolean truth value: either a Boolean, or a Void
+    /// value annotated Boolean (e.g. a record field access, whose IR type is always Void).
+    [[nodiscard]] bool isAlreadyBooleanValue(CoreVM::Value* value) const;
+
+    /// Converts a value to a boolean truth value for conditional branching.
+    /// Boolean values (and Void values annotated Boolean, e.g. record field access) are
+    /// returned as-is; other types yield true when non-zero / non-empty.
     CoreVM::Value* toBool(CoreVM::Value* value);
+
+    /// Treats @p value as a command exit code: success (0) maps to true. Used by shell
+    /// `&&`/`||` (LogicalAndStmt/LogicalOrStmt), which chain on exit status rather than
+    /// value truthiness, so it is the inverse of toBool for the numeric case.
+    CoreVM::Value* exitCodeToSuccess(CoreVM::Value* value);
 
     /// Checks if any expression in the list contains a runtime-evaluated expression.
     [[nodiscard]] static bool containsRuntimeExpr(std::vector<std::unique_ptr<ast::Expr>> const& expressions);

--- a/tests/builtins/toBool_float_nonzero.endo
+++ b/tests/builtins/toBool_float_nonzero.endo
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# description: non-zero float is falsy in shell semantics (1.5 != 0.0)
-# expect: no
+# description: non-zero float is truthy (1.5 != 0.0)
+# expect: yes
 
 if 1.5 then print "yes"
 else print "no"

--- a/tests/builtins/toBool_float_zero.endo
+++ b/tests/builtins/toBool_float_zero.endo
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# description: zero float is truthy in shell semantics (0.0 == 0.0)
-# expect: yes
+# description: zero float is falsy (0.0)
+# expect: no
 
 if 0.0 then print "yes"
 else print "no"

--- a/tests/builtins/toBool_not_float.endo
+++ b/tests/builtins/toBool_not_float.endo
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# description: not(1.5): toBool(1.5) = false (falsy), BNot(false) = true
-# expect: true
+# description: not(1.5): toBool(1.5) = true (truthy), BNot(true) = false
+# expect: false
 
 print (not 1.5)

--- a/tests/builtins/toBool_not_string.endo
+++ b/tests/builtins/toBool_not_string.endo
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# description: not("hello"): toBool("hello") = false (falsy), BNot(false) = true
-# expect: true
+# description: not("hello"): toBool("hello") = true (truthy), BNot(true) = false
+# expect: false
 
 print (not "hello")

--- a/tests/builtins/toBool_string_empty.endo
+++ b/tests/builtins/toBool_string_empty.endo
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# description: empty string is truthy in shell semantics ("" == "")
-# expect: yes
+# description: empty string is falsy ("")
+# expect: no
 
 if "" then print "yes"
 else print "no"

--- a/tests/builtins/toBool_string_nonempty.endo
+++ b/tests/builtins/toBool_string_nonempty.endo
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# description: non-empty string is falsy in shell semantics ("hello" != "")
-# expect: no
+# description: non-empty string is truthy ("hello" != "")
+# expect: yes
 
 if "hello" then print "yes"
 else print "no"

--- a/tests/control-flow/if_number_truthiness.endo
+++ b/tests/control-flow/if_number_truthiness.endo
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: A non-zero number is truthy and zero is falsy in an if condition
+# expect: T
+# expect: F
+
+if 5 then print "T"
+else print "F"
+println ""
+if 0 then print "T"
+else print "F"

--- a/tests/control-flow/if_record_bool_field_false.endo
+++ b/tests/control-flow/if_record_bool_field_false.endo
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: A record boolean field that is false takes the else branch
+# expect: F
+
+type R = { flag: bool; name: string }
+
+let r = { flag = false; name = "x" }
+
+if r.flag then print "T"
+else print "F"

--- a/tests/control-flow/if_record_bool_field_true.endo
+++ b/tests/control-flow/if_record_bool_field_true.endo
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: A record boolean field that is true takes the then branch
+# expect: T
+
+type R = { flag: bool; name: string }
+
+let r = { flag = true; name = "x" }
+
+if r.flag then print "T"
+else print "F"

--- a/tests/structured/ls_exists_bool_field.endo
+++ b/tests/structured/ls_exists_bool_field.endo
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: exists with a boolean-field predicate is true when any row matches
+# mode: structured
+# expect: true
+
+print (ls |> exists (_.isDir))

--- a/tests/structured/ls_filter_bool_field_isDir.endo
+++ b/tests/structured/ls_filter_bool_field_isDir.endo
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: A boolean field returned bare from a filter predicate keeps the matching rows
+# mode: structured
+# expect: [docs]
+
+print (ls |> filter (_.isDir) |> map (_.name))

--- a/tests/structured/ls_forall_bool_field.endo
+++ b/tests/structured/ls_forall_bool_field.endo
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: forall with a boolean-field predicate is false when not every row matches
+# mode: structured
+# expect: false
+
+print (ls |> forall (_.isDir))


### PR DESCRIPTION
`toBool` returned the **inverse** of truthiness for every non-Boolean value — it compared with `== 0` / `== ""` — so `if 5` took the else branch, `if ""` took the then branch, and a boolean record field used as a condition was inverted (e.g. `ls |> filter _.isDir` returned the **non**-directories). Boolean-typed conditions were unaffected because they short-circuit on the first branch, but a record field access is emitted as a Void-typed slot read whose real type lives only in an inner-type annotation, so it fell through to the inverted path. The bug affected `if`, `while`, `filter`, `exists`, `forall`, `find`, match guards, `not`, and F# `&&`/`||` over record boolean fields.

## Changes

- `toBool` now returns Boolean values (and Void values annotated Boolean, e.g. record field access) as-is, and uses non-zero / non-empty truthiness for numbers, floats, and strings.
- Shell `&&`/`||` (`LogicalAndStmt`/`LogicalOrStmt`) chain on command exit status (0 = success), which is the inverse of value truthiness, so that path moves to a dedicated `exitCodeToSuccess` helper that preserves the previous behavior. The shared Boolean / Void-Boolean pass-through is factored into `isAlreadyBooleanValue`.
- The six `toBool_*.endo` tests that had encoded the old inverted behavior as intentional "shell semantics" are updated to the corrected expectations, and new tests cover boolean-field predicates (`filter`/`exists`/`forall`) and number/string condition truthiness.