### PR TITLE
Add Path module and Json.query indexing; fix F# closure capture

### DIFF
--- a/ROADMAP-Language.md
+++ b/ROADMAP-Language.md
@@ -247,6 +247,7 @@ This document tracks the implementation status of F# language features as define
 - [x] Fix `exec` with pattern-matched tuple variables: `ensureString()` bypasses `convertToString` N2S corruption for Object/Void-typed strings from `ObjGetSlot`
 - [x] Fix `TuplePattern` with `ConstructorPattern` sub-patterns: create scrutinee storage allocas so `ConstructorPattern` can reload across block boundaries
 - [x] Shell word splitting: adjacent tokens without whitespace form a single word (e.g., `echo $LINES:$COLUMNS` outputs `35:127` not `35 : 127`)
+- [x] Quoted program paths: `& "X:/Program Files/!Tools/tool.exe"` accepts a double/single-quoted program name (with `$`-interpolation) so paths with spaces, `!`, or a `//` UNC prefix run; Windows drive-letter and UNC paths normalized for resolution
 
 ## Completion System
 

--- a/ROADMAP-Language.md
+++ b/ROADMAP-Language.md
@@ -217,7 +217,7 @@ This document tracks the implementation status of F# language features as define
 - [x] `nth`, `last` — indexed list access returning `option<T>`
 - [x] `replicate` — create list of N copies of a value
 - [x] `fetch` — HTTP GET request, returns `result<str, str>`
-- [x] `Json.query` — extract values from JSON strings using dotted path syntax (`.key`, `[]` for array iteration); returns `list<string>`
+- [x] `Json.query` — extract values from JSON strings using dotted path syntax (`.key`, `[]` for array iteration, `[N]` for indexed element access); returns `list<string>`
 - [ ] `Json.parse`, `Json.stringify` — JSON serialization/deserialization
 - [x] `split`, `join`, `trim`, `contains`, `startsWith`, `endsWith`, `toLower`, `toUpper`, `replace` — string operations
 - [x] `rand` — random integer generation (`rand` → random positive int; `rand A B` → random int in [A, B])
@@ -226,7 +226,9 @@ This document tracks the implementation status of F# language features as define
 - [x] `File.open`, `File.close`, `File.readLine`, `File.readAll`, `File.writeAll`, `File.appendAll` — file I/O operations
 - [x] `File.size`, `File.exists`, `File.delete` — file metadata and management
 - [x] `Path.temporary_directory` — cross-platform temporary directory path
-- [ ] `Path.join`, `Path.extension`, `Path.basename` — path operations
+- [x] `Path.join`, `Path.dirname`, `Path.basename`, `Path.normalize`, `Path.isAbsolute` — lexical path operations (platform-native separators)
+- [x] `Path.separator`, `Path.delimiter` — platform directory / `PATH`-list separators
+- [ ] `Path.extension` — file extension extraction
 
 ## Shell Integration
 

--- a/ROADMAP-Language.md
+++ b/ROADMAP-Language.md
@@ -262,6 +262,7 @@ This document tracks the implementation status of F# language features as define
 - [x] `collectRecordInfo()` extracts record types and variable-type associations from source for LSP
 - [x] Record-aware hover: hovering over record variable shows detected type name (e.g., `Person`) and type definition
 - [x] Standard library function autocompletion: 40 functions (type conversion, string ops, list ops, HOFs, transforms, env/system) in both shell prompt and LSP
+- [x] Auto-quoting on insertion: completions containing spaces or shell-reserved characters are wrapped in double quotes (directories keep the quote open; escapes inside an already-open quote) so the result stays a single token
 
 ## Modules & Imports
 

