### PR TITLE
Fix SHELL to be the fully-qualified endo path

### DIFF
--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -636,7 +636,13 @@ Shell::Shell(TTY& tty, EnvironmentProvider& env, FileSystem& fs):
     _currentPipelineBuilder.defaultStdinFd = _tty.inputFd();
     _currentPipelineBuilder.defaultStdoutFd = _tty.outputFd();
 
-    _env.setAndExport("SHELL", "endo");
+    // SHELL must be a fully-qualified path (not a bare name): programs such as
+    // sudo-rs' `sudo -s` read SHELL and refuse to spawn it unless it resolves to
+    // an absolute path. Fall back to "endo" only if the path cannot be determined.
+    if (auto const exePath = endo::platform::executablePath())
+        _env.setAndExport("SHELL", endo::platform::normalizePath(*exePath));
+    else
+        _env.setAndExport("SHELL", "endo");
     _env.set("PWD", _env.currentDirectory());
 
     // Track shell nesting level (0 = outermost)

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -30,6 +30,7 @@ using crispy::escape;
 
 #include "Shell.hpp"
 #include "TTY.hpp"
+#include <platform/InstallPaths.hpp>
 #include <platform/NativeFileSystem.hpp>
 #include <platform/testing/TestEnvironmentProvider.hpp>
 
@@ -77,6 +78,24 @@ TEST_CASE("shell.syntax.exit")
     CHECK(shell("exit").exitCode == 0);
     CHECK(shell("exit 1").exitCode == 1);
     CHECK(shell("exit 123").exitCode == 123);
+}
+
+// ============================================================================
+// Startup environment
+// ============================================================================
+
+TEST_CASE("shell.env.SHELL_is_absolute_path")
+{
+    // Regression: SHELL used to be the bare name "endo". It must be the
+    // fully-qualified path to the running executable, because programs such as
+    // sudo-rs' `sudo -s` read SHELL and refuse to spawn a non-absolute value.
+    TestShell shell;
+    auto const value = shell.env.get("SHELL");
+    REQUIRE(value.has_value());
+    CHECK(*value != "endo");
+    auto const exe = endo::platform::executablePath();
+    REQUIRE(exe.has_value());
+    CHECK(*value == endo::platform::normalizePath(*exe));
 }
 
 // ============================================================================


### PR DESCRIPTION
`SHELL` was exported as the bare name `endo`. Programs that validate it as a shell path — notably Ubuntu's sudo-rs `sudo -s` — reject a non-absolute value and refuse to spawn. This resolves the running executable's absolute path via the existing `endo::platform::executablePath()` helper and exports that instead, falling back to `endo` only when the path cannot be determined.