--- a/docs/language/command-execution.md
+++ b/docs/language/command-execution.md
@@ -60,6 +60,37 @@ process (cat config.txt)
 analyze (git diff HEAD~1)
 ```
 
+### Quoting the Program Path
+
+The program name in command position is normally a bare word. If the path contains
+characters that would otherwise split it into several tokens — spaces, `!`, `$`, or a
+leading `//` (a UNC path, whose unquoted `//` starts a C-style comment) — wrap it in
+quotes. This is most common on Windows with drive-letter and UNC paths:
+
+<!-- endo-no-check -->
+```endo
+# Drive-letter path with a space and a '!'
+& "X:/Program Files/!Tools/tool.exe" --help
+
+# UNC path — must be quoted, since an unquoted // starts a comment
+& "//server/share/tools/tool.exe" --help
+
+# Double quotes interpolate exactly like a quoted argument. `$VAR` reads an
+# environment variable, so export it (or use one already in the environment):
+let export dir = "X:/Program Files/!Tools"
+& "$dir/tool.exe" --help
+
+# Single quotes are literal (no interpolation):
+& 'X:/Program Files/!Tools/tool.exe' --help
+```
+
+Arguments after the program are quoted the same way. For a program path that is only
+known at runtime from an F# expression (a variable, `which`, or a pattern match), use
+[`exec`](#107-dynamic-command-execution-exec) instead.
+
+> **Tip:** interactive TAB-completion inserts these quotes for you — completing a path
+> that contains a space or other special character produces an already-quoted token.
+
 ### 10.3 String Interpolation
 
 ```endo

--- a/docs/language/command-execution.md
+++ b/docs/language/command-execution.md
@@ -94,19 +94,21 @@ known at runtime from an F# expression (a variable, `which`, or a pattern match)
 ### 10.3 String Interpolation
 
 ```endo
-# Variable interpolation
-let name = "World"
+# Variable interpolation — $VAR and ${VAR} read ENVIRONMENT variables.
+# Use `let export` (or an already-exported name) to make a value visible here;
+# a plain `let` binding is not exported and does not interpolate.
+let export name = "World"
 echo "Hello, $name"               # Hello, World
 echo "Path: ${HOME}/docs"         # Path: /home/user/docs
 
-# Expression interpolation
+# Arithmetic and command substitution
 echo "Sum: $((1 + 2 * 3))"        # Sum: 7
 echo "Files: $(ls | wc -l)"       # Files: 42
-echo "Upper: ${name |> toUpper}"  # Upper: WORLD
 
-# Nested interpolation
-let user = "alice"
-echo "Home: ${getenv "HOME_$user"}"
+# F# expression interpolation — $"...{expr}..." evaluates an F# expression and
+# sees F# let bindings. This (not ${...}) is how you transform a value.
+let title = "world"
+println $"Upper: {title |> toUpper}"   # Upper: WORLD
 
 # Escape to prevent interpolation
 echo "Literal \$name"             # Literal $name

--- a/docs/language/lexical-elements.md
+++ b/docs/language/lexical-elements.md
@@ -37,6 +37,12 @@ of        as        global    lazy
 *)
 ```
 
+> **Note:** `//` starts a C-style comment wherever it appears, including at the start
+> of a command word. A UNC path written with a leading `//` (e.g.
+> `//server/share/tool.exe`) is therefore consumed as a comment unless it is quoted.
+> Quote such paths in command position: `& "//server/share/tool.exe"`. See
+> [Command Execution → Quoting the Program Path](command-execution.md#quoting-the-program-path).
+
 #### Formatter directives
 
 `endo format` recognizes two directive comments that disable and re-enable

--- a/docs/language/standard-library.md
+++ b/docs/language/standard-library.md
@@ -1617,8 +1617,14 @@ On parse error or missing key, returns an empty list.
 
 **Path syntax:**
 - `.key` — access an object property
-- `[]` — iterate array elements
+- `[]` — iterate all array elements
+- `[N]` — access a single array element by zero-based index
 - Chained: `.key1[].key2` — access `key1` (array), iterate elements, access `key2` from each
+
+Use `[N]` to address one specific element (e.g. `.items[0].name`). Unlike `[]`, which
+flattens and skips missing keys — so parallel arrays misalign — `[N]` isolates a single
+object, letting you read its fields independently. An out-of-range index yields an empty
+list.
 
 ```endo
 let json = "{\"name\": \"hello\"}"
@@ -1629,6 +1635,14 @@ r |> each println
 ```endo
 let json = "{\"items\":[{\"name\":\"alpha\"},{\"name\":\"beta\"}]}"
 let r = Json.query ".items[].name" json
+r |> each println
+```
+
+Indexed access selects a single element:
+
+```endo
+let json = "{\"items\":[{\"name\":\"alpha\"},{\"name\":\"beta\"}]}"
+let r = Json.query ".items[1].name" json
 r |> each println
 ```
 
@@ -1694,7 +1708,9 @@ s |> toList |> println
 
 ## 15.25 Path
 
-The `Path` module provides cross-platform filesystem path utilities.
+The `Path` module provides cross-platform filesystem path utilities. The join/dirname/
+basename/normalize/isAbsolute operations are purely lexical (they do not touch the
+filesystem) and use the platform-native separator (`\` on Windows, `/` elsewhere).
 
 #### `Path.temporary_directory`
 
@@ -1705,6 +1721,77 @@ Returns the platform's temporary directory path (e.g. `/tmp` on Linux, `C:\Users
 ```endo
 let tmp = Path.temporary_directory
 println tmp
+```
+
+#### `Path.join`
+
+**Signature:** `Path.join a b -> str`
+
+Joins two path segments with the platform-native separator. If `b` is absolute it
+replaces `a` (matching typical `Path.Combine`/`os.path.join` semantics).
+
+```endo
+println (Path.basename (Path.join "src" "main.endo"))   # => main.endo
+```
+
+#### `Path.dirname`
+
+**Signature:** `Path.dirname p -> str`
+
+Returns the parent-directory portion of a path (empty for a bare file name).
+
+```endo
+println (Path.dirname "a/b/c")   # => a/b
+```
+
+#### `Path.basename`
+
+**Signature:** `Path.basename p -> str`
+
+Returns the final component (file name) of a path.
+
+```endo
+println (Path.basename "a/b/c.txt")   # => c.txt
+```
+
+#### `Path.normalize`
+
+**Signature:** `Path.normalize p -> str`
+
+Lexically collapses `.` and `..` segments and normalizes separators to the platform-native
+form. Does not touch the filesystem.
+
+```endo
+println (Path.basename (Path.normalize "a/b/../c"))   # => c
+```
+
+#### `Path.isAbsolute`
+
+**Signature:** `Path.isAbsolute p -> bool`
+
+Returns `true` if the path is absolute.
+
+```endo
+println (Path.isAbsolute "relative/path")   # => false
+```
+
+#### `Path.separator`
+
+**Signature:** `Path.separator -> str`
+
+The platform's directory separator (`\` on Windows, `/` elsewhere).
+
+#### `Path.delimiter`
+
+**Signature:** `Path.delimiter -> str`
+
+The platform's `PATH`-list separator (`;` on Windows, `:` elsewhere) — useful when
+prepending to `$PATH`.
+
+<!-- endo-no-check -->
+```endo
+let sep = Path.delimiter
+let export PATH = "/opt/mytool/bin" + sep + (env "PATH" ?| "")
 ```
 
 ## 15.26 File I/O

--- a/docs/shell/completions.md
+++ b/docs/shell/completions.md
@@ -26,8 +26,7 @@ $ gi<Tab>
 ### File Path Completion
 
 Anywhere an argument is expected, endo completes file and directory paths. Tilde expansion
-(`~`, `~user`) works transparently, and special characters in filenames are escaped
-automatically.
+(`~`, `~user`) works transparently.
 
 ```
 $ cat ~/Doc<Tab>
@@ -35,6 +34,24 @@ $ cat ~/Doc<Tab>
 ```
 
 Directories are shown with a trailing `/` to distinguish them from files.
+
+#### Automatic quoting
+
+When a completed path contains characters that would otherwise split it into several
+tokens — a space, `!`, `$`, a leading `//` (UNC), and so on — endo inserts it **wrapped in
+double quotes** so it stays a single argument (or program name):
+
+```
+$ cat X:/Program<Tab>
+  cat "X:/Program Files/
+```
+
+A directory completion leaves the quote open so the next **Tab** continues inside it; a
+file (final) completion closes the quote. If you are already inside an open quote when you
+press **Tab**, endo escapes the inserted text for that quote instead of opening a new one.
+This is the same quoting you would write by hand to run a program at such a path, e.g.
+`& "X:/Program Files/tool.exe"` (see
+[Command Execution → Quoting the Program Path](../language/command-execution.md#quoting-the-program-path)).
 
 ### Variable Completion
 

--- a/src/CoreVM/CMakeLists.txt
+++ b/src/CoreVM/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(CoreVM PRIVATE
     ir/Value.cpp
     transform/EmptyBlockElimination.cpp
     transform/InstructionElimination.cpp
+    transform/MaterializeCrossBlockValues.cpp
     transform/MergeBlockPass.cpp
     transform/UnusedBlockPass.cpp
     util/Cidr.cpp

--- a/src/CoreVM/TargetCodeGenerator.cpp
+++ b/src/CoreVM/TargetCodeGenerator.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <CoreVM/CoreVM.hpp>
+#include <CoreVM/transform/Passes.hpp>
 #include <CoreVM/util.hpp>
 #include <CoreVM/util/assert.hpp>
 
@@ -74,6 +75,12 @@ std::unique_ptr<Program> TargetCodeGenerator::generate(IRProgram* programIR)
 
 void TargetCodeGenerator::generate(IRFunction* function)
 {
+    // Required lowering step, done here so it applies to every code-generation path
+    // (shell, test harness, LSP, DAP, …): promote SSA values that live across
+    // basic-block boundaries into allocas, the only form preserved across blocks by the
+    // stack-based lowering below. Must run before the alloca-indexing pass.
+    transform::materializeCrossBlockValues(function);
+
     // explicitely forward-declare function, so we can use its ID internally.
     _functionId = _cp.makeFunction(function);
 

--- a/src/CoreVM/ir/IRProgram.cpp
+++ b/src/CoreVM/ir/IRProgram.cpp
@@ -18,6 +18,17 @@ IRProgram::IRProgram(): _trueLiteral(true, "trueLiteral"), _falseLiteral(false, 
 
 IRProgram::~IRProgram()
 {
+    // Detach every instruction from its operands before destroying any of them. A Value's
+    // destructor asserts it has no remaining uses, but instructions are stored front-to-back
+    // per block, so an alloca (at the front) is otherwise destroyed while the loads that
+    // reference it (later, and possibly in other functions — e.g. capture-forwarding loads of
+    // a global binding) are still alive. Clearing all use/def links up front makes teardown
+    // order-independent.
+    for (auto const& function: _functions)
+        for (BasicBlock* bb: function->basicBlocks())
+            for (Instr* instr: bb->instructions())
+                instr->clearOperands();
+
     // first reset all standard functions and *then* the global-scope initialization function
     // in order to not cause confusion upon resource release
     {

--- a/src/CoreVM/transform/MaterializeCrossBlockValues.cpp
+++ b/src/CoreVM/transform/MaterializeCrossBlockValues.cpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <CoreVM/CoreVM.hpp>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace CoreVM::transform
+{
+
+// Materializes every SSA value that is used outside its defining basic block into a
+// stack slot (alloca): the value is stored right after it is computed, and reloaded at
+// the start of each block that uses it.
+//
+// The target code generator lowers SSA onto a stack machine in which only allocas keep
+// a fixed frame slot across basic-block boundaries — every other temporary is discarded
+// at a block boundary (see TargetCodeGenerator's block-entry stack reset). A value that
+// is defined before a branch (`if`, `match`, `?|`, …) and used afterwards is otherwise
+// lost, which crashes the generator. Promoting such values to allocas restores the
+// invariant the generator relies on, so this is a required lowering step rather than an
+// optimization, and must run for every function regardless of the optimization level.
+bool materializeCrossBlockValues(IRFunction* function)
+{
+    IRProgram* program = function->getProgram();
+    BasicBlock* entry = function->getEntryBlock();
+    if (program == nullptr || entry == nullptr)
+        return false;
+
+    ConstantInt* zero = program->get(static_cast<int64_t>(0));
+    ConstantInt* one = program->get(static_cast<int64_t>(1));
+
+    // Snapshot the definitions up front: the loop below mutates instruction lists.
+    std::vector<Instr*> definitions;
+    for (BasicBlock* bb: function->basicBlocks())
+        for (Instr* instr: bb->instructions())
+            definitions.push_back(instr);
+
+    bool changed = false;
+
+    for (Instr* def: definitions)
+    {
+        if (def->type() == LiteralType::Void) // nothing to preserve
+            continue;
+        if (dynamic_cast<AllocaInstr*>(def) != nullptr) // already frame-resident
+            continue;
+        if (dynamic_cast<PhiNode*>(def) != nullptr) // phis are lowered separately
+            continue;
+
+        BasicBlock* defBlock = def->getBasicBlock();
+        if (defBlock == nullptr)
+            continue;
+
+        // Uses that live in a different block of the SAME function are the ones at risk.
+        // Uses in another function are closure captures, handled by the capture mechanism;
+        // materializing them here would create a load referencing this function's frame
+        // slot from inside a different function's frame.
+        std::vector<Instr*> crossBlockUsers;
+        for (Instr* user: def->uses())
+        {
+            BasicBlock* userBlock = user->getBasicBlock();
+            if (userBlock != nullptr && userBlock != defBlock
+                && userBlock->getFunction() == defBlock->getFunction())
+                crossBlockUsers.push_back(user);
+        }
+        if (crossBlockUsers.empty())
+            continue;
+
+        // Reserve a slot and store the value once computed. Storing before the block
+        // terminator places the store after the defining instruction while leaving the
+        // value available to same-block uses (which keep referencing `def` directly).
+        auto* slot = static_cast<AllocaInstr*>(
+            entry->insertAfterAllocas(std::make_unique<AllocaInstr>(def->type(), one, "r2m.slot")));
+        defBlock->insertBeforeTerminator(std::make_unique<StoreInstr>(slot, zero, def, "r2m.store"));
+
+        // Reload at the top of each using block and rewire that block's uses to it. The
+        // definition dominates every use (SSA), so the store dominates every reload.
+        std::unordered_map<BasicBlock*, Value*> reloadPerBlock;
+        for (Instr* user: crossBlockUsers)
+        {
+            BasicBlock* userBlock = user->getBasicBlock();
+            auto const it = reloadPerBlock.find(userBlock);
+            Value* reload = nullptr;
+            if (it != reloadPerBlock.end())
+            {
+                reload = it->second;
+            }
+            else
+            {
+                reload = userBlock->insertAfterAllocas(std::make_unique<LoadInstr>(slot, "r2m.load"));
+                reloadPerBlock[userBlock] = reload;
+            }
+            user->replaceOperand(def, reload);
+        }
+
+        changed = true;
+    }
+
+    return changed;
+}
+
+} // namespace CoreVM::transform

--- a/src/CoreVM/transform/Passes.hpp
+++ b/src/CoreVM/transform/Passes.hpp
@@ -31,4 +31,12 @@ bool mergeSameBlocks(IRFunction* function);
  */
 bool eliminateUnusedBlocks(IRFunction* function);
 
+/**
+ * Promotes SSA values that are used outside their defining basic block into allocas
+ * (store after definition, reload at each using block). The target code generator only
+ * preserves allocas across block boundaries, so this is a required lowering step (not an
+ * optimization) and must run for every function before target code generation.
+ */
+bool materializeCrossBlockValues(IRFunction* function);
+
 } // namespace CoreVM::transform

--- a/src/endo-language/ast/AST.hpp
+++ b/src/endo-language/ast/AST.hpp
@@ -581,11 +581,14 @@ struct BuiltinWhichStmt final: public Statement
 /// It is a path to an executable, followed by arguments, with optional redirects.
 struct ProgramCall final: public Statement
 {
-    std::string program;                                ///< Program name or path (raw display string)
-    std::unique_ptr<Expr> programExpr;                  ///< Runtime program name expression (tilde expansion)
-    std::optional<SourceLocationRange> programLocation; ///< Source location of the program name token
-    std::vector<std::unique_ptr<Expr>> parameters;      ///< Command arguments
-    std::vector<std::unique_ptr<InputRedirect>> inputRedirects;   ///< Input redirects (< FILE)
+    std::string program; ///< Program name or path (raw display string)
+    std::unique_ptr<Expr>
+        programExpr;            ///< Runtime program name expression (tilde expansion / quoted program path)
+    bool quotedProgram = false; ///< True when the program name came from a quoted string; format via
+                                ///< programExpr, not the raw `program` string
+    std::optional<SourceLocationRange> programLocation;         ///< Source location of the program name token
+    std::vector<std::unique_ptr<Expr>> parameters;              ///< Command arguments
+    std::vector<std::unique_ptr<InputRedirect>> inputRedirects; ///< Input redirects (< FILE)
     std::vector<std::unique_ptr<OutputRedirect>> outputRedirects; ///< Output redirects (> FILE, >> FILE, >&)
     std::vector<std::unique_ptr<HereDocument>> hereDocuments;     ///< Here-documents (<<EOF)
     std::vector<std::unique_ptr<HereString>> hereStrings;         ///< Here-strings (<<<)
@@ -978,10 +981,7 @@ struct LetBindingStmt final: public Statement
     [[nodiscard]] bool isRecursive() const noexcept { return recursion == Recursion::Recursive; }
 
     /// Is this a passthrough function?
-    [[nodiscard]] bool isPassthrough() const noexcept
-    {
-        return captureMode == ShellCaptureMode::Passthrough;
-    }
+    [[nodiscard]] bool isPassthrough() const noexcept { return captureMode == ShellCaptureMode::Passthrough; }
 
     /// Is this a function definition (has parameters)?
     [[nodiscard]] bool isFunction() const noexcept { return !parameters.empty(); }
@@ -1261,8 +1261,8 @@ enum class ApplicationOrigin : uint8_t
 
 struct ApplicationExpr final: public Expr
 {
-    std::unique_ptr<Expr> function;         ///< Function being applied
-    std::unique_ptr<Expr> argument;         ///< Argument being passed
+    std::unique_ptr<Expr> function;                         ///< Function being applied
+    std::unique_ptr<Expr> argument;                         ///< Argument being passed
     ApplicationOrigin origin = ApplicationOrigin::Explicit; ///< How this application was formed
 
     ApplicationExpr(std::unique_ptr<Expr> func, std::unique_ptr<Expr> arg):

--- a/src/endo-language/ast/ASTPrinter.cpp
+++ b/src/endo-language/ast/ASTPrinter.cpp
@@ -69,7 +69,13 @@ void ASTPrinter::visit(HereString const& node)
 
 void ASTPrinter::visit(ProgramCall const& node)
 {
-    _result += std::format("{}", node.program);
+    // A quoted program name is carried by programExpr (a quoted LiteralExpr or an
+    // interpolated ConcatExpr), which re-emits its surrounding quotes; tilde and
+    // bare-word programs print the raw `program` string.
+    if (node.quotedProgram && node.programExpr)
+        node.programExpr->accept(*this);
+    else
+        _result += std::format("{}", node.program);
 
     for (auto const& param: node.parameters)
     {

--- a/src/endo-language/builtins/BuiltinImpls.cpp
+++ b/src/endo-language/builtins/BuiltinImpls.cpp
@@ -54,6 +54,52 @@ void pathTemporaryDirectory(CoreVM::Params& args)
     args.setResult(args.caller()->newString(std::filesystem::temp_directory_path().string()));
 }
 
+void pathJoin(CoreVM::Params& args)
+{
+    auto const base = std::filesystem::path(std::string(args.getString(1)));
+    auto const tail = std::filesystem::path(std::string(args.getString(2)));
+    args.setResult(args.caller()->newString((base / tail).string()));
+}
+
+void pathDirname(CoreVM::Params& args)
+{
+    auto const p = std::filesystem::path(std::string(args.getString(1)));
+    args.setResult(args.caller()->newString(p.parent_path().string()));
+}
+
+void pathBasename(CoreVM::Params& args)
+{
+    auto const p = std::filesystem::path(std::string(args.getString(1)));
+    args.setResult(args.caller()->newString(p.filename().string()));
+}
+
+void pathNormalize(CoreVM::Params& args)
+{
+    auto p = std::filesystem::path(std::string(args.getString(1)));
+    args.setResult(args.caller()->newString(p.lexically_normal().make_preferred().string()));
+}
+
+void pathIsAbsolute(CoreVM::Params& args)
+{
+    auto const p = std::filesystem::path(std::string(args.getString(1)));
+    args.setResult(static_cast<CoreVM::CoreNumber>(p.is_absolute() ? 1 : 0));
+}
+
+void pathSeparator(CoreVM::Params& args)
+{
+    auto const sep = std::string(1, static_cast<char>(std::filesystem::path::preferred_separator));
+    args.setResult(args.caller()->newString(sep));
+}
+
+void pathDelimiter(CoreVM::Params& args)
+{
+#if defined(_WIN32)
+    args.setResult(args.caller()->newString(std::string(";")));
+#else
+    args.setResult(args.caller()->newString(std::string(":")));
+#endif
+}
+
 // ---------------------------------------------------------------------------
 // Value-to-string conversion
 // ---------------------------------------------------------------------------
@@ -1298,11 +1344,13 @@ namespace
     {
         enum class Kind : uint8_t
         {
-            Key,
-            Array,
+            Key,   ///< `.name` — access an object property by name.
+            Array, ///< `[]` — iterate over all elements of an array.
+            Index, ///< `[N]` — access a single array element by zero-based index.
         };
         Kind kind;
-        std::string key;
+        std::string key;  ///< Property name for Kind::Key.
+        size_t index = 0; ///< Element index for Kind::Index.
     };
 
     std::vector<JsonPathSegment> parseJsonPath(std::string_view path)
@@ -1326,6 +1374,24 @@ namespace
             {
                 segments.push_back({ .kind = JsonPathSegment::Kind::Array, .key = {} });
                 i += 2;
+            }
+            else if (path[i] == '[' && i + 1 < path.size() && path[i + 1] >= '0' && path[i + 1] <= '9')
+            {
+                // `[N]` — indexed array element access.
+                ++i; // consume '['
+                size_t value = 0;
+                while (i < path.size() && path[i] >= '0' && path[i] <= '9')
+                {
+                    value = (value * 10) + static_cast<size_t>(path[i] - '0');
+                    ++i;
+                }
+                if (i < path.size() && path[i] == ']')
+                {
+                    segments.push_back({ .kind = JsonPathSegment::Kind::Index, .key = {}, .index = value });
+                    ++i; // consume ']'
+                }
+                // A malformed `[N` without a closing bracket is silently ignored,
+                // matching the tolerant behaviour of the rest of the parser.
             }
             else
             {
@@ -1368,6 +1434,11 @@ namespace
                 for (auto const& elem: node)
                     walkJson(elem, segments, index + 1, results);
             }
+        }
+        else if (seg.kind == JsonPathSegment::Kind::Index)
+        {
+            if (node.is_array() && seg.index < node.size())
+                walkJson(node[seg.index], segments, index + 1, results);
         }
     }
 

--- a/src/endo-language/builtins/BuiltinImpls.hpp
+++ b/src/endo-language/builtins/BuiltinImpls.hpp
@@ -323,8 +323,9 @@ void randRange(CoreVM::Params& args);
 // ---------------------------------------------------------------------------
 
 /// json_query(path, json) -> list<string>: Extracts values from a JSON string using a dotted path.
-/// Path syntax: `.key` accesses an object property, `[]` iterates array elements.
-/// Returns an empty list on parse error or missing key.
+/// Path syntax: `.key` accesses an object property, `[]` iterates all array elements, and
+/// `[N]` accesses a single array element by zero-based index.
+/// Returns an empty list on parse error, missing key, or out-of-range index.
 void jsonQuery(CoreVM::Params& args);
 
 // ---------------------------------------------------------------------------
@@ -364,6 +365,29 @@ void fileDelete(CoreVM::Params& args);
 
 /// path_temporary_directory() -> string: Returns the platform's temporary directory path.
 void pathTemporaryDirectory(CoreVM::Params& args);
+
+/// path_join(a, b) -> string: Joins two path segments with the platform-native separator.
+/// If `b` is absolute, it replaces `a` (matching std::filesystem::path semantics).
+void pathJoin(CoreVM::Params& args);
+
+/// path_dirname(p) -> string: Returns the parent-directory portion of a path (may be empty).
+void pathDirname(CoreVM::Params& args);
+
+/// path_basename(p) -> string: Returns the final component (file name) of a path.
+void pathBasename(CoreVM::Params& args);
+
+/// path_normalize(p) -> string: Lexically collapses `.`/`..` and normalizes separators to the
+/// platform-native form. Purely lexical — does not touch the filesystem.
+void pathNormalize(CoreVM::Params& args);
+
+/// path_is_absolute(p) -> bool: Returns true if the path is absolute.
+void pathIsAbsolute(CoreVM::Params& args);
+
+/// path_separator() -> string: The platform's directory separator (`\` on Windows, `/` elsewhere).
+void pathSeparator(CoreVM::Params& args);
+
+/// path_delimiter() -> string: The platform's PATH-list separator (`;` on Windows, `:` elsewhere).
+void pathDelimiter(CoreVM::Params& args);
 
 // ---------------------------------------------------------------------------
 // Process signal operations

--- a/src/endo-language/builtins/JsonQuery_test.cpp
+++ b/src/endo-language/builtins/JsonQuery_test.cpp
@@ -116,3 +116,54 @@ TEST_CASE("Json.query.list_append_pattern")
         results |> each println
     )") == "a\nb\nc\n");
 }
+
+TEST_CASE("Json.query.indexed_element")
+{
+    // [N] selects a single array element by zero-based index, so a specific object's
+    // fields can be read even when sibling objects omit those keys (unlike [] which
+    // flattens and skips missing keys, misaligning parallel arrays).
+    CHECK(executeSourceAndGetOutput(R"(
+        let json = "{\"items\":[{\"name\":\"alpha\"},{\"name\":\"beta\"},{\"name\":\"gamma\"}]}"
+        let r = Json.query ".items[1].name" json
+        r |> each println
+    )") == "beta\n");
+}
+
+TEST_CASE("Json.query.indexed_first_and_last")
+{
+    CHECK(executeSourceAndGetOutput(R"(
+        let json = "{\"items\":[{\"name\":\"alpha\"},{\"name\":\"beta\"}]}"
+        let r = Json.query ".items[0].name" json @ Json.query ".items[1].name" json
+        r |> each println
+    )") == "alpha\nbeta\n");
+}
+
+TEST_CASE("Json.query.indexed_out_of_range_is_empty")
+{
+    auto output = executeSourceAndGetOutput(R"(
+        let json = "{\"items\":[{\"name\":\"alpha\"}]}"
+        let r = Json.query ".items[5].name" json
+        r |> each println
+    )");
+    CHECK(output.empty());
+}
+
+TEST_CASE("Json.query.indexed_scalar_value")
+{
+    // A path landing on a single scalar yields a one-element list.
+    CHECK(executeSourceAndGetOutput(R"(
+        let json = "{\"xs\":[10,20,30]}"
+        let r = Json.query ".xs[2]" json
+        r |> each println
+    )") == "30\n");
+}
+
+TEST_CASE("Json.query.indexed_on_non_array_is_empty")
+{
+    auto output = executeSourceAndGetOutput(R"(
+        let json = "{\"obj\":{\"a\":1}}"
+        let r = Json.query ".obj[0]" json
+        r |> each println
+    )");
+    CHECK(output.empty());
+}

--- a/src/endo-language/builtins/StdlibDescriptors.cpp
+++ b/src/endo-language/builtins/StdlibDescriptors.cpp
@@ -62,6 +62,7 @@ static constexpr ParamDescriptor CompletionDetailedParams[] = { { .name="text", 
 static constexpr ParamDescriptor FileOpenParams[] = { { .name="path", .type=LT::String }, { .name="mode", .type=LT::String } };
 static constexpr ParamDescriptor FdNumberParam[] = { { .name="fd", .type=LT::Number } };
 static constexpr ParamDescriptor PathStringParam[] = { { .name="path", .type=LT::String } };
+static constexpr ParamDescriptor PathJoinParams[] = { { .name="base", .type=LT::String }, { .name="tail", .type=LT::String } };
 static constexpr ParamDescriptor FileWriteParams[] = { { .name="path", .type=LT::String }, { .name="content", .type=LT::String } };
 
 // Process signal params
@@ -415,6 +416,23 @@ static const std::array descriptors = {
 
     // Path operations
     StdlibDescriptor { .userFacingName="", .vmName="path_temporary_directory", .returnType=LT::String, .params={}, .sharedImpl=&builtins::pathTemporaryDirectory, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="path_join", .returnType=LT::String, .params=PathJoinParams, .sharedImpl=&builtins::pathJoin,
+        .description="Path.join a b -> string",
+        .detail="**Path.join** `a b -> string`\n\nJoins two path segments with the platform-native separator. If **b** is absolute, it replaces **a**." },
+    StdlibDescriptor { .userFacingName="", .vmName="path_dirname", .returnType=LT::String, .params=PathStringParam, .sharedImpl=&builtins::pathDirname,
+        .description="Path.dirname p -> string",
+        .detail="**Path.dirname** `p -> string`\n\nReturns the parent-directory portion of path **p**." },
+    StdlibDescriptor { .userFacingName="", .vmName="path_basename", .returnType=LT::String, .params=PathStringParam, .sharedImpl=&builtins::pathBasename,
+        .description="Path.basename p -> string",
+        .detail="**Path.basename** `p -> string`\n\nReturns the final component (file name) of path **p**." },
+    StdlibDescriptor { .userFacingName="", .vmName="path_normalize", .returnType=LT::String, .params=PathStringParam, .sharedImpl=&builtins::pathNormalize,
+        .description="Path.normalize p -> string",
+        .detail="**Path.normalize** `p -> string`\n\nLexically collapses `.`/`..` segments and normalizes separators. Does not touch the filesystem." },
+    StdlibDescriptor { .userFacingName="", .vmName="path_is_absolute", .returnType=LT::Boolean, .params=PathStringParam, .sharedImpl=&builtins::pathIsAbsolute,
+        .description="Path.isAbsolute p -> bool",
+        .detail="**Path.isAbsolute** `p -> bool`\n\nReturns true if path **p** is absolute." },
+    StdlibDescriptor { .userFacingName="", .vmName="path_separator", .returnType=LT::String, .params={}, .sharedImpl=&builtins::pathSeparator, .description="", .detail="" },
+    StdlibDescriptor { .userFacingName="", .vmName="path_delimiter", .returnType=LT::String, .params={}, .sharedImpl=&builtins::pathDelimiter, .description="", .detail="" },
 
     // File I/O operations
     StdlibDescriptor { .userFacingName="", .vmName="file_open", .returnType=LT::Number, .params=FileOpenParams, .sharedImpl=&builtins::fileOpen, .description="", .detail="" },

--- a/src/endo-language/codegen/IRGenerator.cpp
+++ b/src/endo-language/codegen/IRGenerator.cpp
@@ -1303,14 +1303,47 @@ std::optional<CoreVM::LiteralType> IRGenerator::determineCommonLiteralType(
 std::unordered_map<std::string, CoreVM::Value*> IRGenerator::collectFreeVariables(
     ast::Expr const* body, std::vector<std::string> const& boundNames) const
 {
-    // Delegate AST analysis to the standalone utility
-    auto const freeNames = collectFreeVariableNames(
-        body,
-        boundNames,
-        [this](std::string const& name) { return lookupFSharpVariable(name) != nullptr; },
-        [this](std::string const& name) { return lookupFSharpFunction(name) != nullptr; });
+    auto const isInScope = [this](std::string const& name) {
+        return lookupFSharpVariable(name) != nullptr;
+    };
+    auto const isKnownFunction = [this](std::string const& name) {
+        return lookupFSharpFunction(name) != nullptr;
+    };
 
-    // Map returned names to their CoreVM storage values
+    // Direct free variables, plus the set of known functions this body references.
+    std::unordered_set<std::string> referencedFunctions;
+    auto freeNames =
+        collectFreeVariableNames(body, boundNames, isInScope, isKnownFunction, &referencedFunctions);
+
+    // Transitive captures: calling a closure lowers to passing that closure's captured
+    // variables as leading call arguments, so the caller must itself capture them to have
+    // them available in its own frame. Without this, the caller would try to load the
+    // callee's captures from another function's frame slots at runtime (an out-of-bounds
+    // LOAD). Expand over referenced known functions to a fixed point; the callee's own body
+    // is re-analyzed so this is independent of the order functions were compiled in.
+    std::unordered_set<std::string> visited;
+    std::vector<std::string> worklist(referencedFunctions.begin(), referencedFunctions.end());
+    while (!worklist.empty())
+    {
+        auto const fname = std::move(worklist.back());
+        worklist.pop_back();
+        if (!visited.insert(fname).second)
+            continue;
+        auto const it = _fsharpFunctions.find(fname);
+        if (it == _fsharpFunctions.end() || it->second.body == nullptr)
+            continue;
+
+        std::unordered_set<std::string> calleeReferences;
+        auto const calleeFree = collectFreeVariableNames(
+            it->second.body, it->second.parameters, isInScope, isKnownFunction, &calleeReferences);
+        for (auto const& name: calleeFree)
+            freeNames.insert(name);
+        for (auto const& callee: calleeReferences)
+            if (!visited.contains(callee))
+                worklist.push_back(callee);
+    }
+
+    // Map returned names to their CoreVM storage values in the current scope.
     std::unordered_map<std::string, CoreVM::Value*> freeVars;
     for (auto const& name: freeNames)
         if (auto* storage = lookupFSharpVariable(name))
@@ -6761,9 +6794,19 @@ void IRGenerator::visit(ast::PipelineExpr const& node)
     // Non-recursive: inline the function body with the piped value as argument
     pushFSharpScope();
 
-    // Re-bind captured variables from the closure
+    // Re-bind captured variables from the closure. When inlining inside another function,
+    // that enclosing function has itself (transitively) captured these names, so their live
+    // storage is the enclosing frame's capture slot — not the binding recorded at this
+    // function's definition site (which may live in an outer function's frame and would be
+    // an out-of-bounds load here). Prefer the in-scope storage, mirroring the compiled-call path.
     for (auto const& [capName, capStorage]: func->capturedBindings)
-        bindFSharpVariable(capName, capStorage, func->capturedMutables.contains(capName));
+    {
+        CoreVM::Value* storage = capStorage;
+        if (_compilingFunction)
+            if (auto* inScope = lookupFSharpVariable(capName))
+                storage = inScope;
+        bindFSharpVariable(capName, storage, func->capturedMutables.contains(capName));
+    }
 
     // Re-establish function references from captured function refs (HOF support)
     for (auto const& [varName, targetFunc]: func->capturedFunctionRefs)
@@ -7959,9 +8002,19 @@ void IRGenerator::generateFSharpCall(FSharpFunction const* func,
 
     pushFSharpScope();
 
-    // Re-bind captured variables from the closure
+    // Re-bind captured variables from the closure. When inlining inside another function,
+    // that enclosing function has itself (transitively) captured these names, so their live
+    // storage is the enclosing frame's capture slot — not the binding recorded at this
+    // function's definition site (which may live in an outer function's frame and would be
+    // an out-of-bounds load here). Prefer the in-scope storage, mirroring the compiled-call path.
     for (auto const& [capName, capStorage]: func->capturedBindings)
-        bindFSharpVariable(capName, capStorage, func->capturedMutables.contains(capName));
+    {
+        CoreVM::Value* storage = capStorage;
+        if (_compilingFunction)
+            if (auto* inScope = lookupFSharpVariable(capName))
+                storage = inScope;
+        bindFSharpVariable(capName, storage, func->capturedMutables.contains(capName));
+    }
 
     // Re-establish function references from captured function refs (HOF support)
     for (auto const& [varName, targetFunc]: func->capturedFunctionRefs)

--- a/src/endo-language/codegen/IRGenerator.cpp
+++ b/src/endo-language/codegen/IRGenerator.cpp
@@ -6700,6 +6700,23 @@ void IRGenerator::visit(ast::PipelineExpr const& node)
                 reportTypeError("Json has no member '{}'", std::string_view(fieldAccess->fieldName));
                 return;
             }
+            if (modIdent->name == "Path")
+            {
+                static std::unordered_map<std::string_view, std::string_view> const pathPipeMethods = {
+                    { "dirname", "path_dirname" },
+                    { "basename", "path_basename" },
+                    { "normalize", "path_normalize" },
+                    { "isAbsolute", "path_is_absolute" },
+                };
+                if (auto const it = pathPipeMethods.find(fieldAccess->fieldName); it != pathPipeMethods.end())
+                {
+                    if (tryGenerateNativeCall(std::string(it->second), { value }))
+                        return;
+                }
+                reportTypeError("Path has no member '{}' usable in a pipeline",
+                                std::string_view(fieldAccess->fieldName));
+                return;
+            }
         }
         reportTypeError("Pipeline function must be an identifier, lambda, or partial application");
         return;
@@ -7091,6 +7108,49 @@ void IRGenerator::visit(ast::ApplicationExpr const& node)
                         annotateListElementLiteralType(_result, CoreVM::LiteralType::String);
                         return;
                     }
+                }
+            }
+
+            // Path module dispatch (lexical path operations)
+            if (modIdent->name == "Path")
+            {
+                if (method == "join" && argExprs.size() == 2)
+                {
+                    auto* baseArg = codegen(argExprs[0]);
+                    auto* tailArg = codegen(argExprs[1]);
+                    if (baseArg && tailArg)
+                    {
+                        if (tryGenerateNativeCall("path_join", { baseArg, tailArg }))
+                            return;
+                    }
+                }
+                else if ((method == "dirname" || method == "basename" || method == "normalize")
+                         && argExprs.size() == 1)
+                {
+                    auto* pathArg = codegen(argExprs[0]);
+                    if (pathArg)
+                    {
+                        // method is guaranteed to be dirname/basename/normalize by the
+                        // enclosing condition, and each maps to the path_<method> builtin.
+                        auto const vmName = "path_" + method;
+                        if (tryGenerateNativeCall(vmName, { pathArg }))
+                            return;
+                    }
+                }
+                else if (method == "isAbsolute" && argExprs.size() == 1)
+                {
+                    auto* pathArg = codegen(argExprs[0]);
+                    if (pathArg)
+                    {
+                        if (tryGenerateNativeCall("path_is_absolute", { pathArg }))
+                            return;
+                    }
+                }
+                else
+                {
+                    reportTypeError("Path.{} called with wrong number of arguments",
+                                    std::string_view(method));
+                    return;
                 }
             }
 
@@ -10697,10 +10757,27 @@ void IRGenerator::visit(ast::FieldAccessExpr const& node)
     {
         if (modIdent->name == "Path")
         {
-            if (node.fieldName == "temporary_directory")
+            static std::unordered_map<std::string_view, std::string_view> const pathNullaryMembers = {
+                { "temporary_directory", "path_temporary_directory" },
+                { "separator", "path_separator" },
+                { "delimiter", "path_delimiter" },
+            };
+            if (auto const it = pathNullaryMembers.find(node.fieldName); it != pathNullaryMembers.end())
             {
-                tryGenerateNativeCall("path_temporary_directory", {});
+                tryGenerateNativeCall(std::string(it->second), {});
                 return;
+            }
+            static constexpr std::string_view PathMethods[] = {
+                "join", "dirname", "basename", "normalize", "isAbsolute",
+            };
+            for (auto const& m: PathMethods)
+            {
+                if (node.fieldName == m)
+                {
+                    // Path.xxx requires arguments — handled in ApplicationExpr.
+                    reportTypeError("Path.{} requires arguments", std::string_view(node.fieldName));
+                    return;
+                }
             }
             reportTypeError("Path has no member '{}'", std::string_view(node.fieldName));
             return;

--- a/src/endo-language/format/SourceFormatter.cpp
+++ b/src/endo-language/format/SourceFormatter.cpp
@@ -895,7 +895,13 @@ void SourceFormatter::visit(ast::HereString const& node)
 void SourceFormatter::visit(ast::ProgramCall const& node)
 {
     emitLeadingComments(node);
-    emit(node.program);
+    // A quoted program name is carried by programExpr (a quoted LiteralExpr or an
+    // interpolated ConcatExpr), which re-emits its surrounding quotes and so round
+    // trips exactly. Tilde and bare-word programs keep emitting the raw `program`.
+    if (node.quotedProgram && node.programExpr)
+        node.programExpr->accept(*this);
+    else
+        emit(node.program);
 
     for (auto const& param: node.parameters)
     {

--- a/src/endo-language/format/SourceFormatter_test.cpp
+++ b/src/endo-language/format/SourceFormatter_test.cpp
@@ -89,6 +89,19 @@ TEST_CASE("SourceFormatter.simple_echo", "[format]")
     CHECK(result == "echo hello world\n");
 }
 
+TEST_CASE("SourceFormatter.shell_command_quoted_program", "[format]")
+{
+    // A quoted program path round-trips with quotes preserved (would otherwise
+    // split into multiple tokens).
+    CHECK(SourceFormatter::format("& \"X:/Program Files/tool.exe\" --help")
+          == "& \"X:/Program Files/tool.exe\" --help\n");
+}
+
+TEST_CASE("SourceFormatter.shell_command_quoted_program_interpolated", "[format]")
+{
+    CHECK(SourceFormatter::format("& \"$dir/tool.exe\" --help") == "& \"$dir/tool.exe\" --help\n");
+}
+
 TEST_CASE("SourceFormatter.let_binding_simple", "[format]")
 {
     auto const result = SourceFormatter::format("let x = 42");

--- a/src/endo-language/lexer/Lexer.cpp
+++ b/src/endo-language/lexer/Lexer.cpp
@@ -771,7 +771,7 @@ Token Lexer::finalizeNumberOrShellWord()
     // In shell mode, check if the character after the number continues a word
     // (e.g., git SHA "3a4b5c6" or filename "3.txt")
     using namespace std::string_view_literals;
-    auto constexpr ReservedSymbols = U"|<>()!$'\"\t\r\n ;`"sv;
+    auto constexpr ReservedSymbols = ShellReservedSymbols;
     if (!eof() && ReservedSymbols.find(_currentChar) == std::u32string_view::npos)
     {
         while (!eof() && ReservedSymbols.find(_currentChar) == std::u32string_view::npos)
@@ -822,7 +822,7 @@ Token Lexer::consumeIdentifier(Token token)
     // Note: ~ is NOT reserved to allow mid-word tilde (e.g., HEAD~2 in git).
     //       Tilde expansion (~, ~/foo, ~user) still works because nextToken()'s
     //       `case '~': return consumeTilde()` fires when ~ starts a new token.
-    auto constexpr ReservedSymbols = U"|<>()!$'\"\t\r\n ;`"sv;
+    auto constexpr ReservedSymbols = ShellReservedSymbols;
     // In arithmetic context, operators are also reserved to allow expressions like 1+2
     auto constexpr ArithReservedSymbols = U"|<>()!$'\"\t\r\n ;`~+-*/%^&,?:"sv;
     // In F# expression context, brackets and operators are reserved

--- a/src/endo-language/lexer/Lexer.hpp
+++ b/src/endo-language/lexer/Lexer.hpp
@@ -14,6 +14,14 @@
 namespace endo
 {
 
+/// Characters that terminate a bare (unquoted) word in shell tokenization mode.
+///
+/// A word containing any of these code points cannot be written unquoted without
+/// splitting into multiple tokens, so it must be quoted to survive as a single
+/// shell token. This is the single source of truth shared by the lexer (word
+/// tokenization) and the shell-quoting helpers (see needsShellQuoting).
+inline constexpr std::u32string_view ShellReservedSymbols = U"|<>()!$'\"\t\r\n ;`";
+
 enum class Token // NOLINT(performance-enum-size)
 {
     Invalid,

--- a/src/endo-language/parser/Parser.cpp
+++ b/src/endo-language/parser/Parser.cpp
@@ -1397,6 +1397,7 @@ std::unique_ptr<ast::ProgramCall> Parser::parseCall(bool piped)
 
     std::unique_ptr<ast::Expr> progExpr;
     std::string program;
+    bool quotedProgram = false;
     if (_lexer.currentToken() == Token::Tilde)
     {
         // Tilde-prefixed program name: ~/bin/foo, ~user/bin/bar
@@ -1405,6 +1406,19 @@ std::unique_ptr<ast::ProgramCall> Parser::parseCall(bool piped)
         if (!program.starts_with('~'))
             program = "~" + program;
         progExpr = parseTildeExpansion();
+    }
+    else if (_lexer.currentToken() == Token::DblQuoteStart)
+    {
+        // Double-quoted program name: & "X:/path with spaces/tool.exe" args…
+        // Parse it with the same machinery as a quoted argument so spaces,
+        // reserved characters (e.g. '!'), and $-interpolation are handled. The
+        // resulting expression drives execution (programExpr); `program` keeps a
+        // best-effort display string for diagnostics (empty for interpolated
+        // paths, whose value is only known at runtime).
+        quotedProgram = true;
+        progExpr = parseCompoundParameter();
+        if (auto const* literal = dynamic_cast<ast::LiteralExpr const*>(progExpr.get()))
+            program = literal->value;
     }
     else
     {
@@ -1611,6 +1625,7 @@ std::unique_ptr<ast::ProgramCall> Parser::parseCall(bool piped)
                                                      std::move(hereDocuments),
                                                      std::move(hereStrings));
     result->programExpr = std::move(progExpr);
+    result->quotedProgram = quotedProgram;
     result->programLocation = programLocation;
     return result;
 }

--- a/src/endo-language/parser/Parser_test.cpp
+++ b/src/endo-language/parser/Parser_test.cpp
@@ -1326,6 +1326,34 @@ TEST_CASE("Parser.FSharp.shell_command_with_shell_pipe")
           == "let lines = & cat file.txt | grep pattern");
 }
 
+TEST_CASE("Parser.FSharp.shell_command_quoted_program")
+{
+    // A double-quoted program path (with spaces) is accepted in command position
+    // and round-trips with its quotes preserved.
+    CHECK(parseAndPrintAST("let r = & \"X:/Program Files/tool.exe\" --help")
+          == "let r = & \"X:/Program Files/tool.exe\" --help");
+}
+
+TEST_CASE("Parser.FSharp.shell_command_quoted_program_bang")
+{
+    // The '!' inside quotes is a literal, not the word-terminating Not operator.
+    CHECK(parseAndPrintAST("let r = & \"X:/Workspace/!Programme/tool.exe\" --help")
+          == "let r = & \"X:/Workspace/!Programme/tool.exe\" --help");
+}
+
+TEST_CASE("Parser.FSharp.shell_command_quoted_program_unc")
+{
+    // A quoted UNC path is not mistaken for a '//' C-style comment.
+    CHECK(parseAndPrintAST("let r = & \"//server/share/tool.exe\" --help")
+          == "let r = & \"//server/share/tool.exe\" --help");
+}
+
+TEST_CASE("Parser.FSharp.shell_command_quoted_program_interpolated")
+{
+    // $-interpolation is supported in a quoted program name, like in arguments.
+    CHECK(parseAndPrintAST("let r = & \"$dir/tool.exe\" --help") == "let r = & \"$dir/tool.exe\" --help");
+}
+
 // ============================================================================
 // Option/Result Expression Tests
 // ============================================================================

--- a/src/endo-language/sema/FreeVariableCollector.cpp
+++ b/src/endo-language/sema/FreeVariableCollector.cpp
@@ -11,7 +11,8 @@ namespace endo
 std::unordered_set<std::string> collectFreeVariableNames(ast::Expr const* body,
                                                          std::vector<std::string> const& boundNames,
                                                          ScopeQuery const& isInScope,
-                                                         FunctionQuery const& isKnownFunction)
+                                                         FunctionQuery const& isKnownFunction,
+                                                         std::unordered_set<std::string>* referencedFunctions)
 {
     std::unordered_set<std::string> freeVars;
 
@@ -28,7 +29,13 @@ std::unordered_set<std::string> collectFreeVariableNames(ast::Expr const* body,
                     return;
                 // Check if it's a registered function name
                 if (isKnownFunction(ident->name))
+                {
+                    // Record the reference so callers can pull in this function's own captures
+                    // transitively (needed to forward them at the call site).
+                    if (referencedFunctions)
+                        referencedFunctions->insert(ident->name);
                     return;
+                }
                 // Check if it's accessible in the current variable scope
                 if (isInScope(ident->name))
                     freeVars.insert(ident->name);
@@ -241,6 +248,126 @@ std::unordered_set<std::string> collectFreeVariableNames(ast::Expr const* body,
                 auto innerBound = bound;
                 innerBound.emplace_back(ast::PlaceholderParamName);
                 walk(placeholder->body.get(), innerBound);
+                return;
+            }
+
+            // Interpolated / concatenated strings: `$"...{x}..."` and adjacent-string
+            // concatenation. A variable referenced only inside one of these parts is still
+            // a free variable of an enclosing closure; failing to detect it here means the
+            // closure never captures it, and the body then loads a slot from a different
+            // function's frame at runtime (an out-of-bounds LOAD).
+            if (auto const* fstr = dynamic_cast<ast::FStringExpr const*>(expr))
+            {
+                for (auto const& part: fstr->parts)
+                    walk(part.get(), bound);
+                return;
+            }
+
+            if (auto const* concat = dynamic_cast<ast::ConcatExpr const*>(expr))
+            {
+                for (auto const& part: concat->parts)
+                    walk(part.get(), bound);
+                return;
+            }
+
+            if (auto const* cons = dynamic_cast<ast::ConsExpr const*>(expr))
+            {
+                walk(cons->head.get(), bound);
+                walk(cons->tail.get(), bound);
+                return;
+            }
+
+            if (auto const* concatList = dynamic_cast<ast::ConcatListExpr const*>(expr))
+            {
+                walk(concatList->left.get(), bound);
+                walk(concatList->right.get(), bound);
+                return;
+            }
+
+            if (auto const* unionCtor = dynamic_cast<ast::UnionConstructorExpr const*>(expr))
+            {
+                for (auto const& arg: unionCtor->arguments)
+                    walk(arg.get(), bound);
+                return;
+            }
+
+            if (auto const* record = dynamic_cast<ast::RecordExpr const*>(expr))
+            {
+                for (auto const& field: record->fields)
+                    walk(field.value.get(), bound);
+                return;
+            }
+
+            if (auto const* recordUpdate = dynamic_cast<ast::RecordUpdateExpr const*>(expr))
+            {
+                walk(recordUpdate->base.get(), bound);
+                for (auto const& field: recordUpdate->updates)
+                    walk(field.value.get(), bound);
+                return;
+            }
+
+            if (auto const* fieldAccess = dynamic_cast<ast::FieldAccessExpr const*>(expr))
+            {
+                walk(fieldAccess->object.get(), bound);
+                return;
+            }
+
+            if (auto const* optChain = dynamic_cast<ast::OptionalChainExpr const*>(expr))
+            {
+                walk(optChain->object.get(), bound);
+                return;
+            }
+
+            if (auto const* tryFinally = dynamic_cast<ast::TryFinallyExpr const*>(expr))
+            {
+                walk(tryFinally->body.get(), bound);
+                walk(tryFinally->finallyExpr.get(), bound);
+                return;
+            }
+
+            if (auto const* exec = dynamic_cast<ast::ExecPipelineExpr const*>(expr))
+            {
+                for (auto const& cmd: exec->commands)
+                {
+                    walk(cmd.program.get(), bound);
+                    for (auto const& arg: cmd.arguments)
+                        walk(arg.get(), bound);
+                }
+                return;
+            }
+
+            if (auto const* splat = dynamic_cast<ast::SplatExpr const*>(expr))
+            {
+                // `...name` splats a variable into shell arguments; the name itself is a
+                // free variable reference when not locally bound.
+                if (std::ranges::find(bound, splat->name) == bound.end() && isInScope(splat->name))
+                    freeVars.insert(splat->name);
+                return;
+            }
+
+            if (auto const* letIn = dynamic_cast<ast::LetInExpr const*>(expr))
+            {
+                // `let [rec] name [params] = value in body`. The binding name is in scope for
+                // the value only when recursive; function parameters are in scope for the
+                // value; the binding (or destructured names) is always in scope for the body.
+                auto valueBound = bound;
+                if (letIn->isRecursive())
+                    valueBound.push_back(letIn->name);
+                auto const paramNames = ast::extractParameterNames(letIn->parameters);
+                valueBound.insert(valueBound.end(), paramNames.begin(), paramNames.end());
+                walk(letIn->value.get(), valueBound);
+
+                auto bodyBound = bound;
+                if (letIn->isDestructuring())
+                {
+                    auto bindings = pattern::collectBindings(*letIn->destructurePattern);
+                    bodyBound.insert(bodyBound.end(), bindings.begin(), bindings.end());
+                }
+                else
+                {
+                    bodyBound.push_back(letIn->name);
+                }
+                walk(letIn->body.get(), bodyBound);
                 return;
             }
 

--- a/src/endo-language/sema/FreeVariableCollector.hpp
+++ b/src/endo-language/sema/FreeVariableCollector.hpp
@@ -27,11 +27,15 @@ using FunctionQuery = std::function<bool(std::string const&)>;
 /// @param boundNames   Names already bound (e.g., function parameters).
 /// @param isInScope    Returns true if a name is accessible in the current variable scope.
 /// @param isKnownFunction Returns true if a name is a registered function definition.
+/// @param referencedFunctions  When non-null, receives the names of every referenced known
+///        function. Callers use this to compute transitive captures: a function that calls a
+///        closure must itself capture that closure's free variables in order to forward them.
 /// @return Set of free variable names found in @p body.
 [[nodiscard]] std::unordered_set<std::string> collectFreeVariableNames(
     ast::Expr const* body,
     std::vector<std::string> const& boundNames,
     ScopeQuery const& isInScope,
-    FunctionQuery const& isKnownFunction);
+    FunctionQuery const& isKnownFunction,
+    std::unordered_set<std::string>* referencedFunctions = nullptr);
 
 } // namespace endo

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -135,6 +135,8 @@ add_library(endo-shell STATIC
     util/GlobMatcher.cpp
     util/Suggestions.hpp
     util/Suggestions.cpp
+    util/ShellQuoting.hpp
+    util/ShellQuoting.cpp
 
     # Directory Configuration
     DirectoryConfig.hpp
@@ -310,6 +312,7 @@ if(ENDO_TESTING)
         output/OutputParser_test.cpp
         util/CommandResolver_test.cpp
         util/Suggestions_test.cpp
+        util/ShellQuoting_test.cpp
         ui/RichConsoleReport_test.cpp
         ui/SyntaxHighlighter_test.cpp
     )

--- a/src/shell/builtins/CommandBuilder.cpp
+++ b/src/shell/builtins/CommandBuilder.cpp
@@ -491,6 +491,13 @@ std::expected<std::filesystem::path, ShellError> Shell::resolveProgram(std::stri
 #endif
     )
     {
+#if defined(_WIN32)
+        // Normalize separators to the native form so forward-slash drive-letter
+        // and UNC paths (e.g. "X:/dir/tool.exe", "//server/share/tool.exe") that a
+        // user may quote resolve reliably via GetFileAttributesW and, once
+        // resolved, spawn via CreateProcessW.
+        programPath.make_preferred();
+#endif
         // Native programs must be executable. Endo scripts are run in-process
         // (see ProcessExecution.cpp) and therefore carry no execute bit, so accept
         // an existing .endo regular file or symlink even when it is not executable.

--- a/src/shell/completion/FileCompleter.cpp
+++ b/src/shell/completion/FileCompleter.cpp
@@ -201,45 +201,6 @@ std::filesystem::path FileCompleter::expandTilde(std::string_view path) const
     return std::filesystem::path(result);
 }
 
-std::string FileCompleter::escapeForShell(std::string_view path)
-{
-    std::string result;
-    result.reserve(path.size());
-
-    for (char ch: path)
-    {
-        switch (ch)
-        {
-            case ' ':
-            case '\\':
-            case '\'':
-            case '"':
-            case '`':
-            case '$':
-            case '!':
-            case '&':
-            case '|':
-            case ';':
-            case '(':
-            case ')':
-            case '<':
-            case '>':
-            case '*':
-            case '?':
-            case '[':
-            case ']':
-            case '#':
-            case '~':
-                result += '\\';
-                result += ch;
-                break;
-            default: result += ch; break;
-        }
-    }
-
-    return result;
-}
-
 bool FileCompleter::isHidden(std::string_view name)
 {
     return !name.empty() && name[0] == '.';

--- a/src/shell/completion/FileCompleter.hpp
+++ b/src/shell/completion/FileCompleter.hpp
@@ -26,9 +26,6 @@ class FileCompleter: public CompletionProvider
 
     [[nodiscard]] int priority() const override { return 50; }
 
-    /// @brief Escapes special characters for shell.
-    [[nodiscard]] static std::string escapeForShell(std::string_view path);
-
   private:
     EnvironmentProvider const& _env;
 

--- a/src/shell/ui/PromptComponent.cpp
+++ b/src/shell/ui/PromptComponent.cpp
@@ -7,6 +7,7 @@
 #include <shell/ui/SourceOffsetUtils.hpp>
 #include <shell/ui/SyntaxHighlighter.hpp>
 #include <shell/util/CommandResolver.hpp>
+#include <shell/util/ShellQuoting.hpp>
 
 #include <endo-language/ide/HoverProvider.hpp>
 
@@ -995,7 +996,7 @@ PromptComponent::Action PromptComponent::processInput(tui::InputEvent const& eve
         {
             case tui::FuzzyPickerAction::Accepted:
                 if (auto const* selected = _fuzzyFileFinder.selectedItem())
-                    insertCompletion(FileCompleter::escapeForShell(*selected));
+                    insertCompletion(*selected);
                 _fuzzyFileFinder.hide();
                 return Action::Changed;
             case tui::FuzzyPickerAction::Dismissed: return Action::Changed;
@@ -1571,12 +1572,18 @@ void PromptComponent::insertCompletion(std::string_view text)
 
     // Calculate how much text to replace (the prefix being completed)
     auto const prefixLen = ctx.prefix.size();
+    auto const prefixStart = cursor - prefixLen;
+
+    // Auto-quote so the inserted value stays a single shell token. A directory
+    // candidate (trailing '/') is left with its quote open so the next TAB
+    // continues completing inside the same quote; a final candidate closes it.
+    auto const insertion = quoteCompletionValue(text, prefixStart > 0 ? inputText[prefixStart - 1] : '\0');
 
     // Build new buffer: text before prefix + completion + text after cursor
     std::string newBuffer;
-    newBuffer.reserve(inputText.size() - prefixLen + text.size());
-    newBuffer.append(inputText.substr(0, cursor - prefixLen));
-    newBuffer.append(text);
+    newBuffer.reserve(inputText.size() - prefixLen + insertion.size());
+    newBuffer.append(inputText.substr(0, prefixStart));
+    newBuffer.append(insertion);
     newBuffer.append(inputText.substr(cursor));
 
     // Update the input field

--- a/src/shell/ui/PromptComponent_test.cpp
+++ b/src/shell/ui/PromptComponent_test.cpp
@@ -138,6 +138,34 @@ TEST_CASE("PromptComponent.tab_inserts_common_prefix_before_popup", "[prompt]")
     fs::remove_all(base);
 }
 
+TEST_CASE("PromptComponent.tab_quotes_path_with_space", "[prompt]")
+{
+    // Completing a path whose value contains a space must insert it wrapped in a
+    // double quote so it stays a single argument. A directory candidate leaves the
+    // quote open so completion can continue inside it.
+    namespace fs = std::filesystem;
+    auto const base = fs::temp_directory_path() / "endo_prompt_quote_space";
+    fs::remove_all(base);
+    fs::create_directories(base / "space dir");
+
+    endo::InMemoryHistory history;
+    endo::TestEnvironment env;
+    endo::FSharpPersistentState fsharpState;
+    endo::Completer completer(env, history, fsharpState);
+
+    auto const typed = "cd " + endo::platform::normalizePath((base / "space").string());
+    auto const expected = "cd \"" + endo::platform::canonicalCasePath(base) + "/space dir/";
+
+    auto comp = PromptComponent();
+    comp.setCompleter(&completer);
+    comp.inputField().setText(typed);
+
+    (void) comp.processInput(tabEvent());
+    CHECK(comp.text() == expected);
+
+    fs::remove_all(base);
+}
+
 TEST_CASE("PromptComponent.ctrl_d_after_timeout_shows_hint_again", "[prompt]")
 {
     auto comp = PromptComponent();

--- a/src/shell/util/ShellQuoting.cpp
+++ b/src/shell/util/ShellQuoting.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "ShellQuoting.hpp"
+
+#include <endo-language/lexer/Lexer.hpp>
+
+#include <algorithm>
+
+namespace endo
+{
+
+namespace
+{
+    /// Returns true if @p ch is a shell reserved word-terminator.
+    /// Every reserved symbol is ASCII, so a byte comparison against the shared
+    /// ShellReservedSymbols set is sufficient.
+    /// @param ch The byte to test.
+    /// @return True if the byte terminates a bare word.
+    [[nodiscard]] bool isReservedByte(char ch)
+    {
+        auto const code = static_cast<char32_t>(static_cast<unsigned char>(ch));
+        return ShellReservedSymbols.find(code) != std::u32string_view::npos;
+    }
+} // namespace
+
+bool needsShellQuoting(std::string_view value)
+{
+    if (value.empty())
+        return true;
+
+    // A leading comment marker would swallow the token (or the rest of the line).
+    if (value.starts_with("//") || value.starts_with("#"))
+        return true;
+
+    return std::ranges::any_of(value, isReservedByte);
+}
+
+std::string escapeDoubleQuoteContext(std::string_view value)
+{
+    std::string result;
+    result.reserve(value.size());
+    for (char const ch: value)
+    {
+        if (ch == '\\' || ch == '"' || ch == '$' || ch == '`')
+            result += '\\';
+        result += ch;
+    }
+    return result;
+}
+
+std::string shellQuoteDouble(std::string_view value)
+{
+    std::string result;
+    result.reserve(value.size() + 2);
+    result += '"';
+    result += escapeDoubleQuoteContext(value);
+    result += '"';
+    return result;
+}
+
+std::string quoteCompletionValue(std::string_view text, char precedingChar)
+{
+    // A directory candidate has more to complete, so keep the quote open.
+    bool const isDirectory = text.ends_with('/');
+    auto closeIfFinal = [&](std::string value, char quote) {
+        if (!isDirectory)
+            value += quote;
+        return value;
+    };
+
+    // Already inside an open double quote (e.g. `& "X:/Work<TAB>`): escape for the
+    // double-quote context instead of opening a new quote.
+    if (precedingChar == '"')
+        return closeIfFinal(escapeDoubleQuoteContext(text), '"');
+
+    // Already inside an open single quote: single-quoted content is fully literal.
+    // (A value containing a single quote cannot be represented here; left to the user.)
+    if (precedingChar == '\'')
+        return closeIfFinal(std::string(text), '\'');
+
+    // Bare word: wrap in double quotes only when it would otherwise not read as a
+    // single parameter (spaces, '!', '$', a leading comment marker, etc.).
+    if (needsShellQuoting(text))
+        return closeIfFinal('"' + escapeDoubleQuoteContext(text), '"');
+
+    return std::string(text);
+}
+
+} // namespace endo

--- a/src/shell/util/ShellQuoting.hpp
+++ b/src/shell/util/ShellQuoting.hpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace endo
+{
+
+/// @brief Tests whether a value must be quoted to survive as a single shell token.
+///
+/// A bare (unquoted) word cannot contain characters that the lexer treats as word
+/// terminators (see @ref ShellReservedSymbols: whitespace and `| < > ( ) ! $ ' "
+/// ; ` and backtick) nor begin a comment (`//` C-style or `#` shell-style), or it
+/// would split into several tokens (or be swallowed as a comment). This predicate
+/// reports when quoting is required so the value reads as one parameter.
+///
+/// @param value The candidate word (UTF-8).
+/// @return True if @p value needs quoting to remain a single token; false for a
+///         value that is already a valid bare word.
+[[nodiscard]] bool needsShellQuoting(std::string_view value);
+
+/// @brief Escapes a value for insertion inside an already-open double-quoted string.
+///
+/// Prefixes a backslash before each character the double-quoted-string lexer treats
+/// specially — backslash, double quote, `$`, and backtick — so the escaped text is
+/// consumed verbatim. No surrounding quotes are added.
+///
+/// @param value The string to escape (UTF-8).
+/// @return The escaped representation, without surrounding quotes.
+[[nodiscard]] std::string escapeDoubleQuoteContext(std::string_view value);
+
+/// @brief Wraps a value in double quotes, escaping inner special characters.
+///
+/// Produces `"<escaped value>"` such that the result parses back to exactly
+/// @p value as a single token. Inner backslash, double quote, `$`, and backtick are
+/// escaped via @ref escapeDoubleQuoteContext.
+///
+/// @param value The string to quote (UTF-8).
+/// @return The double-quoted, escaped representation.
+[[nodiscard]] std::string shellQuoteDouble(std::string_view value);
+
+/// @brief Renders a completion value for insertion so it stays a single token.
+///
+/// Given the character immediately preceding the text being replaced, produces the
+/// string to splice into the input buffer:
+/// - inside an open double quote (@p precedingChar == '"'): escape for that context
+///   and close the quote for a final candidate;
+/// - inside an open single quote (@p precedingChar == '\''): insert literally and
+///   close for a final candidate (single-quoted content is not escapable);
+/// - otherwise: wrap in double quotes when @ref needsShellQuoting reports the value
+///   would not survive bare, else insert unchanged.
+///
+/// A @em directory candidate (trailing '/') has more to complete, so its quote is
+/// left open for the next completion; a final candidate closes it.
+///
+/// @param text The raw completion value.
+/// @param precedingChar The byte just before the replaced prefix ('"'/'\'' when
+///        completing inside an open quote; '\0' at the start of input).
+/// @return The text to insert into the buffer.
+[[nodiscard]] std::string quoteCompletionValue(std::string_view text, char precedingChar);
+
+} // namespace endo

--- a/src/shell/util/ShellQuoting_test.cpp
+++ b/src/shell/util/ShellQuoting_test.cpp
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string_view>
+
+#include "ShellQuoting.hpp"
+
+using namespace std::string_view_literals;
+using endo::escapeDoubleQuoteContext;
+using endo::needsShellQuoting;
+using endo::quoteCompletionValue;
+using endo::shellQuoteDouble;
+
+// =================================================================================================
+// needsShellQuoting
+// =================================================================================================
+
+TEST_CASE("ShellQuoting.needsShellQuoting.plain_words")
+{
+    CHECK_FALSE(needsShellQuoting("echo"sv));
+    CHECK_FALSE(needsShellQuoting("tool.exe"sv));
+    CHECK_FALSE(needsShellQuoting("X:/dir/tool.exe"sv)); // drive-letter, forward slashes: bare-word safe
+    CHECK_FALSE(needsShellQuoting("--help"sv));
+    CHECK_FALSE(needsShellQuoting("a:b:c"sv)); // colon is deliberately not reserved
+}
+
+TEST_CASE("ShellQuoting.needsShellQuoting.empty")
+{
+    CHECK(needsShellQuoting(""sv)); // empty must be quoted to be a token at all
+}
+
+TEST_CASE("ShellQuoting.needsShellQuoting.reserved_characters")
+{
+    CHECK(needsShellQuoting("a b"sv));           // whitespace
+    CHECK(needsShellQuoting("X:/!Programme"sv)); // '!' terminates a bare word
+    CHECK(needsShellQuoting("a$b"sv));           // '$' starts interpolation
+    CHECK(needsShellQuoting("a|b"sv));           // pipe
+    CHECK(needsShellQuoting("a;b"sv));           // statement separator
+    CHECK(needsShellQuoting("a(b)"sv));          // parentheses
+    CHECK(needsShellQuoting("a<b"sv));           // redirect
+    CHECK(needsShellQuoting("a>b"sv));           // redirect
+    CHECK(needsShellQuoting("a`b"sv));           // backtick substitution
+    CHECK(needsShellQuoting("a\"b"sv));          // embedded double quote
+    CHECK(needsShellQuoting("a'b"sv));           // embedded single quote
+}
+
+TEST_CASE("ShellQuoting.needsShellQuoting.comment_prefixes")
+{
+    CHECK(needsShellQuoting("//server/share/tool.exe"sv)); // '//' would start a C-style comment
+    CHECK(needsShellQuoting("#file"sv));                   // '#' would start a shell comment
+    CHECK_FALSE(needsShellQuoting("a//b"sv));              // '//' only matters at the start
+}
+
+// =================================================================================================
+// escapeDoubleQuoteContext / shellQuoteDouble
+// =================================================================================================
+
+TEST_CASE("ShellQuoting.escapeDoubleQuoteContext.escapes_specials")
+{
+    CHECK(escapeDoubleQuoteContext("plain"sv) == "plain");
+    CHECK(escapeDoubleQuoteContext("a\"b"sv) == "a\\\"b");
+    CHECK(escapeDoubleQuoteContext("a\\b"sv) == "a\\\\b");
+    CHECK(escapeDoubleQuoteContext("a$b"sv) == "a\\$b");
+    CHECK(escapeDoubleQuoteContext("a`b"sv) == "a\\`b");
+}
+
+TEST_CASE("ShellQuoting.shellQuoteDouble.wraps_and_escapes")
+{
+    CHECK(shellQuoteDouble("X:/Program Files/tool.exe"sv) == "\"X:/Program Files/tool.exe\"");
+    CHECK(shellQuoteDouble("X:/!Programme/tool.exe"sv) == "\"X:/!Programme/tool.exe\"");
+    CHECK(shellQuoteDouble("//server/share/tool.exe"sv) == "\"//server/share/tool.exe\"");
+    CHECK(shellQuoteDouble("a$b"sv) == "\"a\\$b\"");
+    CHECK(shellQuoteDouble("a\"b"sv) == "\"a\\\"b\"");
+}
+
+// =================================================================================================
+// quoteCompletionValue — context-aware insertion
+// =================================================================================================
+
+TEST_CASE("ShellQuoting.quoteCompletionValue.bare_word")
+{
+    // Plain value: inserted unchanged.
+    CHECK(quoteCompletionValue("tool.exe"sv, '\0') == "tool.exe");
+    // Value needing quotes: wrapped and closed (final candidate).
+    CHECK(quoteCompletionValue("X:/Program Files/tool.exe"sv, '\0') == "\"X:/Program Files/tool.exe\"");
+    CHECK(quoteCompletionValue("X:/!Programme/tool.exe"sv, ' ') == "\"X:/!Programme/tool.exe\"");
+}
+
+TEST_CASE("ShellQuoting.quoteCompletionValue.directory_leaves_quote_open")
+{
+    // Directory candidate (trailing '/'): opening quote, no close, so completion
+    // continues inside the same quote on the next Tab.
+    CHECK(quoteCompletionValue("X:/Program Files/"sv, '\0') == "\"X:/Program Files/");
+    // A directory needing no quoting is inserted as-is.
+    CHECK(quoteCompletionValue("X:/dir/"sv, '\0') == "X:/dir/");
+}
+
+TEST_CASE("ShellQuoting.quoteCompletionValue.inside_open_double_quote")
+{
+    // Already inside `"`: escape for the context, do not re-open; close a final candidate.
+    CHECK(quoteCompletionValue("X:/Program Files/tool.exe"sv, '"') == "X:/Program Files/tool.exe\"");
+    // Directory inside `"`: stays open.
+    CHECK(quoteCompletionValue("X:/Program Files/"sv, '"') == "X:/Program Files/");
+    // Inner specials are escaped.
+    CHECK(quoteCompletionValue("a$b.exe"sv, '"') == "a\\$b.exe\"");
+}
+
+TEST_CASE("ShellQuoting.quoteCompletionValue.inside_open_single_quote")
+{
+    // Single-quoted content is literal: no escaping, close a final candidate.
+    CHECK(quoteCompletionValue("X:/Program Files/tool.exe"sv, '\'') == "X:/Program Files/tool.exe'");
+    CHECK(quoteCompletionValue("X:/Program Files/"sv, '\'') == "X:/Program Files/");
+}

--- a/tests/path/path_basename.endo
+++ b/tests/path/path_basename.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Path.basename returns the final path component
+# expect: c.txt
+
+println (Path.basename "a/b/c.txt")

--- a/tests/path/path_delimiter.endo
+++ b/tests/path/path_delimiter.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Path.delimiter is a single-character platform PATH-list separator
+# expect: 1
+
+println (string_length Path.delimiter)

--- a/tests/path/path_dirname.endo
+++ b/tests/path/path_dirname.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Path.dirname returns the parent-directory portion
+# expect: a/b
+
+println (Path.dirname "a/b/c")

--- a/tests/path/path_is_absolute.endo
+++ b/tests/path/path_is_absolute.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Path.isAbsolute is false for a relative path
+# expect: false
+
+println (Path.isAbsolute "relative/path")

--- a/tests/path/path_join_basename.endo
+++ b/tests/path/path_join_basename.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Path.join joins two segments; basename recovers the last component
+# expect: file.txt
+
+println (Path.basename (Path.join "dir" "file.txt"))

--- a/tests/path/path_normalize.endo
+++ b/tests/path/path_normalize.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Path.normalize collapses '..' segments (basename is separator-agnostic)
+# expect: c
+
+println (Path.basename (Path.normalize "a/b/../c"))

--- a/tests/path/path_pipeline.endo
+++ b/tests/path/path_pipeline.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Path.dirname works as a pipeline stage
+# expect: a/b
+
+println ("a/b/c.txt" |> Path.dirname)

--- a/tests/path/path_separator.endo
+++ b/tests/path/path_separator.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Path.separator is a single-character platform directory separator
+# expect: 1
+
+println (string_length Path.separator)

--- a/tests/regression/capture_in_compound_expr.endo
+++ b/tests/regression/capture_in_compound_expr.endo
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Variables referenced only inside compound expressions (here list concatenation
+#   `@`) from within a function must also be captured. Same free-variable-collector gap as
+#   capture_in_fstring, exercised through a non-string node type.
+# expect: 3
+# mode: shell
+
+let prefix = ["a"]
+
+let combine () = prefix @ ["b"; "c"]
+
+println (length (combine ()))

--- a/tests/regression/capture_in_fstring.endo
+++ b/tests/regression/capture_in_fstring.endo
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: A variable referenced only inside an interpolated string, from within a
+#   function, must be detected as a free variable and captured by that function. Regression:
+#   the free-variable collector did not descend into FStringExpr, so the closure never
+#   captured the binding and loaded it from another function's frame slot at runtime
+#   (out-of-bounds LOAD -> crash).
+# expect: inner sees hello
+# mode: shell
+
+let cfg = "hello"
+
+let inner () = println $"inner sees {cfg}"
+
+inner ()

--- a/tests/regression/cross_block_temporary_binary.endo
+++ b/tests/regression/cross_block_temporary_binary.endo
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: A temporary defined before a branch (?|) and used after it must survive.
+#   Regression: the target code generator discarded such cross-block temporaries at a
+#   basic-block boundary, so a chained binary like `a + b + (opt ?| d)` crashed codegen.
+#   Fixed by the reg2mem materialization pass.
+# expect: a-X
+
+let r = "a" + "-" + (head ["X"; "Y"] ?| "z")
+
+println r

--- a/tests/regression/cross_block_temporary_in_map.endo
+++ b/tests/regression/cross_block_temporary_in_map.endo
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Same reg2mem regression, but with the branchy sub-expression as a function
+#   argument inside a mapped lambda (exercises the CallInstr path, not just binary ops).
+# expect: 2
+
+let build n =
+    (string n) + "=" + (string (head ["v"] ?| ""))
+
+let acc = map build ["x"; "y"]
+
+println (length acc)

--- a/tests/regression/transitive_capture_forwarding.endo
+++ b/tests/regression/transitive_capture_forwarding.endo
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: A function that calls a closure must transitively capture that closure's own
+#   captured variables, because calling a closure lowers to passing its captures as leading
+#   arguments. Regression: the caller did not capture them and forwarded them from an outer
+#   function's frame at runtime (out-of-bounds LOAD -> crash). Here `dispatch` calls `emit`,
+#   which captures `banner`, but `dispatch` never references `banner` itself.
+# expect: [banner] a
+# expect: [banner] b
+# mode: shell
+
+let banner = "[banner]"
+
+let emit label = println $"{banner} {label}"
+
+let dispatch which =
+    if which == "a" then emit "a"
+    else emit "b"
+
+dispatch "a"
+dispatch "b"

--- a/tests/shell/quoted_program_path.endo
+++ b/tests/shell/quoted_program_path.endo
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: A double-quoted program path with spaces and '!' parses as a single program token
+# mode: parse-only
+
+& "X:/Workspace/!Programme/CLI-Tools/tool.exe" --help

--- a/tests/shell/quoted_program_path_interpolated.endo
+++ b/tests/shell/quoted_program_path_interpolated.endo
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: A double-quoted program path supports $-interpolation, like a quoted argument
+# mode: parse-only
+
+let dir = "X:/Workspace/!Programme/CLI-Tools"
+
+& "$dir/tool.exe" --help


### PR DESCRIPTION
Extends the Endo standard library with path and JSON-indexing operations, and fixes two compiler correctness bugs in closure conversion and stack lowering that surfaced while writing non-trivial F# scripts. The bugs caused hard crashes (out-of-bounds frame loads), so the fixes are required rather than cosmetic.

## Changes

- **`Json.query` indexed access.** Add `[N]` path segments (e.g. `.items[2].name`) so positional elements of an array can be addressed; previously only `.key` and `[]` iterate-all were supported. Out-of-range or non-array access yields nothing.
- **Path module.** New pure-lexical operations on `std::filesystem::path` (no I/O): `Path.join`, `Path.dirname`, `Path.basename`, `Path.normalize`, `Path.isAbsolute`, plus the `Path.separator` / `Path.delimiter` constants for the host platform. Declared once in the stdlib descriptor table and dispatched alongside the existing `File` module.
- **Fix closure capture of interpolated/compound expressions.** The free-variable collector did not descend into `FStringExpr` and several other compound node types, so a variable referenced only inside them (e.g. `$"{cfg}"`) was never captured and was loaded from another function's frame at run time. It now descends into all such nodes, resolves transitive captures (a function that calls a closure captures that closure's free variables to forward them), and re-binds captures against the enclosing frame when inlining.
- **Fix cross-block SSA temporaries.** A value computed before a branch and used after it was discarded at the basic-block boundary by the stack lowering, producing an out-of-bounds frame load. A required reg2mem pass now materializes such values into allocas for every function, and `~IRProgram` detaches operands before teardown to avoid a use-after-free assertion.

Docs and the language roadmap are updated, with E2E tests under `tests/path` and `tests/regression` plus additional `Json.query` unit cases.