### PR TITLE
Add WebAssembly compilation backend (endo -o script.wasm)

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -44,6 +44,9 @@ jobs:
         # libssl-dev backs the TLS transport in the vendored net library.
         sudo apt-get install -y clang-tidy-${{ env.LLVM_VERSION }} libssl-dev
 
+    - name: Install binaryen (WASM backend headers)
+      run: sudo apt-get install -y binaryen
+
     - name: Setup clang-tidy problem matcher
       run: echo "::add-matcher::.github/clang-tidy-matcher.json"
 
@@ -66,11 +69,21 @@ jobs:
           echo "::error::clang-tidy-diff.py not found"
           exit 1
         fi
+        # The WASM backend is optional: when the runner's binaryen is missing
+        # or too old, its sources are not in the compile database and would be
+        # mis-analyzed against the wrong headers — exclude them (they are
+        # tidied by any build whose binaryen enables the backend).
+        WASM_EXCLUDES=()
+        if ! grep -sq "CoreVM/wasm/WasmCodeGenerator.cpp" build/compile_commands.json; then
+          echo "WASM backend disabled at configure time; skipping src/CoreVM/wasm in clang-tidy"
+          WASM_EXCLUDES=(':!src/CoreVM/wasm/*' ':!src/endo-language/CompileToWasm.hpp')
+        fi
         git diff -U0 origin/${{ github.base_ref }}...HEAD \
             -- 'src/*.cpp' 'src/*.hpp' 'src/*.h' \
             ':!src/crispy/*' ':!src/vtparser/*' ':!src/coro/*' ':!src/net/*' \
             ':!src/shell/platform/Windows*' \
             ':!src/endo-language/wasm_bridge.cpp' \
+            "${WASM_EXCLUDES[@]}" \
           | python3 "$CLANG_TIDY_DIFF" \
               -p1 \
               -path build \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ endif()
 
 
 option(ENDO_ENABLE_AGENT "Build with AI agent support (LLM providers, agent mode, MCP)" ON)
+option(ENDO_ENABLE_WASM "Build the WebAssembly compilation backend (requires binaryen) [default: ON]" ON)
 
 if(NOT DEFINED ENDO_TRACE_VM)
     option(ENDO_TRACE_VM "Enables debug output" OFF)
@@ -146,6 +147,17 @@ include(ClangTidy)
 
 if(NOT EMSCRIPTEN)
     check_static_system_requirements()
+endif()
+
+# WebAssembly compilation backend: requires the system binaryen library.
+# Disabled under Emscripten (no cross-compiled binaryen) and under static
+# linking (binaryen ships as a shared library only).
+set(ENDO_HAS_WASM OFF)
+if(ENDO_ENABLE_WASM AND NOT EMSCRIPTEN AND NOT ENABLE_STATIC_LINKING)
+    find_package(Binaryen)
+    if(Binaryen_FOUND)
+        set(ENDO_HAS_WASM ON)
+    endif()
 endif()
 
 if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
@@ -223,6 +235,7 @@ message(STATUS "endo trace parser   ${ENDO_TRACE_PARSER}")
 message(STATUS "endo trace lexer    ${ENDO_TRACE_LEXER}")
 message(STATUS "Testing             ${ENDO_TESTING}")
 message(STATUS "Static linking      ${ENABLE_STATIC_LINKING}")
+message(STATUS "WASM backend        ${ENDO_HAS_WASM}")
 message(STATUS "Built in crashdump  ${ENDO_BUILTIN_CRARHDUMP}")
 if(NOT EMSCRIPTEN)
     message(STATUS "Address Sanitizer   ${ENABLE_ASAN}")

--- a/ROADMAP-WASM.md
+++ b/ROADMAP-WASM.md
@@ -10,6 +10,36 @@ endo -o hello.wasm hello.endo     # Compile to WebAssembly
 endo -o hello.wat hello.endo      # Compile to WebAssembly Text format (for debugging)
 ```
 
+## Implementation Status
+
+The first iteration of the backend is implemented in `src/CoreVM/wasm/`
+(user docs: `docs/shell/wasm-compilation.md`). Deviations from the original
+plan below:
+
+- **System binaryen via `cmake/FindBinaryen.cmake`** instead of FetchContent
+  (the C API, `binaryen-c.h`); the backend is gated on `ENDO_HAS_WASM` and
+  auto-disabled without binaryen, under Emscripten, and for static builds.
+- Naming follows the Handler→Function rename: the generator consumes
+  `IRFunction`s; the frontend's entry function is `@main`.
+- The `-O0/-Os/-O2` levels collapsed into a single `-O` (binaryen `-O2`).
+- Compiled modules run in the terminal via **wasmtime** (WASI Preview 1);
+  a browser/portable import mode has not been started.
+
+Landed (milestones W1–W3 plus the WASI core of W4): CLI `-o .wasm/.wat` and
+`-O`, uniform-i64 codegen over the relooper, integer/float/boolean/string
+operations with VM semantics, casts, user functions with `return_call` tail
+calls, Option/Result/tuples/lists with pattern matching and VM-identical
+display formatting, the list builtins (length/head/tail/nth/isEmpty/`@`),
+print/println/exit/exit-status via WASI, collected compile-time diagnostics
+for unsupported constructs, Catch2 unit tests, and `# mode: wasm` E2E tests
+in `tests/wasm/` (differential against the VM, skipped without wasmtime).
+
+Not yet implemented (clean compile errors): shell command execution, file
+I/O, regex, closures as first-class values (IndirectCall), lazy sequences,
+env access, `rand`, sort/distinct/sortBy/groupBy natives, most string_*
+natives (split/join/replace/repeat/case-conversion/codepoints), record field
+display, browser import mode, and source maps.
+
 ## Design Goals
 
 1. **Dual-mode support:**
@@ -551,39 +581,40 @@ src/CoreVM/wasm/
 ## Milestones
 
 ### Milestone W1: Basic WASM Generation
-- [ ] Phase 1: CLI and binaryen integration
-- [ ] Phase 2.1-2.2: Arithmetic and comparison operations
-- [ ] Generate valid WASM for simple arithmetic expressions
+- [x] Phase 1: CLI and binaryen integration
+- [x] Phase 2.1-2.2: Arithmetic and comparison operations
+- [x] Generate valid WASM for simple arithmetic expressions
 
-**Target:** `let x = 1 + 2 * 3` compiles to valid WASM
+**Target:** `let x = 1 + 2 * 3` compiles to valid WASM ✓
 
 ### Milestone W2: Control Flow and Functions
-- [ ] Phase 2.3: Control flow structuring
-- [ ] Phase 3.1-3.2: Memory layout and strings
-- [ ] Support if/else, while loops, function definitions
+- [x] Phase 2.3: Control flow structuring (binaryen relooper)
+- [x] Phase 3.1-3.2: Memory layout and strings
+- [x] Support if/else, recursion, function definitions
 
-**Target:** FizzBuzz compiles to WASM
+**Target:** FizzBuzz compiles to WASM ✓ (VM-identical output)
 
 ### Milestone W3: Full Language Support
-- [ ] Phase 3.3: Runtime support functions
-- [ ] String operations, regex (if feasible)
-- [ ] All F# expression features
+- [x] Phase 3.3: Runtime support functions
+- [x] String operations (regex: clean compile error)
+- [x] Core F# expression features (Option/Result/tuples/lists, pattern
+      matching, HOF pipelines; closures and lazy sequences still error)
 
-**Target:** All pure-computation Endo features work
+**Target:** Pure-computation Endo features work (see status section for gaps)
 
 ### Milestone W4: WASI Integration
-- [ ] Phase 4: WASI imports
+- [x] Phase 4: WASI imports (fd_write, proc_exit; exit-status semantics)
 - [ ] Phase 5: Process execution (limited)
-- [ ] Environment variables, file I/O, exit codes
+- [ ] Environment variables, file I/O
 
-**Target:** Simple shell scripts work in wasmtime
+**Target:** Simple shell scripts work in wasmtime (pure-computation scripts do)
 
 ### Milestone W5: Production Ready
-- [ ] Phase 6: Optimizations
-- [ ] Phase 7: Comprehensive testing
-- [ ] Documentation and examples
+- [x] Phase 6: Optimizations (-O via binaryen)
+- [x] Phase 7: Testing (unit tests + differential E2E in tests/wasm/)
+- [x] Documentation (docs/shell/wasm-compilation.md)
 
-**Target:** Production-quality WASM output
+**Target:** Production-quality WASM output for the supported subset ✓
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1531,6 +1531,18 @@ to deliver rich language intelligence outside the interactive shell.
   interactive shell (Phase 2.5 Tooltips, Phase 2.3 Completion) via in-process API calls, avoiding
   the need for duplicate logic between the interactive editor and external editor support
 
+### Phase 5.6: WebAssembly Compilation Backend (first iteration) ✅
+
+**Status:** Core complete — see `ROADMAP-WASM.md` for details and remaining gaps
+
+`endo -o script.wasm script.endo` compiles scripts to self-contained WASI
+command modules that run under wasmtime with VM-identical output and exit
+codes for the supported subset (arithmetic, strings, floats, functions with
+tail calls, Option/Result/tuples/lists, pattern matching, HOF pipelines).
+Built on the system binaryen library; unsupported constructs (shell
+execution, file I/O, regex, closures, lazy) fail with located compile-time
+errors. User docs: `docs/shell/wasm-compilation.md`.
+
 ---
 
 ## Feature Dependency Graph

--- a/cmake/FindBinaryen.cmake
+++ b/cmake/FindBinaryen.cmake
@@ -6,9 +6,12 @@
 # linker search path. This module handles both cases.
 #
 # Defines the imported target `Binaryen::Binaryen` on success, plus:
-#   Binaryen_FOUND        - TRUE if header and library were found
-#   Binaryen_INCLUDE_DIR  - directory containing binaryen-c.h
-#   Binaryen_LIBRARY      - full path to the binaryen library
+#   Binaryen_FOUND         - TRUE if header and library were found
+#   Binaryen_INCLUDE_DIR   - directory containing binaryen-c.h
+#   Binaryen_LIBRARY       - full path to the binaryen library
+#   Binaryen_INSTALL_RPATH - directory to add to the RPATH of installed
+#                            executables, or empty when the dynamic loader
+#                            searches the library's directory by default
 
 find_path(Binaryen_INCLUDE_DIR binaryen-c.h)
 find_library(Binaryen_LIBRARY NAMES binaryen PATH_SUFFIXES binaryen)
@@ -34,6 +37,25 @@ if(Binaryen_FOUND AND NOT TARGET Binaryen::Binaryen)
     set_target_properties(Binaryen::Binaryen PROPERTIES
         IMPORTED_LOCATION "${Binaryen_LIBRARY}"
         INTERFACE_INCLUDE_DIRECTORIES "${Binaryen_INCLUDE_DIR}")
+endif()
+
+# When the library sits in a private directory (see above), the dynamic loader
+# will not find it at runtime: libbinaryen.so carries no versioned SONAME and no
+# entry in /etc/ld.so.conf.d.  Distributions solve this by putting that
+# directory on the RPATH of their own binaries (Fedora's wasm-opt, for example,
+# records RUNPATH=$ORIGIN/../lib64/binaryen), and consumers must do the same.
+#
+# CMake gives the *build tree* such an RPATH automatically, but drops it on
+# install, so only installed executables are affected.  Report the directory
+# that installed consumers need to record, and report nothing when binaryen is
+# in a default loader directory -- there, an RPATH would be dead weight.
+set(Binaryen_INSTALL_RPATH "")
+if(Binaryen_FOUND)
+    get_filename_component(_binaryen_library_dir "${Binaryen_LIBRARY}" DIRECTORY)
+    if(NOT _binaryen_library_dir IN_LIST CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES)
+        set(Binaryen_INSTALL_RPATH "${_binaryen_library_dir}")
+    endif()
+    unset(_binaryen_library_dir)
 endif()
 
 mark_as_advanced(Binaryen_INCLUDE_DIR Binaryen_LIBRARY)

--- a/cmake/FindBinaryen.cmake
+++ b/cmake/FindBinaryen.cmake
@@ -1,0 +1,39 @@
+# Finds the Binaryen library (C API) for WebAssembly code generation.
+#
+# Binaryen ships no pkg-config or CMake package configuration, and some
+# distributions (e.g. Fedora) install the shared library into a private
+# directory such as /usr/lib64/binaryen that is not part of the default
+# linker search path. This module handles both cases.
+#
+# Defines the imported target `Binaryen::Binaryen` on success, plus:
+#   Binaryen_FOUND        - TRUE if header and library were found
+#   Binaryen_INCLUDE_DIR  - directory containing binaryen-c.h
+#   Binaryen_LIBRARY      - full path to the binaryen library
+
+find_path(Binaryen_INCLUDE_DIR binaryen-c.h)
+find_library(Binaryen_LIBRARY NAMES binaryen PATH_SUFFIXES binaryen)
+
+# binaryen-c.h carries no version macro; probe for the newest API entry point
+# the backend needs so that a too-old system binaryen cleanly reports
+# "not found" (disabling the backend) instead of breaking the build.
+if(Binaryen_INCLUDE_DIR AND Binaryen_LIBRARY)
+    include(CheckSymbolExists)
+    set(CMAKE_REQUIRED_INCLUDES "${Binaryen_INCLUDE_DIR}")
+    set(CMAKE_REQUIRED_LIBRARIES "${Binaryen_LIBRARY}")
+    check_symbol_exists(BinaryenFeatureBulkMemoryOpt "binaryen-c.h" Binaryen_HAS_REQUIRED_API)
+    unset(CMAKE_REQUIRED_INCLUDES)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    Binaryen REQUIRED_VARS Binaryen_LIBRARY Binaryen_INCLUDE_DIR Binaryen_HAS_REQUIRED_API)
+
+if(Binaryen_FOUND AND NOT TARGET Binaryen::Binaryen)
+    add_library(Binaryen::Binaryen UNKNOWN IMPORTED)
+    set_target_properties(Binaryen::Binaryen PROPERTIES
+        IMPORTED_LOCATION "${Binaryen_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${Binaryen_INCLUDE_DIR}")
+endif()
+
+mark_as_advanced(Binaryen_INCLUDE_DIR Binaryen_LIBRARY)

--- a/cmake/tests/TestInstalledBinary.cmake
+++ b/cmake/tests/TestInstalledBinary.cmake
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Smoke test for the installed endo executable. Installs the project into a
+# throwaway prefix and runs `endo --version` there, so that the dynamic loader
+# has to resolve every shared library from the executable's own RPATH.
+#
+# This is what catches a dependency living outside the loader's search path
+# (binaryen on Fedora, for instance): the build-tree binary starts fine because
+# CMake gives it an automatic RPATH, while the installed one dies with
+# "error while loading shared libraries" -- a failure no other test sees.
+#
+# Run via:
+#   cmake -DBUILD_DIR=<dir> [-DCONFIG=<cfg>] -P cmake/tests/TestInstalledBinary.cmake
+
+if(NOT BUILD_DIR)
+    message(FATAL_ERROR "installed-binary: BUILD_DIR must be set.")
+endif()
+
+set(_prefix "${BUILD_DIR}/install-smoke-test")
+file(REMOVE_RECURSE "${_prefix}")
+
+set(_install_command "${CMAKE_COMMAND}" --install "${BUILD_DIR}" --prefix "${_prefix}")
+if(CONFIG)
+    list(APPEND _install_command --config "${CONFIG}")
+endif()
+
+execute_process(COMMAND ${_install_command} RESULT_VARIABLE _result OUTPUT_QUIET ERROR_VARIABLE _stderr)
+if(NOT _result EQUAL 0)
+    message(FATAL_ERROR "installed-binary: install into '${_prefix}' failed (${_result}):\n${_stderr}")
+endif()
+
+find_program(_endo endo PATHS "${_prefix}/bin" NO_DEFAULT_PATH REQUIRED)
+
+# Clear the library search-path overrides: a developer's environment may point
+# at the build tree, which would mask exactly the breakage under test. The
+# installed binary must stand on its own, as it does under a login shell.
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E env --unset=LD_LIBRARY_PATH --unset=DYLD_LIBRARY_PATH
+            "${_endo}" --version
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE _stdout
+    ERROR_VARIABLE _stderr
+)
+
+if(NOT _result EQUAL 0)
+    message(FATAL_ERROR
+        "installed-binary: '${_endo} --version' failed (${_result}).\n"
+        "The installed executable cannot resolve its shared libraries; a "
+        "dependency outside the loader's search path is likely missing from "
+        "its INSTALL_RPATH.\n${_stdout}${_stderr}")
+endif()
+
+string(STRIP "${_stdout}" _stdout)
+if(NOT _stdout)
+    message(FATAL_ERROR "installed-binary: '${_endo} --version' printed nothing.")
+endif()
+
+file(REMOVE_RECURSE "${_prefix}")
+message(STATUS "installed-binary: ${_stdout}")

--- a/docs/shell/wasm-compilation.md
+++ b/docs/shell/wasm-compilation.md
@@ -1,0 +1,98 @@
+# WebAssembly Compilation
+
+Endo can compile scripts to WebAssembly instead of executing them:
+
+```bash
+endo -o hello.wasm hello.endo    # compile to a WASI command module
+endo -o hello.wat hello.endo     # compile to WebAssembly text format (for inspection)
+```
+
+The output is a self-contained [WASI](https://wasi.dev/) Preview 1 command
+module: it exports `_start` and `memory`, imports only `fd_write` and
+`proc_exit`, and runs under any WASI runtime:
+
+```bash
+$ echo 'println "hello, world"' > hello.endo
+$ endo -o hello.wasm hello.endo
+$ wasmtime hello.wasm
+hello, world
+```
+
+Exit codes follow shell semantics: an explicit `exit N`, a failing command
+status, or the script's final status all propagate to the WASM process exit
+code, so `wasmtime script.wasm; echo $?` matches `endo script.endo; echo $?`.
+
+## Options
+
+| Option | Effect |
+|--------|--------|
+| `-o, --output FILE` | Compile to `FILE`; the format is derived from the extension (`.wasm`, `.wat`) |
+| `-O` | Run binaryen's optimizer over the generated module (smaller and faster output) |
+| `--wasm-no-tail-call` | Lower tail calls as plain calls for runtimes without the tail-call proposal (deep recursion may overflow the stack) |
+
+## Supported language features
+
+The backend compiles the pure-computation core of the language:
+
+- Integers, floats, booleans and strings, including string interpolation
+- Arithmetic, comparisons, boolean logic (division by zero is a runtime
+  error, as in the interpreter)
+- `if`/`else`, loops and pattern matching (literals, constructors, cons
+  patterns, wildcards, string matches)
+- User-defined functions, including `let rec`; tail calls compile to the
+  WASM tail-call instruction, so deep recursion runs in constant stack space
+- Option, Result, tuples and lists, with the same display formatting as the
+  interpreter (`[1; 2; 3]`, `Some 42`, `("a", 5, true)`)
+- Higher-order pipelines (`map`, `filter`, `fold`, `reverse`, `take`, ...)
+  and the list builtins `length`, `head`, `tail`, `nth`, `isEmpty`, `@`
+- `print`/`println` via WASI `fd_write`; `exit` via `proc_exit`
+
+Unsupported constructs are reported as **compile-time errors** with source
+locations — all of them in one run, not just the first:
+
+```
+$ echo 'ls -l' > script.endo
+$ endo -o script.wasm script.endo
+script.endo:1:1: type error: cannot compile to WebAssembly: builtin 'internal.setup_redirects(I)V' is not supported
+```
+
+Currently unsupported: shell command execution and pipes, file I/O, regular
+expressions, closures as first-class values, lazy sequences, `fetch`,
+environment variables, and most of the string/JSON/path standard library.
+See `ROADMAP-WASM.md` in the repository for the full status.
+
+## Known differences from the interpreter
+
+The compiled module reimplements the runtime inside WebAssembly; a few edge
+cases intentionally differ:
+
+- Runtime errors print `endo: runtime error: <message>` to stderr without
+  source locations, and always exit with code 1.
+- Memory is bump-allocated and never freed. This is fine for scripts, but a
+  long-running hot loop that allocates (string concatenation, list building)
+  grows memory monotonically.
+- `string -> int` conversion parses permissively into 64 bits (the
+  interpreter's `std::stoi` is 32-bit and throwing).
+- Float `**` requires an integral exponent; float remainder may differ in
+  the last bit for extreme magnitudes.
+- `INT64_MIN / -1` yields `INT64_MIN` instead of aborting.
+- Record values print as `<object>` instead of their field listing.
+- Printing a *dynamically typed* integer whose value collides with a valid
+  heap address can misformat (the interpreter tracks allocations exactly;
+  the WASM runtime uses a header heuristic). Statically typed values are
+  unaffected.
+
+## Testing
+
+E2E tests live in `tests/wasm/` and use the `# mode: wasm` directive: each
+test compiles the script and runs it under `wasmtime`, comparing output and
+exit code. They are skipped when `wasmtime` is not installed (set
+`ENDO_WASMTIME` to point at a specific binary).
+
+## Build requirements
+
+The WASM backend requires the [binaryen](https://github.com/WebAssembly/binaryen)
+library at build time (`dnf install binaryen` / `apt install binaryen`).
+Without it, endo builds normally and `-o` reports that the backend is
+unavailable. The backend is also disabled for static builds (binaryen ships
+as a shared library only).

--- a/docs/shell/wasm-compilation.md
+++ b/docs/shell/wasm-compilation.md
@@ -96,3 +96,9 @@ library at build time (`dnf install binaryen` / `apt install binaryen`).
 Without it, endo builds normally and `-o` reports that the backend is
 unavailable. The backend is also disabled for static builds (binaryen ships
 as a shared library only).
+
+Because binaryen is a shared library, it must remain installed at runtime as
+well. Some distributions (Fedora among them) place `libbinaryen.so` in a
+private directory such as `/usr/lib64/binaryen`, which the dynamic loader does
+not search; the build records that directory in the installed executable's
+RPATH so that `endo` starts without any `LD_LIBRARY_PATH` setup.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
     - Builtins: shell/builtins.md
     - Completions: shell/completions.md
     - Structured Output: shell/structured-output.md
+    - WebAssembly Compilation: shell/wasm-compilation.md
   - Debugging:
     - Overview: debugging/index.md
     - Neovim (nvim-dap): debugging/neovim.md

--- a/src/CoreVM/CMakeLists.txt
+++ b/src/CoreVM/CMakeLists.txt
@@ -75,6 +75,8 @@ if(ENDO_HAS_WASM)
         wasm/WasmFunctionLowerer.cpp
         wasm/WasmOpTables.cpp
         wasm/WasmBuiltins.cpp
+        wasm/WasmStringTable.cpp
+        wasm/WasmRuntime.cpp
     )
     target_link_libraries(CoreVM-wasm PUBLIC CoreVM PRIVATE Binaryen::Binaryen)
     target_compile_definitions(CoreVM-wasm INTERFACE ENDO_HAS_WASM=1)

--- a/src/CoreVM/CMakeLists.txt
+++ b/src/CoreVM/CMakeLists.txt
@@ -73,6 +73,8 @@ if(ENDO_HAS_WASM)
     add_library(CoreVM-wasm STATIC
         wasm/WasmCodeGenerator.cpp
         wasm/WasmFunctionLowerer.cpp
+        wasm/WasmOpTables.cpp
+        wasm/WasmBuiltins.cpp
     )
     target_link_libraries(CoreVM-wasm PUBLIC CoreVM PRIVATE Binaryen::Binaryen)
     target_compile_definitions(CoreVM-wasm INTERFACE ENDO_HAS_WASM=1)

--- a/src/CoreVM/CMakeLists.txt
+++ b/src/CoreVM/CMakeLists.txt
@@ -68,6 +68,18 @@ endif()
 enable_sanitizers(CoreVM)
 enable_clang_tidy(CoreVM)
 
+# WebAssembly compilation backend (requires system binaryen; see FindBinaryen.cmake)
+if(ENDO_HAS_WASM)
+    add_library(CoreVM-wasm STATIC
+        wasm/WasmCodeGenerator.cpp
+        wasm/WasmFunctionLowerer.cpp
+    )
+    target_link_libraries(CoreVM-wasm PUBLIC CoreVM PRIVATE Binaryen::Binaryen)
+    target_compile_definitions(CoreVM-wasm INTERFACE ENDO_HAS_WASM=1)
+    enable_sanitizers(CoreVM-wasm)
+    enable_clang_tidy(CoreVM-wasm)
+endif()
+
 # Tests
 if(ENDO_TESTING)
     add_executable(test-corevm
@@ -79,6 +91,10 @@ if(ENDO_TESTING)
         vm/Runner_test.cpp
     )
     target_link_libraries(test-corevm CoreVM crispy::core Catch2::Catch2)
+    if(ENDO_HAS_WASM)
+        target_sources(test-corevm PRIVATE wasm/WasmCodeGenerator_test.cpp)
+        target_link_libraries(test-corevm CoreVM-wasm Binaryen::Binaryen)
+    endif()
     add_test(NAME test-corevm COMMAND test-corevm)
     enable_sanitizers(test-corevm)
     enable_clang_tidy(test-corevm)

--- a/src/CoreVM/TargetCodeGenerator.cpp
+++ b/src/CoreVM/TargetCodeGenerator.cpp
@@ -35,29 +35,8 @@ TargetCodeGenerator::TargetCodeGenerator() = default;
 
 std::unique_ptr<Program> TargetCodeGenerator::generate(IRProgram* programIR)
 {
-    // Register custom product types (records) in the TypeRegistry before code generation
-    for (auto const& customType: programIR->customProductTypes())
-    {
-        auto type = std::make_unique<TypeDescriptor>();
-        type->kind = TypeKind::Product;
-        type->id = customType.assignedId;
-        type->name = customType.name;
-        type->fields = customType.fields;
-        type->slotCount =
-            customType.slotCount > 0 ? customType.slotCount : static_cast<uint16_t>(customType.fields.size());
-        _cp.typeRegistry().registerProductType(std::move(type));
-    }
-
-    // Register custom sum types (discriminated unions) in the TypeRegistry before code generation
-    for (auto const& customType: programIR->customSumTypes())
-    {
-        auto type = std::make_unique<TypeDescriptor>();
-        type->kind = TypeKind::Sum;
-        type->id = customType.assignedId;
-        type->name = customType.name;
-        type->variants = customType.variants;
-        _cp.typeRegistry().registerSumType(std::move(type));
-    }
+    // Register custom product/sum types in the TypeRegistry before code generation
+    registerCustomTypes(*programIR, _cp.typeRegistry());
 
     // generate target code for global scope initialization, if any
     IRFunction* init = programIR->findFunction(GLOBAL_SCOPE_INIT_NAME);

--- a/src/CoreVM/ir/IRProgram.cpp
+++ b/src/CoreVM/ir/IRProgram.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <CoreVM/CoreVM.hpp>
+#include <CoreVM/types/TypeRegistry.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -106,6 +107,31 @@ IRBuiltinFunction* IRProgram::getBuiltinFunction(const NativeCallback& cb)
 
     _builtinFunctions.emplace_back(std::make_unique<IRBuiltinFunction>(cb));
     return _builtinFunctions.back().get();
+}
+
+void registerCustomTypes(IRProgram& program, TypeRegistry& registry)
+{
+    for (auto const& customType: program.customProductTypes())
+    {
+        auto type = std::make_unique<TypeDescriptor>();
+        type->kind = TypeKind::Product;
+        type->id = customType.assignedId;
+        type->name = customType.name;
+        type->fields = customType.fields;
+        type->slotCount =
+            customType.slotCount > 0 ? customType.slotCount : static_cast<uint16_t>(customType.fields.size());
+        registry.registerProductType(std::move(type));
+    }
+
+    for (auto const& customType: program.customSumTypes())
+    {
+        auto type = std::make_unique<TypeDescriptor>();
+        type->kind = TypeKind::Sum;
+        type->id = customType.assignedId;
+        type->name = customType.name;
+        type->variants = customType.variants;
+        registry.registerSumType(std::move(type));
+    }
 }
 
 } // namespace CoreVM

--- a/src/CoreVM/ir/IRProgram.hpp
+++ b/src/CoreVM/ir/IRProgram.hpp
@@ -473,4 +473,11 @@ T* IRProgram::get(std::vector<T>& table, U&& literal)
     return &table.back();
 }
 
+class TypeRegistry;
+
+/// Registers the program's custom product and sum types (records and
+/// discriminated unions) into @p registry, resolving slot counts. Shared by
+/// every backend that needs type layout metadata (bytecode, WASM).
+void registerCustomTypes(IRProgram& program, TypeRegistry& registry);
+
 } // namespace CoreVM

--- a/src/CoreVM/wasm/WasmBuiltins.cpp
+++ b/src/CoreVM/wasm/WasmBuiltins.cpp
@@ -13,6 +13,12 @@ namespace
     /// runtime helpers come into existence.
     constexpr auto WasmBuiltins = std::to_array<WasmBuiltinDescriptor>({
         { .signature = "exit(I)V", .inlineOp = BuiltinInlineOp::ProcExit },
+        { .signature = "setvar.exitstatus(I)V", .inlineOp = BuiltinInlineOp::SetExitStatus },
+        { .signature = "ref_write_barrier(I)V", .inlineOp = BuiltinInlineOp::Ignore },
+        { .signature = "print(S)V", .runtimeHelper = "endo_print" },
+        { .signature = "println(S)V", .runtimeHelper = "endo_println" },
+        { .signature = "object_to_string(I)S", .inlineOp = BuiltinInlineOp::ObjectToString },
+        { .signature = "list_to_string(I)S", .runtimeHelper = "endo_list_to_string" },
     });
 } // namespace
 

--- a/src/CoreVM/wasm/WasmBuiltins.cpp
+++ b/src/CoreVM/wasm/WasmBuiltins.cpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <CoreVM/wasm/WasmBuiltins.hpp>
+
+#include <array>
+
+namespace CoreVM::wasm
+{
+
+namespace
+{
+    /// The builtins compilable to WebAssembly. Everything else is a
+    /// compile-time error. Rows are added milestone by milestone as their
+    /// runtime helpers come into existence.
+    constexpr auto WasmBuiltins = std::to_array<WasmBuiltinDescriptor>({
+        { .signature = "exit(I)V", .inlineOp = BuiltinInlineOp::ProcExit },
+    });
+} // namespace
+
+WasmBuiltinDescriptor const* findWasmBuiltin(std::string_view signature)
+{
+    for (auto const& builtin: WasmBuiltins)
+        if (builtin.signature == signature)
+            return &builtin;
+    return nullptr;
+}
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmBuiltins.cpp
+++ b/src/CoreVM/wasm/WasmBuiltins.cpp
@@ -19,6 +19,13 @@ namespace
         { .signature = "println(S)V", .runtimeHelper = "endo_println" },
         { .signature = "object_to_string(I)S", .inlineOp = BuiltinInlineOp::ObjectToString },
         { .signature = "list_to_string(I)S", .runtimeHelper = "endo_list_to_string" },
+        { .signature = "display_result(I)V", .runtimeHelper = "endo_display_result" },
+        { .signature = "list_length(I)I", .runtimeHelper = "endo_list_length" },
+        { .signature = "list_isEmpty(I)B", .runtimeHelper = "endo_list_is_empty" },
+        { .signature = "list_head(I)I", .runtimeHelper = "endo_list_head" },
+        { .signature = "list_tail(I)I", .runtimeHelper = "endo_list_tail" },
+        { .signature = "list_nth(II)I", .runtimeHelper = "endo_list_nth" },
+        { .signature = "list_concat(II)I", .runtimeHelper = "endo_list_concat" },
     });
 } // namespace
 

--- a/src/CoreVM/wasm/WasmBuiltins.hpp
+++ b/src/CoreVM/wasm/WasmBuiltins.hpp
@@ -16,10 +16,14 @@ namespace CoreVM::wasm
 /// Special-cased lowerings that do not map 1:1 to a runtime helper call.
 enum class BuiltinInlineOp : uint8_t
 {
-    None,          ///< Not inline: call the runtime helper.
-    ProcExit,      ///< Call WASI proc_exit with the (wrapped) i32 argument.
-    SetExitStatus, ///< Store the argument into the exit-status global.
-    Ignore,        ///< Emit nothing (e.g. GC write barriers).
+    None,           ///< Not inline: call the runtime helper.
+    ProcExit,       ///< Call WASI proc_exit with the (wrapped) i32 argument.
+    SetExitStatus,  ///< Store the argument into the exit-status global.
+    Ignore,         ///< Emit nothing (e.g. GC write barriers).
+    ObjectToString, ///< Value-to-string with compile-time type dispatch: statically
+                    ///< Number/Boolean-typed arguments use the integer formatter,
+                    ///< String-typed pass through, and only dynamically typed
+                    ///< values go through the runtime classifier.
 };
 
 /// One row of the builtin mapping table.

--- a/src/CoreVM/wasm/WasmBuiltins.hpp
+++ b/src/CoreVM/wasm/WasmBuiltins.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+/// @file
+/// Data-driven mapping from native builtin signatures (as they appear on
+/// CallInstr, e.g. "println(S)V") to their WASM lowering. A builtin that is
+/// not in this table cannot be compiled to WebAssembly and produces a clean
+/// compile-time diagnostic.
+
+namespace CoreVM::wasm
+{
+
+/// Special-cased lowerings that do not map 1:1 to a runtime helper call.
+enum class BuiltinInlineOp : uint8_t
+{
+    None,          ///< Not inline: call the runtime helper.
+    ProcExit,      ///< Call WASI proc_exit with the (wrapped) i32 argument.
+    SetExitStatus, ///< Store the argument into the exit-status global.
+    Ignore,        ///< Emit nothing (e.g. GC write barriers).
+};
+
+/// One row of the builtin mapping table.
+struct WasmBuiltinDescriptor
+{
+    std::string_view signature;     ///< Builtin signature, e.g. "println(S)V".
+    std::string_view runtimeHelper; ///< Runtime helper implementing it (when inlineOp is None).
+    BuiltinInlineOp inlineOp = BuiltinInlineOp::None;
+};
+
+/// Looks up the WASM lowering for a builtin signature.
+/// @return the descriptor, or nullptr if the builtin is unsupported.
+[[nodiscard]] WasmBuiltinDescriptor const* findWasmBuiltin(std::string_view signature);
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmCodeGenerator.cpp
+++ b/src/CoreVM/wasm/WasmCodeGenerator.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <CoreVM/ir/IRProgram.hpp>
+#include <CoreVM/types/TypeRegistry.hpp>
 #include <CoreVM/wasm/WasmCodeGenerator.hpp>
 #include <CoreVM/wasm/WasmFunctionLowerer.hpp>
 #include <CoreVM/wasm/WasmRuntimeABI.hpp>
@@ -68,6 +69,39 @@ namespace
                                    BinaryenTypeNone());
         BinaryenAddFunction(module, "_start", BinaryenTypeNone(), BinaryenTypeNone(), nullptr, 0, body);
         BinaryenAddFunctionExport(module, "_start", "_start");
+    }
+
+    /// Builds the object typeId -> slot count map from the builtin type
+    /// registry plus the program's custom product/sum types, mirroring
+    /// TargetCodeGenerator's type registration.
+    std::unordered_map<int64_t, int64_t> collectSlotCounts(IRProgram& program)
+    {
+        auto registry = TypeRegistry {};
+        for (auto const& customType: program.customProductTypes())
+        {
+            auto type = std::make_unique<TypeDescriptor>();
+            type->kind = TypeKind::Product;
+            type->id = customType.assignedId;
+            type->name = customType.name;
+            type->fields = customType.fields;
+            type->slotCount = customType.slotCount > 0 ? customType.slotCount
+                                                       : static_cast<uint16_t>(customType.fields.size());
+            registry.registerProductType(std::move(type));
+        }
+        for (auto const& customType: program.customSumTypes())
+        {
+            auto type = std::make_unique<TypeDescriptor>();
+            type->kind = TypeKind::Sum;
+            type->id = customType.assignedId;
+            type->name = customType.name;
+            type->variants = customType.variants;
+            registry.registerSumType(std::move(type));
+        }
+
+        auto slotCounts = std::unordered_map<int64_t, int64_t> {};
+        for (auto const& type: registry.allTypes())
+            slotCounts[type->id] = type->slotCount;
+        return slotCounts;
     }
 
     /// Finalizes the linear memory: one active data segment holding the
@@ -139,11 +173,12 @@ std::optional<WasmOutput> WasmCodeGenerator::generate(IRProgram* program, diagno
 
     auto strings = WasmStringTable {};
     auto usedHelpers = std::set<RuntimeHelperDef const*> {};
+    auto const slotCounts = collectSlotCounts(*program);
     for (IRFunction* function: program->functions())
     {
         if (function->empty())
             continue;
-        WasmFunctionLowerer lowerer(module, _options, report, usedHelpers, strings);
+        WasmFunctionLowerer lowerer(module, _options, report, usedHelpers, strings, slotCounts);
         lowerer.lower(function);
     }
 

--- a/src/CoreVM/wasm/WasmCodeGenerator.cpp
+++ b/src/CoreVM/wasm/WasmCodeGenerator.cpp
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <CoreVM/ir/IRProgram.hpp>
+#include <CoreVM/wasm/WasmCodeGenerator.hpp>
+#include <CoreVM/wasm/WasmFunctionLowerer.hpp>
+#include <CoreVM/wasm/WasmRuntimeABI.hpp>
+
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include <binaryen-c.h>
+
+namespace CoreVM::wasm
+{
+
+namespace
+{
+    /// RAII ownership of a binaryen module.
+    struct ModuleGuard
+    {
+        BinaryenModuleRef module;
+
+        ModuleGuard(): module { BinaryenModuleCreate() } {}
+
+        ModuleGuard(ModuleGuard const&) = delete;
+        ModuleGuard& operator=(ModuleGuard const&) = delete;
+        ModuleGuard(ModuleGuard&&) = delete;
+        ModuleGuard& operator=(ModuleGuard&&) = delete;
+
+        ~ModuleGuard() { BinaryenModuleDispose(module); }
+    };
+
+    /// Synthesizes the WASI command entry point: `_start` runs global
+    /// initialization (if present) and then the program's main function.
+    void synthesizeStart(BinaryenModuleRef module, IRProgram& program)
+    {
+        auto statements = std::vector<BinaryenExpressionRef> {};
+        for (auto const* name: { "@__global_init__", "@main" })
+        {
+            auto* function = program.findFunction(name);
+            if (function == nullptr || function->empty())
+                continue;
+            auto* call = BinaryenCall(
+                module, WasmFunctionLowerer::mangledName(name).c_str(), nullptr, 0, BinaryenTypeInt64());
+            statements.push_back(BinaryenDrop(module, call));
+        }
+        auto* body = BinaryenBlock(module,
+                                   nullptr,
+                                   statements.data(),
+                                   static_cast<BinaryenIndex>(statements.size()),
+                                   BinaryenTypeNone());
+        BinaryenAddFunction(module, "_start", BinaryenTypeNone(), BinaryenTypeNone(), nullptr, 0, body);
+        BinaryenAddFunctionExport(module, "_start", "_start");
+    }
+} // namespace
+
+WasmCodeGenerator::WasmCodeGenerator(WasmRuntimeProvider& runtimeProvider, WasmOptions options):
+    _runtimeProvider { runtimeProvider }, _options { options }
+{
+}
+
+std::optional<WasmOutput> WasmCodeGenerator::generate(IRProgram* program, diagnostics::Report& report)
+{
+    auto guard = ModuleGuard {};
+    auto* module = guard.module;
+
+    auto features = BinaryenFeatureBulkMemory() | BinaryenFeatureNontrappingFPToInt();
+    if (_options.tailCalls)
+        features |= BinaryenFeatureTailCall();
+    BinaryenModuleSetFeatures(module, features);
+
+    // One linear memory, exported as "memory" (required by WASI).
+    // Data segments for string constants are added in a later milestone.
+    BinaryenSetMemory(module,
+                      /*initial=*/1,
+                      /*maximum=*/65536,
+                      std::string(layout::MemoryExportName).c_str(),
+                      /*segmentNames=*/nullptr,
+                      /*segmentDatas=*/nullptr,
+                      /*segmentPassives=*/nullptr,
+                      /*segmentOffsets=*/nullptr,
+                      /*segmentSizes=*/nullptr,
+                      /*numSegments=*/0,
+                      /*shared=*/false,
+                      /*memory64=*/false,
+                      /*name=*/"0");
+
+    // WASI Preview 1 imports used directly by generated code.
+    BinaryenAddFunctionImport(
+        module, "proc_exit", "wasi_snapshot_preview1", "proc_exit", BinaryenTypeInt32(), BinaryenTypeNone());
+
+    auto usedHelpers = std::set<RuntimeHelperDef const*> {};
+    for (IRFunction* function: program->functions())
+    {
+        if (function->empty())
+            continue;
+        WasmFunctionLowerer lowerer(module, _options, report, usedHelpers);
+        lowerer.lower(function);
+    }
+
+    synthesizeStart(module, *program);
+    _runtimeProvider.provide(module, usedHelpers);
+
+    if (report.containsFailures())
+        return std::nullopt;
+
+    if (!BinaryenModuleValidate(module))
+    {
+        report.typeError(SourceLocation {},
+                         "internal error (WASM backend): generated module failed validation; "
+                         "compile with a .wat output file to inspect the module");
+        return std::nullopt;
+    }
+
+    if (_options.optimize)
+    {
+        BinaryenSetOptimizeLevel(2);
+        BinaryenSetShrinkLevel(0);
+        BinaryenModuleOptimize(module);
+    }
+
+    // Binaryen allocates the serialization buffers with malloc() and hands
+    // ownership to the caller.
+    using MallocGuard = std::unique_ptr<void, decltype(&std::free)>;
+
+    auto output = WasmOutput {};
+    auto writeResult = BinaryenModuleAllocateAndWrite(module, nullptr);
+    auto const binaryGuard = MallocGuard { writeResult.binary, &std::free };
+    auto const sourceMapGuard = MallocGuard { writeResult.sourceMap, &std::free };
+    auto const* bytes = static_cast<uint8_t const*>(writeResult.binary);
+    output.binary.assign(bytes, bytes + writeResult.binaryBytes);
+
+    if (_options.emitWat)
+    {
+        auto const watGuard = MallocGuard { BinaryenModuleAllocateAndWriteText(module), &std::free };
+        output.wat = static_cast<char const*>(watGuard.get());
+    }
+
+    return output;
+}
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmCodeGenerator.cpp
+++ b/src/CoreVM/wasm/WasmCodeGenerator.cpp
@@ -35,8 +35,11 @@ namespace
 
     /// Synthesizes the WASI command entry point: `_start` runs global
     /// initialization (if present), then the program's main function, and
-    /// finally reports a non-zero exit status via proc_exit.
-    void synthesizeStart(BinaryenModuleRef module, IRProgram& program)
+    /// exits through the endo_exit runtime helper (the single home of the
+    /// shell exit-status policy; falling off @main equals `ret 0`).
+    void synthesizeStart(BinaryenModuleRef module,
+                         IRProgram& program,
+                         std::set<RuntimeHelperDef const*>& usedHelpers)
     {
         auto statements = std::vector<BinaryenExpressionRef> {};
         for (auto const* name: { "@__global_init__", "@main" })
@@ -49,18 +52,14 @@ namespace
             statements.push_back(BinaryenDrop(module, call));
         }
 
-        // if (exit_status != 0) proc_exit(exit_status)
-        auto const exitStatusName = std::string(layout::ExitStatusGlobal);
-        auto exitArgs = std::array { BinaryenGlobalGet(module, exitStatusName.c_str(), BinaryenTypeInt32()) };
-        statements.push_back(
-            BinaryenIf(module,
-                       BinaryenGlobalGet(module, exitStatusName.c_str(), BinaryenTypeInt32()),
-                       BinaryenCall(module,
-                                    "proc_exit",
-                                    exitArgs.data(),
-                                    static_cast<BinaryenIndex>(exitArgs.size()),
-                                    BinaryenTypeNone()),
-                       nullptr));
+        auto const* exitHelper = findRuntimeHelper("endo_exit");
+        usedHelpers.insert(exitHelper);
+        auto exitArgs = std::array { BinaryenConst(module, BinaryenLiteralInt64(0)) };
+        statements.push_back(BinaryenCall(module,
+                                          exitHelper->name,
+                                          exitArgs.data(),
+                                          static_cast<BinaryenIndex>(exitArgs.size()),
+                                          BinaryenTypeNone()));
 
         auto* body = BinaryenBlock(module,
                                    nullptr,
@@ -72,31 +71,11 @@ namespace
     }
 
     /// Builds the object typeId -> slot count map from the builtin type
-    /// registry plus the program's custom product/sum types, mirroring
-    /// TargetCodeGenerator's type registration.
+    /// registry plus the program's custom product/sum types.
     std::unordered_map<int64_t, int64_t> collectSlotCounts(IRProgram& program)
     {
         auto registry = TypeRegistry {};
-        for (auto const& customType: program.customProductTypes())
-        {
-            auto type = std::make_unique<TypeDescriptor>();
-            type->kind = TypeKind::Product;
-            type->id = customType.assignedId;
-            type->name = customType.name;
-            type->fields = customType.fields;
-            type->slotCount = customType.slotCount > 0 ? customType.slotCount
-                                                       : static_cast<uint16_t>(customType.fields.size());
-            registry.registerProductType(std::move(type));
-        }
-        for (auto const& customType: program.customSumTypes())
-        {
-            auto type = std::make_unique<TypeDescriptor>();
-            type->kind = TypeKind::Sum;
-            type->id = customType.assignedId;
-            type->name = customType.name;
-            type->variants = customType.variants;
-            registry.registerSumType(std::move(type));
-        }
+        registerCustomTypes(program, registry);
 
         auto slotCounts = std::unordered_map<int64_t, int64_t> {};
         for (auto const& type: registry.allTypes())
@@ -111,7 +90,7 @@ namespace
     {
         auto const heapBase = (strings.dataEnd() + 15U) & ~15U;
         BinaryenAddGlobal(module,
-                          std::string(layout::HeapPointerGlobal).c_str(),
+                          layout::HeapPointerGlobal,
                           BinaryenTypeInt32(),
                           /*mutable=*/true,
                           BinaryenConst(module, BinaryenLiteralInt32(static_cast<int32_t>(heapBase))));
@@ -130,7 +109,7 @@ namespace
         BinaryenSetMemory(module,
                           initialPages,
                           /*maximum=*/65536,
-                          std::string(layout::MemoryExportName).c_str(),
+                          layout::MemoryExportName,
                           &segmentName,
                           &segmentData,
                           &segmentPassive,
@@ -166,7 +145,7 @@ std::optional<WasmOutput> WasmCodeGenerator::generate(IRProgram* program, diagno
     // Shell exit-status semantics: builtins update this global; a non-zero
     // value at the end of _start becomes the process exit code.
     BinaryenAddGlobal(module,
-                      std::string(layout::ExitStatusGlobal).c_str(),
+                      layout::ExitStatusGlobal,
                       BinaryenTypeInt32(),
                       /*mutable=*/true,
                       BinaryenConst(module, BinaryenLiteralInt32(0)));
@@ -182,7 +161,7 @@ std::optional<WasmOutput> WasmCodeGenerator::generate(IRProgram* program, diagno
         lowerer.lower(function);
     }
 
-    synthesizeStart(module, *program);
+    synthesizeStart(module, *program, usedHelpers);
     _runtimeProvider.provide(module, usedHelpers, strings);
     finalizeMemory(module, strings);
 

--- a/src/CoreVM/wasm/WasmCodeGenerator.cpp
+++ b/src/CoreVM/wasm/WasmCodeGenerator.cpp
@@ -3,9 +3,11 @@
 #include <CoreVM/wasm/WasmCodeGenerator.hpp>
 #include <CoreVM/wasm/WasmFunctionLowerer.hpp>
 #include <CoreVM/wasm/WasmRuntimeABI.hpp>
+#include <CoreVM/wasm/WasmStringTable.hpp>
 
 #include <cstdlib>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <binaryen-c.h>
@@ -31,7 +33,8 @@ namespace
     };
 
     /// Synthesizes the WASI command entry point: `_start` runs global
-    /// initialization (if present) and then the program's main function.
+    /// initialization (if present), then the program's main function, and
+    /// finally reports a non-zero exit status via proc_exit.
     void synthesizeStart(BinaryenModuleRef module, IRProgram& program)
     {
         auto statements = std::vector<BinaryenExpressionRef> {};
@@ -44,6 +47,20 @@ namespace
                 module, WasmFunctionLowerer::mangledName(name).c_str(), nullptr, 0, BinaryenTypeInt64());
             statements.push_back(BinaryenDrop(module, call));
         }
+
+        // if (exit_status != 0) proc_exit(exit_status)
+        auto const exitStatusName = std::string(layout::ExitStatusGlobal);
+        auto exitArgs = std::array { BinaryenGlobalGet(module, exitStatusName.c_str(), BinaryenTypeInt32()) };
+        statements.push_back(
+            BinaryenIf(module,
+                       BinaryenGlobalGet(module, exitStatusName.c_str(), BinaryenTypeInt32()),
+                       BinaryenCall(module,
+                                    "proc_exit",
+                                    exitArgs.data(),
+                                    static_cast<BinaryenIndex>(exitArgs.size()),
+                                    BinaryenTypeNone()),
+                       nullptr));
+
         auto* body = BinaryenBlock(module,
                                    nullptr,
                                    statements.data(),
@@ -51,6 +68,44 @@ namespace
                                    BinaryenTypeNone());
         BinaryenAddFunction(module, "_start", BinaryenTypeNone(), BinaryenTypeNone(), nullptr, 0, body);
         BinaryenAddFunctionExport(module, "_start", "_start");
+    }
+
+    /// Finalizes the linear memory: one active data segment holding the
+    /// interned string constants, the bump-allocator base global, and the
+    /// exported memory sized to cover data plus initial heap room.
+    void finalizeMemory(BinaryenModuleRef module, WasmStringTable const& strings)
+    {
+        auto const heapBase = (strings.dataEnd() + 15U) & ~15U;
+        BinaryenAddGlobal(module,
+                          std::string(layout::HeapPointerGlobal).c_str(),
+                          BinaryenTypeInt32(),
+                          /*mutable=*/true,
+                          BinaryenConst(module, BinaryenLiteralInt32(static_cast<int32_t>(heapBase))));
+
+        auto const pageSize = 65536U;
+        auto const initialPages = (heapBase + pageSize + (pageSize - 1)) / pageSize;
+
+        auto const* segmentName = "strings";
+        auto const* segmentData = reinterpret_cast<char const*>(strings.blob().data());
+        auto segmentPassive = false;
+        auto* segmentOffset =
+            BinaryenConst(module, BinaryenLiteralInt32(static_cast<int32_t>(layout::DataBase)));
+        auto segmentSize = static_cast<BinaryenIndex>(strings.blob().size());
+        auto const numSegments = BinaryenIndex { strings.empty() ? 0U : 1U };
+
+        BinaryenSetMemory(module,
+                          initialPages,
+                          /*maximum=*/65536,
+                          std::string(layout::MemoryExportName).c_str(),
+                          &segmentName,
+                          &segmentData,
+                          &segmentPassive,
+                          &segmentOffset,
+                          &segmentSize,
+                          numSegments,
+                          /*shared=*/false,
+                          /*memory64=*/false,
+                          /*name=*/"0");
     }
 } // namespace
 
@@ -64,42 +119,37 @@ std::optional<WasmOutput> WasmCodeGenerator::generate(IRProgram* program, diagno
     auto guard = ModuleGuard {};
     auto* module = guard.module;
 
-    auto features = BinaryenFeatureBulkMemory() | BinaryenFeatureNontrappingFPToInt();
+    auto features =
+        BinaryenFeatureBulkMemory() | BinaryenFeatureBulkMemoryOpt() | BinaryenFeatureNontrappingFPToInt();
     if (_options.tailCalls)
         features |= BinaryenFeatureTailCall();
     BinaryenModuleSetFeatures(module, features);
-
-    // One linear memory, exported as "memory" (required by WASI).
-    // Data segments for string constants are added in a later milestone.
-    BinaryenSetMemory(module,
-                      /*initial=*/1,
-                      /*maximum=*/65536,
-                      std::string(layout::MemoryExportName).c_str(),
-                      /*segmentNames=*/nullptr,
-                      /*segmentDatas=*/nullptr,
-                      /*segmentPassives=*/nullptr,
-                      /*segmentOffsets=*/nullptr,
-                      /*segmentSizes=*/nullptr,
-                      /*numSegments=*/0,
-                      /*shared=*/false,
-                      /*memory64=*/false,
-                      /*name=*/"0");
 
     // WASI Preview 1 imports used directly by generated code.
     BinaryenAddFunctionImport(
         module, "proc_exit", "wasi_snapshot_preview1", "proc_exit", BinaryenTypeInt32(), BinaryenTypeNone());
 
+    // Shell exit-status semantics: builtins update this global; a non-zero
+    // value at the end of _start becomes the process exit code.
+    BinaryenAddGlobal(module,
+                      std::string(layout::ExitStatusGlobal).c_str(),
+                      BinaryenTypeInt32(),
+                      /*mutable=*/true,
+                      BinaryenConst(module, BinaryenLiteralInt32(0)));
+
+    auto strings = WasmStringTable {};
     auto usedHelpers = std::set<RuntimeHelperDef const*> {};
     for (IRFunction* function: program->functions())
     {
         if (function->empty())
             continue;
-        WasmFunctionLowerer lowerer(module, _options, report, usedHelpers);
+        WasmFunctionLowerer lowerer(module, _options, report, usedHelpers, strings);
         lowerer.lower(function);
     }
 
     synthesizeStart(module, *program);
-    _runtimeProvider.provide(module, usedHelpers);
+    _runtimeProvider.provide(module, usedHelpers, strings);
+    finalizeMemory(module, strings);
 
     if (report.containsFailures())
         return std::nullopt;

--- a/src/CoreVM/wasm/WasmCodeGenerator.hpp
+++ b/src/CoreVM/wasm/WasmCodeGenerator.hpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <CoreVM/Diagnostics.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace CoreVM
+{
+class IRProgram;
+}
+
+namespace CoreVM::wasm
+{
+
+class WasmRuntimeProvider;
+
+/// Result of a successful WASM compilation.
+struct WasmOutput
+{
+    std::vector<uint8_t> binary; ///< The .wasm binary module.
+    std::string wat;             ///< The module in text format (only when WasmOptions::emitWat).
+};
+
+/// Compilation options for the WASM backend.
+struct WasmOptions
+{
+    bool optimize = false; ///< Run binaryen's optimizer over the generated module.
+    bool tailCalls = true; ///< Emit return_call for tail calls (requires the tail-call proposal).
+    bool emitWat = false;  ///< Additionally produce the text format in WasmOutput::wat.
+};
+
+/// Compiles a CoreVM IRProgram to a WebAssembly module (WASI command).
+///
+/// This is the WASM analog of TargetCodeGenerator: it consumes the same
+/// SSA-form IR and produces a self-contained `.wasm` binary whose `_start`
+/// export runs the program under any WASI runtime (e.g. wasmtime).
+///
+/// The WASM-side runtime (allocator, string helpers, WASI shims) is supplied
+/// via the injected WasmRuntimeProvider.
+class WasmCodeGenerator
+{
+  public:
+    /// @param runtimeProvider supplies the in-module runtime helper functions
+    /// @param options         compilation options
+    explicit WasmCodeGenerator(WasmRuntimeProvider& runtimeProvider, WasmOptions options = {});
+
+    /// Generates a WASM module from the given IR program.
+    ///
+    /// Unsupported IR constructs are collected as diagnostics in @p report
+    /// (all of them, not just the first) and result in std::nullopt.
+    ///
+    /// @param program the IR program to compile (mutated: cross-block values are materialized)
+    /// @param report  receives diagnostics for unsupported constructs and internal errors
+    /// @return the compiled module, or std::nullopt if any diagnostic was reported
+    [[nodiscard]] std::optional<WasmOutput> generate(IRProgram* program, diagnostics::Report& report);
+
+  private:
+    WasmRuntimeProvider& _runtimeProvider;
+    WasmOptions _options;
+};
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmCodeGenerator_test.cpp
+++ b/src/CoreVM/wasm/WasmCodeGenerator_test.cpp
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests for WasmCodeGenerator: IR is built programmatically with IRBuilder,
+// compiled to a WASM module, and verified structurally (the module always
+// passes binaryen validation before generate() returns) plus via WAT
+// substring checks. Runtime helpers are satisfied by ImportOnlyRuntimeProvider.
+
+#include <CoreVM/CoreVM.hpp>
+#include <CoreVM/wasm/WasmCodeGenerator.hpp>
+#include <CoreVM/wasm/WasmRuntimeABI.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+
+using namespace CoreVM;
+
+namespace
+{
+
+/// Builds IR via IRBuilder and compiles it with the WASM backend.
+class WasmTestCompiler
+{
+  public:
+    WasmTestCompiler() { _builder.setProgram(std::make_unique<IRProgram>()); }
+
+    IRBuilder& builder() { return _builder; }
+
+    IRFunction* createFunction(std::string const& name)
+    {
+        auto* function = _builder.getFunction(name);
+        _builder.setFunction(function);
+        return function;
+    }
+
+    /// Compiles the program; on success returns the output with WAT enabled.
+    std::optional<CoreVM::wasm::WasmOutput> compile()
+    {
+        auto provider = CoreVM::wasm::ImportOnlyRuntimeProvider {};
+        auto generator =
+            CoreVM::wasm::WasmCodeGenerator(provider, CoreVM::wasm::WasmOptions { .emitWat = true });
+        return generator.generate(_builder.program(), _report);
+    }
+
+    diagnostics::BufferedReport const& report() const { return _report; }
+
+  private:
+    IRBuilder _builder;
+    diagnostics::BufferedReport _report;
+};
+
+/// True if the WASM binary starts with the "\0asm" magic and version 1.
+bool hasWasmMagic(std::vector<uint8_t> const& binary)
+{
+    return binary.size() >= 8 && binary[0] == 0x00 && binary[1] == 'a' && binary[2] == 's' && binary[3] == 'm'
+           && binary[4] == 0x01;
+}
+
+} // namespace
+
+TEST_CASE("WasmCodeGenerator.main_ret_zero")
+{
+    // @main: ret 0  =>  valid module with an exported _start calling proc_exit.
+    WasmTestCompiler compiler;
+    compiler.createFunction("@main");
+    auto& builder = compiler.builder();
+
+    auto* entry = builder.createBlock("entry");
+    builder.setInsertPoint(entry);
+    builder.createRet(builder.get(static_cast<CoreNumber>(0)));
+
+    auto const output = compiler.compile();
+    REQUIRE(output.has_value());
+    CHECK(hasWasmMagic(output->binary));
+    CHECK(output->wat.contains("_start"));
+    CHECK(output->wat.contains("proc_exit"));
+    CHECK(output->wat.contains("fn$@main"));
+    CHECK(output->wat.contains("(memory"));
+}
+
+TEST_CASE("WasmCodeGenerator.alloca_store_load_ret")
+{
+    // %x = alloca; store 42, %x; %v = load %x; ret %v
+    WasmTestCompiler compiler;
+    compiler.createFunction("@main");
+    auto& builder = compiler.builder();
+
+    auto* entry = builder.createBlock("entry");
+    builder.setInsertPoint(entry);
+    auto* variable = builder.createAlloca(LiteralType::Number, builder.get(1), "x");
+    builder.createStore(variable, builder.get(static_cast<CoreNumber>(42)), "store");
+    auto* loaded = builder.createLoad(variable, "load");
+    builder.createRet(loaded);
+
+    auto const output = compiler.compile();
+    REQUIRE(output.has_value());
+    CHECK(output->wat.contains("local.set"));
+    CHECK(output->wat.contains("local.get"));
+}
+
+TEST_CASE("WasmCodeGenerator.cond_br_diamond")
+{
+    // Diamond control flow:
+    //   entry: %x = alloca; store 1, %x; %c = load %x; condbr %c, then, else
+    //   then:  store 10, %x; br merge
+    //   else:  store 20, %x; br merge
+    //   merge: %r = load %x; ret %r
+    WasmTestCompiler compiler;
+    compiler.createFunction("@main");
+    auto& builder = compiler.builder();
+
+    auto* entry = builder.createBlock("entry");
+    auto* thenBlock = builder.createBlock("then");
+    auto* elseBlock = builder.createBlock("else");
+    auto* mergeBlock = builder.createBlock("merge");
+
+    builder.setInsertPoint(entry);
+    auto* variable = builder.createAlloca(LiteralType::Number, builder.get(1), "x");
+    builder.createStore(variable, builder.get(static_cast<CoreNumber>(1)), "init");
+    auto* condition = builder.createLoad(variable, "cond");
+    builder.createCondBr(condition, thenBlock, elseBlock);
+
+    builder.setInsertPoint(thenBlock);
+    builder.createStore(variable, builder.get(static_cast<CoreNumber>(10)), "then.store");
+    builder.createBr(mergeBlock);
+
+    builder.setInsertPoint(elseBlock);
+    builder.createStore(variable, builder.get(static_cast<CoreNumber>(20)), "else.store");
+    builder.createBr(mergeBlock);
+
+    builder.setInsertPoint(mergeBlock);
+    auto* result = builder.createLoad(variable, "result");
+    builder.createRet(result);
+
+    auto const output = compiler.compile();
+    REQUIRE(output.has_value());
+    CHECK(output->wat.contains("if"));
+}
+
+TEST_CASE("WasmCodeGenerator.loop_back_edge")
+{
+    // Loop with a back edge (no arithmetic yet; the condition is re-loaded):
+    //   entry: %x = alloca; store 1, %x; br head
+    //   head:  %c = load %x; condbr %c, body, exit
+    //   body:  store 0, %x; br head
+    //   exit:  ret 0
+    WasmTestCompiler compiler;
+    compiler.createFunction("@main");
+    auto& builder = compiler.builder();
+
+    auto* entry = builder.createBlock("entry");
+    auto* head = builder.createBlock("head");
+    auto* body = builder.createBlock("body");
+    auto* exitBlock = builder.createBlock("exit");
+
+    builder.setInsertPoint(entry);
+    auto* variable = builder.createAlloca(LiteralType::Number, builder.get(1), "x");
+    builder.createStore(variable, builder.get(static_cast<CoreNumber>(1)), "init");
+    builder.createBr(head);
+
+    builder.setInsertPoint(head);
+    auto* condition = builder.createLoad(variable, "cond");
+    builder.createCondBr(condition, body, exitBlock);
+
+    builder.setInsertPoint(body);
+    builder.createStore(variable, builder.get(static_cast<CoreNumber>(0)), "clear");
+    builder.createBr(head);
+
+    builder.setInsertPoint(exitBlock);
+    builder.createRet(builder.get(static_cast<CoreNumber>(0)));
+
+    auto const output = compiler.compile();
+    REQUIRE(output.has_value());
+    CHECK(output->wat.contains("loop"));
+}
+
+TEST_CASE("WasmCodeGenerator.unsupported_construct_reports_error")
+{
+    // Regular expressions are permanently unsupported in the WASM backend:
+    // generation must fail with a diagnostic instead of producing a module.
+    WasmTestCompiler compiler;
+    compiler.createFunction("@main");
+    auto& builder = compiler.builder();
+
+    auto* entry = builder.createBlock("entry");
+    builder.setInsertPoint(entry);
+    auto* group = builder.createRegExpGroup(builder.get(static_cast<CoreNumber>(0)), "re.group");
+    builder.createRet(group);
+
+    auto const output = compiler.compile();
+    CHECK(!output.has_value());
+    CHECK(compiler.report().containsFailures());
+
+    auto errorText = std::string {};
+    for (auto const& message: compiler.report())
+        errorText += message.string();
+    CHECK(errorText.contains("cannot compile to WebAssembly"));
+    CHECK(errorText.contains("not supported"));
+}

--- a/src/CoreVM/wasm/WasmFunctionLowerer.cpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.cpp
@@ -436,19 +436,61 @@ void WasmFunctionLowerer::visit(CallInstr& instr)
 
 void WasmFunctionLowerer::visit(FunctionCallInstr& instr)
 {
-    unsupported(instr, "user-defined function calls");
+    if (instr.callee()->empty())
+    {
+        unsupported(instr, "calling a function without a compiled body");
+        return;
+    }
+    auto args = std::vector<BinaryenExpressionRef> {};
+    args.reserve(instr.operands().size());
+    for (auto* operand: instr.operands())
+        args.push_back(asI64(emitValue(operand)));
+    auto* call = BinaryenCall(_module,
+                              mangledName(instr.callee()->name()).c_str(),
+                              args.data(),
+                              static_cast<BinaryenIndex>(args.size()),
+                              BinaryenTypeInt64());
+    setResult(instr, call, ResultMode::Ordered);
 }
 
 void WasmFunctionLowerer::visit(FunctionRetInstr& instr)
 {
-    unsupported(instr, "returning from user-defined functions");
-    pushStatement(BinaryenUnreachable(_module));
+    auto* result = instr.result() != nullptr ? asI64(emitValue(instr.result())) : zeroI64();
+    pushStatement(BinaryenReturn(_module, result));
 }
 
 void WasmFunctionLowerer::visit(TailCallInstr& instr)
 {
-    unsupported(instr, "tail calls");
-    pushStatement(BinaryenUnreachable(_module));
+    if (instr.callee()->empty())
+    {
+        unsupported(instr, "tail-calling a function without a compiled body");
+        pushStatement(BinaryenUnreachable(_module));
+        return;
+    }
+    auto args = std::vector<BinaryenExpressionRef> {};
+    args.reserve(instr.operands().size());
+    for (auto* operand: instr.operands())
+        args.push_back(asI64(emitValue(operand)));
+    auto const callee = mangledName(instr.callee()->name());
+    if (_options.tailCalls)
+    {
+        pushStatement(BinaryenReturnCall(_module,
+                                         callee.c_str(),
+                                         args.data(),
+                                         static_cast<BinaryenIndex>(args.size()),
+                                         BinaryenTypeInt64()));
+    }
+    else
+    {
+        // Portable fallback for runtimes without the tail-call proposal;
+        // deep recursion may exhaust the value stack here.
+        auto* call = BinaryenCall(_module,
+                                  callee.c_str(),
+                                  args.data(),
+                                  static_cast<BinaryenIndex>(args.size()),
+                                  BinaryenTypeInt64());
+        pushStatement(BinaryenReturn(_module, call));
+    }
 }
 
 void WasmFunctionLowerer::visit(IndirectCallInstr& instr)

--- a/src/CoreVM/wasm/WasmFunctionLowerer.cpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.cpp
@@ -228,7 +228,7 @@ uint32_t WasmFunctionLowerer::scratchLocal(BinaryenType type)
 }
 
 BinaryenExpressionRef WasmFunctionLowerer::callRuntime(std::string_view helperName,
-                                                       std::span<BinaryenExpressionRef const> args)
+                                                       std::span<BinaryenExpressionRef> args)
 {
     auto const* helper = findRuntimeHelper(helperName);
     if (helper == nullptr)
@@ -237,11 +237,10 @@ BinaryenExpressionRef WasmFunctionLowerer::callRuntime(std::string_view helperNa
         return BinaryenConst(_module, BinaryenLiteralInt64(0));
     }
     _usedHelpers.insert(helper);
-    auto operands = std::vector<BinaryenExpressionRef>(args.begin(), args.end());
     return BinaryenCall(_module,
-                        std::string(helperName).c_str(),
-                        operands.data(),
-                        static_cast<BinaryenIndex>(operands.size()),
+                        helper->name,
+                        args.data(),
+                        static_cast<BinaryenIndex>(args.size()),
                         binaryenResultType(*helper));
 }
 
@@ -411,7 +410,7 @@ void WasmFunctionLowerer::visit(CallInstr& instr)
         case BuiltinInlineOp::SetExitStatus:
             pushStatement(BinaryenGlobalSet(
                 _module,
-                std::string(layout::ExitStatusGlobal).c_str(),
+                layout::ExitStatusGlobal,
                 BinaryenUnary(_module, BinaryenWrapInt64(), args.empty() ? zeroI64() : args[0])));
             mapDummyResultForUses();
             return;
@@ -543,19 +542,10 @@ void WasmFunctionLowerer::visit(BrInstr& instr)
 void WasmFunctionLowerer::visit(RetInstr& instr)
 {
     // RetInstr terminates the *program* (VM: EXIT), not the current function.
-    // Shell semantics (Shell::execute): an exit status set during execution
-    // wins; otherwise the EXIT operand collapses to 1 (non-zero) or 0.
-    auto* code = instr.operands().empty() ? zeroI64() : asI64(emitValue(instr.operand(0)));
-    auto const statusName = std::string(layout::ExitStatusGlobal);
-    auto* status = BinaryenGlobalGet(_module, statusName.c_str(), BinaryenTypeInt32());
-    auto* statusAgain = BinaryenGlobalGet(_module, statusName.c_str(), BinaryenTypeInt32());
-    auto* operandNonZero = BinaryenBinary(_module, BinaryenNeInt64(), code, zeroI64());
-    auto exitCode = std::array { BinaryenSelect(_module, status, statusAgain, operandNonZero) };
-    pushStatement(BinaryenCall(_module,
-                               "proc_exit",
-                               exitCode.data(),
-                               static_cast<BinaryenIndex>(exitCode.size()),
-                               BinaryenTypeNone()));
+    // The shell exit-status policy (status global wins, operand collapses to
+    // 1/0) lives in the endo_exit runtime helper.
+    auto args = std::array { instr.operands().empty() ? zeroI64() : asI64(emitValue(instr.operand(0))) };
+    pushStatement(callRuntime("endo_exit", args));
     pushStatement(BinaryenUnreachable(_module));
 }
 
@@ -715,54 +705,7 @@ void WasmFunctionLowerer::visit(CastInstr& instr)
         return;
     }
 
-    /// How one (target, source) conversion pair lowers.
-    struct CastRule
-    {
-        enum class Kind : uint8_t
-        {
-            HelperI64, ///< Runtime helper taking the canonical i64 form.
-            HelperF64, ///< Runtime helper taking the f64 view.
-            TruncSat,  ///< f64 -> i64 (non-trapping saturating truncation).
-            Convert,   ///< i64 -> f64 numeric conversion.
-        };
-        Kind kind;
-        std::string_view helper;
-    };
-
-    using Kind = CastRule::Kind;
-
-    // Mirrors TargetCodeGenerator's cast matrix: dynamic types (Void/Object)
-    // are treated as numbers at runtime.
-    static auto const matrix = std::unordered_map<LiteralType, std::unordered_map<LiteralType, CastRule>> {
-        { LiteralType::String,
-          {
-              { LiteralType::Number, { .kind = Kind::HelperI64, .helper = "endo_i64_to_str" } },
-              { LiteralType::Boolean, { .kind = Kind::HelperI64, .helper = "endo_i64_to_str" } },
-              { LiteralType::Void, { .kind = Kind::HelperI64, .helper = "endo_i64_to_str" } },
-              { LiteralType::Object, { .kind = Kind::HelperI64, .helper = "endo_i64_to_str" } },
-              { LiteralType::Float, { .kind = Kind::HelperF64, .helper = "endo_f64_to_str_g" } },
-          } },
-        { LiteralType::Number,
-          {
-              { LiteralType::String, { .kind = Kind::HelperI64, .helper = "endo_str_to_i64" } },
-              { LiteralType::Float, { .kind = Kind::TruncSat } },
-          } },
-        { LiteralType::Float,
-          {
-              { LiteralType::Number, { .kind = Kind::Convert } },
-              { LiteralType::Void, { .kind = Kind::Convert } },
-              { LiteralType::Object, { .kind = Kind::Convert } },
-              { LiteralType::String, { .kind = Kind::HelperI64, .helper = "endo_str_to_f64" } },
-          } },
-    };
-
-    auto const targetIt = matrix.find(targetType);
-    auto const* rule = [&]() -> CastRule const* {
-        if (targetIt == matrix.end())
-            return nullptr;
-        auto const sourceIt = targetIt->second.find(sourceType);
-        return sourceIt != targetIt->second.end() ? &sourceIt->second : nullptr;
-    }();
+    auto const* rule = castLowering(targetType, sourceType);
     if (rule == nullptr)
     {
         unsupported(instr, std::format("conversion from {} to {}", tos(sourceType), tos(targetType)));
@@ -771,23 +714,23 @@ void WasmFunctionLowerer::visit(CastInstr& instr)
 
     switch (rule->kind)
     {
-        case Kind::HelperI64: {
+        case CastLowering::Kind::HelperI64: {
             auto args = std::array { asI64(emitValue(instr.source())) };
             setResult(instr, callRuntime(rule->helper, args), ResultMode::Ordered);
             return;
         }
-        case Kind::HelperF64: {
+        case CastLowering::Kind::HelperF64: {
             auto args = std::array { asF64(emitValue(instr.source())) };
             setResult(instr, callRuntime(rule->helper, args), ResultMode::Ordered);
             return;
         }
-        case Kind::TruncSat:
+        case CastLowering::Kind::TruncSat:
             setResult(
                 instr,
                 BinaryenUnary(_module, BinaryenTruncSatSFloat64ToInt64(), asF64(emitValue(instr.source()))),
                 ResultMode::Pure);
             return;
-        case Kind::Convert:
+        case CastLowering::Kind::Convert:
             setResult(
                 instr,
                 BinaryenUnary(_module, BinaryenConvertSInt64ToFloat64(), asI64(emitValue(instr.source()))),
@@ -849,17 +792,26 @@ void WasmFunctionLowerer::visit(ObjReleaseInstr& instr)
     (void) instr;
 }
 
+BinaryenExpressionRef WasmFunctionLowerer::loadObjectField(Value* object,
+                                                           uint32_t bytes,
+                                                           uint32_t offset,
+                                                           BinaryenType type)
+{
+    return BinaryenLoad(_module,
+                        bytes,
+                        false,
+                        offset,
+                        0,
+                        type,
+                        BinaryenUnary(_module, BinaryenWrapInt64(), asI64(emitValue(object))),
+                        "0");
+}
+
 void WasmFunctionLowerer::visit(ObjGetTagInstr& instr)
 {
-    auto* tag = BinaryenLoad(_module,
-                             1,
-                             false,
-                             layout::TagOffset,
-                             0,
-                             BinaryenTypeInt32(),
-                             BinaryenUnary(_module, BinaryenWrapInt64(), asI64(emitValue(instr.object()))),
-                             "0");
-    setResult(instr, tag, ResultMode::PinIfUsed);
+    setResult(instr,
+              loadObjectField(instr.object(), 1, layout::TagOffset, BinaryenTypeInt32()),
+              ResultMode::PinIfUsed);
 }
 
 void WasmFunctionLowerer::visit(ObjSetTagInstr& instr)
@@ -876,15 +828,7 @@ void WasmFunctionLowerer::visit(ObjGetSlotInstr& instr)
 {
     auto const offset =
         layout::HeaderSize + (layout::SlotSize * static_cast<uint32_t>(instr.slotIndex()->get()));
-    auto* slot = BinaryenLoad(_module,
-                              8,
-                              false,
-                              offset,
-                              0,
-                              BinaryenTypeInt64(),
-                              BinaryenUnary(_module, BinaryenWrapInt64(), asI64(emitValue(instr.object()))),
-                              "0");
-    setResult(instr, slot, ResultMode::PinIfUsed);
+    setResult(instr, loadObjectField(instr.object(), 8, offset, BinaryenTypeInt64()), ResultMode::PinIfUsed);
 }
 
 void WasmFunctionLowerer::visit(ObjSetSlotInstr& instr)
@@ -906,31 +850,17 @@ void WasmFunctionLowerer::visit(ObjSetSlotInstr& instr)
 
 void WasmFunctionLowerer::visit(ObjTypeIdInstr& instr)
 {
-    auto* typeId = BinaryenLoad(_module,
-                                2,
-                                false,
-                                layout::TypeIdOffset,
-                                0,
-                                BinaryenTypeInt32(),
-                                BinaryenUnary(_module, BinaryenWrapInt64(), asI64(emitValue(instr.object()))),
-                                "0");
-    setResult(instr, typeId, ResultMode::PinIfUsed);
+    setResult(instr,
+              loadObjectField(instr.object(), 2, layout::TypeIdOffset, BinaryenTypeInt32()),
+              ResultMode::PinIfUsed);
 }
 
 void WasmFunctionLowerer::visit(ObjIsTypeInstr& instr)
 {
-    auto* typeId = BinaryenLoad(_module,
-                                2,
-                                false,
-                                layout::TypeIdOffset,
-                                0,
-                                BinaryenTypeInt32(),
-                                BinaryenUnary(_module, BinaryenWrapInt64(), asI64(emitValue(instr.object()))),
-                                "0");
     auto* test = BinaryenBinary(
         _module,
         BinaryenEqInt32(),
-        typeId,
+        loadObjectField(instr.object(), 2, layout::TypeIdOffset, BinaryenTypeInt32()),
         BinaryenConst(_module, BinaryenLiteralInt32(static_cast<int32_t>(instr.typeId()->get()))));
     setResult(instr, test, ResultMode::PinIfUsed);
 }

--- a/src/CoreVM/wasm/WasmFunctionLowerer.cpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.cpp
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <CoreVM/ir/BasicBlock.hpp>
+#include <CoreVM/ir/IRProgram.hpp>
+#include <CoreVM/transform/Passes.hpp>
+#include <CoreVM/vm/NativeCallback.hpp>
+#include <CoreVM/wasm/WasmFunctionLowerer.hpp>
+
+#include <array>
+#include <format>
+
+namespace CoreVM::wasm
+{
+
+WasmFunctionLowerer::WasmFunctionLowerer(BinaryenModuleRef module,
+                                         WasmOptions const& options,
+                                         diagnostics::Report& report,
+                                         std::set<RuntimeHelperDef const*>& usedHelpers):
+    _module { module }, _options { options }, _report { report }, _usedHelpers { usedHelpers }
+{
+}
+
+std::string WasmFunctionLowerer::mangledName(std::string_view irName)
+{
+    return std::format("fn${}", irName);
+}
+
+void WasmFunctionLowerer::lower(IRFunction* function)
+{
+    _function = function;
+
+    // Mandatory lowering: after this pass no SSA value crosses basic-block
+    // boundaries except through allocas, and PhiNodes never occur.
+    transform::materializeCrossBlockValues(function);
+
+    assignLocals();
+
+    auto* relooper = RelooperCreate(_module);
+    for (BasicBlock* block: function->basicBlocks())
+    {
+        _statements.clear();
+        _currentBlock = block;
+        for (Instr* instr: block->instructions())
+        {
+            _currentInstr = instr;
+            instr->accept(*this);
+        }
+        if (block->getTerminator() == nullptr)
+            pushStatement(BinaryenUnreachable(_module));
+        auto* code = BinaryenBlock(_module,
+                                   nullptr,
+                                   _statements.data(),
+                                   static_cast<BinaryenIndex>(_statements.size()),
+                                   BinaryenTypeAuto());
+        _relooperBlocks[block] = RelooperAddBlock(relooper, code);
+    }
+
+    for (auto const& branch: _pendingBranches)
+    {
+        auto* condition = branch.condition != nullptr ? asCond(emitValue(branch.condition)) : nullptr;
+        RelooperAddBranch(_relooperBlocks[branch.from], _relooperBlocks[branch.to], condition, nullptr);
+    }
+
+    auto const labelHelper = scratchLocal(BinaryenTypeInt32());
+    auto* body = RelooperRenderAndDispose(relooper, _relooperBlocks[function->getEntryBlock()], labelHelper);
+
+    // Safety net: guarantee the body yields the declared i64 result even if
+    // all exits go through proc_exit/return (renders as unreachable type).
+    auto tail = std::array {
+        body,
+        BinaryenReturn(_module, BinaryenConst(_module, BinaryenLiteralInt64(0))),
+    };
+    auto* wrapped = BinaryenBlock(
+        _module, nullptr, tail.data(), static_cast<BinaryenIndex>(tail.size()), BinaryenTypeAuto());
+
+    auto params = std::vector<BinaryenType>(_paramCount, BinaryenTypeInt64());
+    auto const paramsType = _paramCount == 0
+                                ? BinaryenTypeNone()
+                                : BinaryenTypeCreate(params.data(), static_cast<BinaryenIndex>(_paramCount));
+    BinaryenAddFunction(_module,
+                        mangledName(function->name()).c_str(),
+                        paramsType,
+                        BinaryenTypeInt64(),
+                        _varTypes.data(),
+                        static_cast<BinaryenIndex>(_varTypes.size()),
+                        wrapped);
+}
+
+void WasmFunctionLowerer::assignLocals()
+{
+    // The first parameterCount() allocas (in block/instruction order) are the
+    // function parameters; they map to param locals 0..P-1 and contribute no
+    // varTypes entry. All later allocas become i64 locals.
+    _paramCount = static_cast<uint32_t>(_function->parameterCount());
+    auto allocaOrdinal = uint32_t { 0 };
+    for (BasicBlock* block: _function->basicBlocks())
+    {
+        for (Instr* instr: block->instructions())
+        {
+            auto* alloca = dynamic_cast<AllocaInstr*>(instr);
+            if (alloca == nullptr)
+                continue;
+            if (allocaOrdinal < _paramCount)
+            {
+                _localIndex[alloca] = allocaOrdinal;
+            }
+            else
+            {
+                _localIndex[alloca] = _paramCount + static_cast<uint32_t>(_varTypes.size());
+                _varTypes.push_back(BinaryenTypeInt64());
+            }
+            ++allocaOrdinal;
+        }
+    }
+}
+
+// {{{ value materialization and result integration
+
+BinaryenExpressionRef WasmFunctionLowerer::emitValue(Value* value)
+{
+    if (auto* constInt = dynamic_cast<ConstantInt*>(value))
+        return BinaryenConst(_module, BinaryenLiteralInt64(constInt->get()));
+
+    if (auto* constBool = dynamic_cast<ConstantBoolean*>(value))
+        return BinaryenConst(_module, BinaryenLiteralInt64(constBool->get() ? 1 : 0));
+
+    if (auto* constFloat = dynamic_cast<ConstantFloat*>(value))
+        return BinaryenConst(_module, BinaryenLiteralFloat64(constFloat->get()));
+
+    if (auto* alloca = dynamic_cast<AllocaInstr*>(value))
+    {
+        if (auto const it = _localIndex.find(alloca); it != _localIndex.end())
+            return BinaryenLocalGet(_module, it->second, BinaryenTypeInt64());
+        internalError("reference to an unassigned alloca");
+        return BinaryenConst(_module, BinaryenLiteralInt64(0));
+    }
+
+    if (auto const pinned = _pinned.find(value); pinned != _pinned.end())
+        return BinaryenLocalGet(_module, pinned->second.localIndex, pinned->second.type);
+
+    if (auto const mapped = _valueMap.find(value); mapped != _valueMap.end())
+    {
+        // Binaryen expressions are single-use tree nodes: hand the expression
+        // out exactly once. Multi-use values are pinned by setResult instead.
+        auto* expr = mapped->second;
+        _valueMap.erase(mapped);
+        return expr;
+    }
+
+    internalError(std::format("operand '{}' has no materialized value", value->name()));
+    return BinaryenConst(_module, BinaryenLiteralInt64(0));
+}
+
+void WasmFunctionLowerer::setResult(Instr& instr, BinaryenExpressionRef expr, ResultMode mode)
+{
+    switch (mode)
+    {
+        case ResultMode::Pure:
+            if (!instr.isUsed())
+                return; // dead pure value: emit nothing
+            if (instr.useCount() > 1)
+                pin(instr, expr);
+            else
+                _valueMap[&instr] = expr;
+            return;
+        case ResultMode::PinIfUsed:
+            if (instr.isUsed())
+                pin(instr, expr);
+            return;
+        case ResultMode::Ordered:
+            if (instr.isUsed())
+                pin(instr, expr);
+            else if (BinaryenExpressionGetType(expr) == BinaryenTypeNone())
+                pushStatement(expr);
+            else
+                pushStatement(BinaryenDrop(_module, expr));
+            return;
+    }
+}
+
+void WasmFunctionLowerer::pin(Value& value, BinaryenExpressionRef expr)
+{
+    auto const type = BinaryenExpressionGetType(expr);
+    auto const localIndex = scratchLocal(type);
+    pushStatement(BinaryenLocalSet(_module, localIndex, expr));
+    _pinned[&value] = PinnedValue { .localIndex = localIndex, .type = type };
+}
+
+void WasmFunctionLowerer::pinValue(Value* value)
+{
+    if (dynamic_cast<Constant*>(value) != nullptr || dynamic_cast<AllocaInstr*>(value) != nullptr)
+        return; // re-materialized freshly on each emitValue()
+    if (_pinned.contains(value))
+        return;
+    if (auto const mapped = _valueMap.find(value); mapped != _valueMap.end())
+    {
+        auto* expr = mapped->second;
+        _valueMap.erase(mapped);
+        pin(*value, expr);
+        return;
+    }
+    internalError(std::format("cannot pin value '{}': no materialized expression", value->name()));
+}
+
+uint32_t WasmFunctionLowerer::scratchLocal(BinaryenType type)
+{
+    _varTypes.push_back(type);
+    return _paramCount + static_cast<uint32_t>(_varTypes.size()) - 1;
+}
+
+BinaryenExpressionRef WasmFunctionLowerer::callRuntime(std::string_view helperName,
+                                                       std::span<BinaryenExpressionRef const> args)
+{
+    auto const* helper = findRuntimeHelper(helperName);
+    if (helper == nullptr)
+    {
+        internalError(std::format("unknown runtime helper '{}'", helperName));
+        return BinaryenConst(_module, BinaryenLiteralInt64(0));
+    }
+    _usedHelpers.insert(helper);
+    auto operands = std::vector<BinaryenExpressionRef>(args.begin(), args.end());
+    return BinaryenCall(_module,
+                        std::string(helperName).c_str(),
+                        operands.data(),
+                        static_cast<BinaryenIndex>(operands.size()),
+                        binaryenResultType(*helper));
+}
+
+BinaryenExpressionRef WasmFunctionLowerer::asI64(BinaryenExpressionRef expr)
+{
+    auto const type = BinaryenExpressionGetType(expr);
+    if (type == BinaryenTypeFloat64())
+        return BinaryenUnary(_module, BinaryenReinterpretFloat64(), expr);
+    if (type == BinaryenTypeInt32())
+        return BinaryenUnary(_module, BinaryenExtendUInt32(), expr);
+    return expr;
+}
+
+BinaryenExpressionRef WasmFunctionLowerer::asF64(BinaryenExpressionRef expr)
+{
+    auto const type = BinaryenExpressionGetType(expr);
+    if (type == BinaryenTypeInt64())
+        return BinaryenUnary(_module, BinaryenReinterpretInt64(), expr);
+    if (type == BinaryenTypeInt32())
+        return BinaryenUnary(_module, BinaryenReinterpretInt64(), asI64(expr));
+    return expr;
+}
+
+BinaryenExpressionRef WasmFunctionLowerer::asCond(BinaryenExpressionRef expr)
+{
+    auto const type = BinaryenExpressionGetType(expr);
+    if (type == BinaryenTypeInt32())
+        return expr;
+    // Robust against non-canonical booleans: any non-zero i64 is true.
+    return BinaryenBinary(
+        _module, BinaryenNeInt64(), asI64(expr), BinaryenConst(_module, BinaryenLiteralInt64(0)));
+}
+
+// }}}
+// {{{ diagnostics
+
+void WasmFunctionLowerer::unsupported(Instr& instr, std::string_view what)
+{
+    _report.typeError(instr.sourceLocation(), "cannot compile to WebAssembly: {} is not supported", what);
+    // Poison the result so lowering can continue and collect further errors.
+    if (instr.isUsed())
+        _valueMap[&instr] = BinaryenConst(_module, BinaryenLiteralInt64(0));
+}
+
+void WasmFunctionLowerer::internalError(std::string_view what)
+{
+    auto const location = _currentInstr != nullptr ? _currentInstr->sourceLocation() : SourceLocation {};
+    _report.typeError(location, "internal error (WASM backend): {}", what);
+}
+
+// }}}
+// {{{ storage instructions
+
+void WasmFunctionLowerer::visit(NopInstr& instr)
+{
+    (void) instr;
+}
+
+void WasmFunctionLowerer::visit(AllocaInstr& instr)
+{
+    // Locals are pre-assigned in assignLocals(); no code is emitted here.
+    auto const* size = dynamic_cast<ConstantInt*>(instr.arraySize());
+    if (size == nullptr || size->get() != 1)
+        unsupported(instr, "array allocation");
+}
+
+void WasmFunctionLowerer::visit(StoreInstr& instr)
+{
+    if (instr.index()->get() != 0)
+    {
+        unsupported(instr, "indexed store (array element assignment)");
+        return;
+    }
+    auto* alloca = dynamic_cast<AllocaInstr*>(instr.variable());
+    if (alloca == nullptr)
+    {
+        internalError("store target is not an alloca");
+        return;
+    }
+    auto const it = _localIndex.find(alloca);
+    if (it == _localIndex.end())
+    {
+        internalError("store target alloca has no local index");
+        return;
+    }
+    pushStatement(BinaryenLocalSet(_module, it->second, asI64(emitValue(instr.source()))));
+}
+
+void WasmFunctionLowerer::visit(LoadInstr& instr)
+{
+    auto* alloca = dynamic_cast<AllocaInstr*>(instr.variable());
+    if (alloca == nullptr)
+    {
+        unsupported(instr, "load from a non-local variable");
+        return;
+    }
+    auto const it = _localIndex.find(alloca);
+    if (it == _localIndex.end())
+    {
+        internalError("loaded alloca has no local index");
+        return;
+    }
+    // Pin the loaded value now: the local may be re-stored later in this
+    // block, so the load must observe the value at this program point.
+    setResult(instr, BinaryenLocalGet(_module, it->second, BinaryenTypeInt64()), ResultMode::PinIfUsed);
+}
+
+void WasmFunctionLowerer::visit(PhiNode& instr)
+{
+    (void) instr;
+    // materializeCrossBlockValues() eliminates all cross-block SSA values.
+    internalError("unexpected PhiNode after cross-block value materialization");
+}
+
+// }}}
+// {{{ calls
+
+void WasmFunctionLowerer::visit(CallInstr& instr)
+{
+    unsupported(instr, std::format("builtin '{}'", instr.callee()->signature().to_s()));
+}
+
+void WasmFunctionLowerer::visit(FunctionCallInstr& instr)
+{
+    unsupported(instr, "user-defined function calls");
+}
+
+void WasmFunctionLowerer::visit(FunctionRetInstr& instr)
+{
+    unsupported(instr, "returning from user-defined functions");
+    pushStatement(BinaryenUnreachable(_module));
+}
+
+void WasmFunctionLowerer::visit(TailCallInstr& instr)
+{
+    unsupported(instr, "tail calls");
+    pushStatement(BinaryenUnreachable(_module));
+}
+
+void WasmFunctionLowerer::visit(IndirectCallInstr& instr)
+{
+    unsupported(instr, "closures and function values (indirect calls)");
+}
+
+void WasmFunctionLowerer::visit(IndirectTailCallInstr& instr)
+{
+    unsupported(instr, "closures and function values (indirect tail calls)");
+    pushStatement(BinaryenUnreachable(_module));
+}
+
+void WasmFunctionLowerer::visit(FunctionRefInstr& instr)
+{
+    unsupported(instr, "function references (closures)");
+}
+
+// }}}
+// {{{ terminators
+
+void WasmFunctionLowerer::visit(CondBrInstr& instr)
+{
+    pinValue(instr.condition());
+    _pendingBranches.push_back(
+        PendingBranch { .from = _currentBlock, .to = instr.trueBlock(), .condition = instr.condition() });
+    _pendingBranches.push_back(
+        PendingBranch { .from = _currentBlock, .to = instr.falseBlock(), .condition = nullptr });
+}
+
+void WasmFunctionLowerer::visit(BrInstr& instr)
+{
+    _pendingBranches.push_back(
+        PendingBranch { .from = _currentBlock, .to = instr.targetBlock(), .condition = nullptr });
+}
+
+void WasmFunctionLowerer::visit(RetInstr& instr)
+{
+    // RetInstr terminates the *program* (VM: EXIT), not the current function.
+    auto* code = instr.operands().empty() ? BinaryenConst(_module, BinaryenLiteralInt64(0))
+                                          : asI64(emitValue(instr.operand(0)));
+    auto exitCode = std::array { BinaryenUnary(_module, BinaryenWrapInt64(), code) };
+    pushStatement(BinaryenCall(_module,
+                               "proc_exit",
+                               exitCode.data(),
+                               static_cast<BinaryenIndex>(exitCode.size()),
+                               BinaryenTypeNone()));
+    pushStatement(BinaryenUnreachable(_module));
+}
+
+void WasmFunctionLowerer::visit(MatchInstr& instr)
+{
+    unsupported(instr, "match dispatch");
+    pushStatement(BinaryenUnreachable(_module));
+}
+
+// }}}
+// {{{ operator families (data-driven lowering; tables filled in later milestones)
+
+void WasmFunctionLowerer::lowerUnaryOp(Instr& instr, UnaryOperator op)
+{
+    unsupported(instr, std::format("operator '{}'", cstr(op)));
+}
+
+void WasmFunctionLowerer::lowerBinaryOp(Instr& instr, BinaryOperator op)
+{
+    unsupported(instr, std::format("operator '{}'", cstr(op)));
+}
+
+// }}}
+// {{{ casts, regexp
+
+void WasmFunctionLowerer::visit(CastInstr& instr)
+{
+    unsupported(instr, "type conversion");
+}
+
+void WasmFunctionLowerer::visit(RegExpGroupInstr& instr)
+{
+    unsupported(instr, "regular expressions");
+}
+
+// }}}
+// {{{ object operations
+
+void WasmFunctionLowerer::visit(ObjAllocInstr& instr)
+{
+    unsupported(instr, "object allocation");
+}
+
+void WasmFunctionLowerer::visit(ObjRetainInstr& instr)
+{
+    unsupported(instr, "object retain");
+}
+
+void WasmFunctionLowerer::visit(ObjReleaseInstr& instr)
+{
+    unsupported(instr, "object release");
+}
+
+void WasmFunctionLowerer::visit(ObjGetTagInstr& instr)
+{
+    unsupported(instr, "object tag access");
+}
+
+void WasmFunctionLowerer::visit(ObjSetTagInstr& instr)
+{
+    unsupported(instr, "object tag assignment");
+}
+
+void WasmFunctionLowerer::visit(ObjGetSlotInstr& instr)
+{
+    unsupported(instr, "object slot access");
+}
+
+void WasmFunctionLowerer::visit(ObjSetSlotInstr& instr)
+{
+    unsupported(instr, "object slot assignment");
+}
+
+void WasmFunctionLowerer::visit(ObjTypeIdInstr& instr)
+{
+    unsupported(instr, "object type-id access");
+}
+
+void WasmFunctionLowerer::visit(ObjIsTypeInstr& instr)
+{
+    unsupported(instr, "object type test");
+}
+
+// }}}
+// {{{ dynamic value comparison
+
+void WasmFunctionLowerer::visit(VCmpEQInstr& instr)
+{
+    unsupported(instr, "dynamic value comparison");
+}
+
+void WasmFunctionLowerer::visit(VCmpNEInstr& instr)
+{
+    unsupported(instr, "dynamic value comparison");
+}
+
+void WasmFunctionLowerer::visit(VCmpLTInstr& instr)
+{
+    unsupported(instr, "dynamic value comparison");
+}
+
+void WasmFunctionLowerer::visit(VCmpLEInstr& instr)
+{
+    unsupported(instr, "dynamic value comparison");
+}
+
+void WasmFunctionLowerer::visit(VCmpGTInstr& instr)
+{
+    unsupported(instr, "dynamic value comparison");
+}
+
+void WasmFunctionLowerer::visit(VCmpGEInstr& instr)
+{
+    unsupported(instr, "dynamic value comparison");
+}
+
+// }}}
+// {{{ lazy evaluation
+
+void WasmFunctionLowerer::visit(LazyForceInstr& instr)
+{
+    unsupported(instr, "lazy sequences");
+}
+
+// }}}
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmFunctionLowerer.cpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.cpp
@@ -417,8 +417,11 @@ void WasmFunctionLowerer::visit(CallInstr& instr)
             return;
         case BuiltinInlineOp::Ignore: mapDummyResultForUses(); return;
         case BuiltinInlineOp::ObjectToString: {
-            // Prefer compile-time type dispatch over the runtime pointer/number
-            // classifier: it is both faster and immune to value aliasing.
+            // Compile-time dispatch where the value is unambiguous; everything
+            // else goes through the runtime pointer/number classifier. Note
+            // that a Number-typed argument may still be an object pointer
+            // (native callbacks return object pointers as Number), so only
+            // constants and statically String/Boolean-typed values short-cut.
             auto* argument = instr.operands().size() > 1 ? instr.operand(1) : nullptr;
             auto const argumentType = argument != nullptr ? argument->type() : LiteralType::Void;
             if (argumentType == LiteralType::String)
@@ -426,7 +429,9 @@ void WasmFunctionLowerer::visit(CallInstr& instr)
                 setResult(instr, args.empty() ? zeroI64() : args[0], ResultMode::Pure);
                 return;
             }
-            auto const* helper = (argumentType == LiteralType::Number || argumentType == LiteralType::Boolean)
+            auto const isConstantNumeric = dynamic_cast<ConstantInt*>(argument) != nullptr
+                                           || dynamic_cast<ConstantBoolean*>(argument) != nullptr;
+            auto const* helper = (isConstantNumeric || argumentType == LiteralType::Boolean)
                                      ? "endo_i64_to_str"
                                      : "endo_object_to_string";
             setResult(instr, callRuntime(helper, args), ResultMode::Ordered);

--- a/src/CoreVM/wasm/WasmFunctionLowerer.cpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.cpp
@@ -3,10 +3,13 @@
 #include <CoreVM/ir/IRProgram.hpp>
 #include <CoreVM/transform/Passes.hpp>
 #include <CoreVM/vm/NativeCallback.hpp>
+#include <CoreVM/wasm/WasmBuiltins.hpp>
 #include <CoreVM/wasm/WasmFunctionLowerer.hpp>
+#include <CoreVM/wasm/WasmOpTables.hpp>
 
 #include <array>
 #include <format>
+#include <ranges>
 
 namespace CoreVM::wasm
 {
@@ -225,6 +228,18 @@ BinaryenExpressionRef WasmFunctionLowerer::callRuntime(std::string_view helperNa
                         binaryenResultType(*helper));
 }
 
+BinaryenExpressionRef WasmFunctionLowerer::zeroI64()
+{
+    return BinaryenConst(_module, BinaryenLiteralInt64(0));
+}
+
+void WasmFunctionLowerer::lowerValueCompare(Instr& instr, BinaryenOp compareOp)
+{
+    auto* lhs = asI64(emitValue(instr.operand(0)));
+    auto* rhs = asI64(emitValue(instr.operand(1)));
+    setResult(instr, BinaryenBinary(_module, compareOp, lhs, rhs), ResultMode::Pure);
+}
+
 BinaryenExpressionRef WasmFunctionLowerer::asI64(BinaryenExpressionRef expr)
 {
     auto const type = BinaryenExpressionGetType(expr);
@@ -341,7 +356,57 @@ void WasmFunctionLowerer::visit(PhiNode& instr)
 
 void WasmFunctionLowerer::visit(CallInstr& instr)
 {
-    unsupported(instr, std::format("builtin '{}'", instr.callee()->signature().to_s()));
+    auto const signature = instr.callee()->signature().to_s();
+    auto const* builtin = findWasmBuiltin(signature);
+    if (builtin == nullptr)
+    {
+        unsupported(instr, std::format("builtin '{}'", signature));
+        return;
+    }
+
+    // Operand 0 is the callee; the arguments follow.
+    auto args = std::vector<BinaryenExpressionRef> {};
+    args.reserve(instr.operands().size() - 1);
+    for (auto* operand: instr.operands() | std::views::drop(1))
+        args.push_back(asI64(emitValue(operand)));
+
+    // Inline lowerings produce no meaningful value; IR may still reference the
+    // call result (e.g. as an if-arm value), so map a dummy for those uses.
+    auto const mapDummyResultForUses = [&]() {
+        if (instr.isUsed())
+            setResult(instr, zeroI64(), ResultMode::Pure);
+    };
+
+    switch (builtin->inlineOp)
+    {
+        case BuiltinInlineOp::ProcExit: {
+            auto exitCode = std::array { BinaryenUnary(
+                _module, BinaryenWrapInt64(), args.empty() ? zeroI64() : args[0]) };
+            pushStatement(BinaryenCall(_module,
+                                       "proc_exit",
+                                       exitCode.data(),
+                                       static_cast<BinaryenIndex>(exitCode.size()),
+                                       BinaryenTypeNone()));
+            pushStatement(BinaryenUnreachable(_module));
+            mapDummyResultForUses();
+            return;
+        }
+        case BuiltinInlineOp::SetExitStatus:
+            pushStatement(BinaryenGlobalSet(
+                _module,
+                std::string(layout::ExitStatusGlobal).c_str(),
+                BinaryenUnary(_module, BinaryenWrapInt64(), args.empty() ? zeroI64() : args[0])));
+            mapDummyResultForUses();
+            return;
+        case BuiltinInlineOp::Ignore: mapDummyResultForUses(); return;
+        case BuiltinInlineOp::None: break;
+    }
+
+    auto* result = callRuntime(builtin->runtimeHelper, args);
+    if (instr.callee()->signature().returnType() == LiteralType::Void)
+        pushStatement(result);
+    else
+        setResult(instr, result, ResultMode::Ordered);
 }
 
 void WasmFunctionLowerer::visit(FunctionCallInstr& instr)
@@ -398,8 +463,7 @@ void WasmFunctionLowerer::visit(BrInstr& instr)
 void WasmFunctionLowerer::visit(RetInstr& instr)
 {
     // RetInstr terminates the *program* (VM: EXIT), not the current function.
-    auto* code = instr.operands().empty() ? BinaryenConst(_module, BinaryenLiteralInt64(0))
-                                          : asI64(emitValue(instr.operand(0)));
+    auto* code = instr.operands().empty() ? zeroI64() : asI64(emitValue(instr.operand(0)));
     auto exitCode = std::array { BinaryenUnary(_module, BinaryenWrapInt64(), code) };
     pushStatement(BinaryenCall(_module,
                                "proc_exit",
@@ -420,12 +484,81 @@ void WasmFunctionLowerer::visit(MatchInstr& instr)
 
 void WasmFunctionLowerer::lowerUnaryOp(Instr& instr, UnaryOperator op)
 {
-    unsupported(instr, std::format("operator '{}'", cstr(op)));
+    auto const& lowering = unaryOpLowering(op);
+    auto const coerce = [&](BinaryenExpressionRef expr) {
+        return lowering.floatOperand ? asF64(expr) : asI64(expr);
+    };
+
+    switch (lowering.kind)
+    {
+        case UnaryOpLowering::Kind::DirectOp:
+            setResult(instr,
+                      BinaryenUnary(_module, lowering.op(), coerce(emitValue(instr.operand(0)))),
+                      ResultMode::Pure);
+            return;
+        case UnaryOpLowering::Kind::SubFromZero:
+            setResult(
+                instr,
+                BinaryenBinary(_module, BinaryenSubInt64(), zeroI64(), asI64(emitValue(instr.operand(0)))),
+                ResultMode::Pure);
+            return;
+        case UnaryOpLowering::Kind::XorImmediate:
+            setResult(instr,
+                      BinaryenBinary(_module,
+                                     BinaryenXorInt64(),
+                                     asI64(emitValue(instr.operand(0))),
+                                     BinaryenConst(_module, BinaryenLiteralInt64(lowering.immediate))),
+                      ResultMode::Pure);
+            return;
+        case UnaryOpLowering::Kind::HelperCall: {
+            auto args = std::array { coerce(emitValue(instr.operand(0))) };
+            setResult(instr, callRuntime(lowering.helper, args), ResultMode::Ordered);
+            return;
+        }
+        case UnaryOpLowering::Kind::HelperIsZero: {
+            auto args = std::array { coerce(emitValue(instr.operand(0))) };
+            setResult(instr,
+                      BinaryenUnary(_module, BinaryenEqZInt64(), callRuntime(lowering.helper, args)),
+                      ResultMode::Ordered);
+            return;
+        }
+        case UnaryOpLowering::Kind::Unsupported: break;
+    }
+    unsupported(instr, std::format("operator '{}' ({})", cstr(op), lowering.unsupportedWhat));
 }
 
 void WasmFunctionLowerer::lowerBinaryOp(Instr& instr, BinaryOperator op)
 {
-    unsupported(instr, std::format("operator '{}'", cstr(op)));
+    auto const& lowering = binaryOpLowering(op);
+    auto const coerce = [&](BinaryenExpressionRef expr) {
+        return lowering.floatOperands ? asF64(expr) : asI64(expr);
+    };
+
+    switch (lowering.kind)
+    {
+        case BinaryOpLowering::Kind::DirectOp: {
+            auto* lhs = coerce(emitValue(instr.operand(0)));
+            auto* rhs = coerce(emitValue(instr.operand(1)));
+            setResult(instr, BinaryenBinary(_module, lowering.op(), lhs, rhs), ResultMode::Pure);
+            return;
+        }
+        case BinaryOpLowering::Kind::HelperCall: {
+            auto args =
+                std::array { coerce(emitValue(instr.operand(0))), coerce(emitValue(instr.operand(1))) };
+            setResult(instr, callRuntime(lowering.helper, args), ResultMode::Ordered);
+            return;
+        }
+        case BinaryOpLowering::Kind::HelperCmp0: {
+            auto args =
+                std::array { coerce(emitValue(instr.operand(0))), coerce(emitValue(instr.operand(1))) };
+            setResult(instr,
+                      BinaryenBinary(_module, lowering.op(), callRuntime(lowering.helper, args), zeroI64()),
+                      ResultMode::Ordered);
+            return;
+        }
+        case BinaryOpLowering::Kind::Unsupported: break;
+    }
+    unsupported(instr, std::format("operator '{}' ({})", cstr(op), lowering.unsupportedWhat));
 }
 
 // }}}
@@ -490,36 +623,36 @@ void WasmFunctionLowerer::visit(ObjIsTypeInstr& instr)
 }
 
 // }}}
-// {{{ dynamic value comparison
+// {{{ dynamic value comparison (raw canonical i64 values, mirroring the VM)
 
 void WasmFunctionLowerer::visit(VCmpEQInstr& instr)
 {
-    unsupported(instr, "dynamic value comparison");
+    lowerValueCompare(instr, BinaryenEqInt64());
 }
 
 void WasmFunctionLowerer::visit(VCmpNEInstr& instr)
 {
-    unsupported(instr, "dynamic value comparison");
+    lowerValueCompare(instr, BinaryenNeInt64());
 }
 
 void WasmFunctionLowerer::visit(VCmpLTInstr& instr)
 {
-    unsupported(instr, "dynamic value comparison");
+    lowerValueCompare(instr, BinaryenLtSInt64());
 }
 
 void WasmFunctionLowerer::visit(VCmpLEInstr& instr)
 {
-    unsupported(instr, "dynamic value comparison");
+    lowerValueCompare(instr, BinaryenLeSInt64());
 }
 
 void WasmFunctionLowerer::visit(VCmpGTInstr& instr)
 {
-    unsupported(instr, "dynamic value comparison");
+    lowerValueCompare(instr, BinaryenGtSInt64());
 }
 
 void WasmFunctionLowerer::visit(VCmpGEInstr& instr)
 {
-    unsupported(instr, "dynamic value comparison");
+    lowerValueCompare(instr, BinaryenGeSInt64());
 }
 
 // }}}

--- a/src/CoreVM/wasm/WasmFunctionLowerer.cpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.cpp
@@ -18,12 +18,14 @@ WasmFunctionLowerer::WasmFunctionLowerer(BinaryenModuleRef module,
                                          WasmOptions const& options,
                                          diagnostics::Report& report,
                                          std::set<RuntimeHelperDef const*>& usedHelpers,
-                                         WasmStringTable& strings):
+                                         WasmStringTable& strings,
+                                         std::unordered_map<int64_t, int64_t> const& slotCounts):
     _module { module },
     _options { options },
     _report { report },
     _usedHelpers { usedHelpers },
-    _strings { strings }
+    _strings { strings },
+    _slotCounts { slotCounts }
 {
 }
 
@@ -64,7 +66,13 @@ void WasmFunctionLowerer::lower(IRFunction* function)
 
     for (auto const& branch: _pendingBranches)
     {
-        auto* condition = branch.condition != nullptr ? asCond(emitValue(branch.condition)) : nullptr;
+        auto* condition = [&]() -> BinaryenExpressionRef {
+            if (branch.condition == nullptr)
+                return nullptr;
+            if (branch.caseLabel != nullptr)
+                return matchCaseCondition(branch.condition, *branch.caseLabel, branch.matchClass);
+            return asCond(emitValue(branch.condition));
+        }();
         RelooperAddBranch(_relooperBlocks[branch.from], _relooperBlocks[branch.to], condition, nullptr);
     }
 
@@ -548,8 +556,61 @@ void WasmFunctionLowerer::visit(RetInstr& instr)
 
 void WasmFunctionLowerer::visit(MatchInstr& instr)
 {
-    unsupported(instr, "match dispatch");
-    pushStatement(BinaryenUnreachable(_module));
+    if (instr.op() == MatchClass::RegExp)
+    {
+        unsupported(instr, "regular expression matching");
+        pushStatement(BinaryenUnreachable(_module));
+        return;
+    }
+    if (instr.elseBlock() == nullptr)
+    {
+        internalError("match dispatch without an else block");
+        pushStatement(BinaryenUnreachable(_module));
+        return;
+    }
+
+    pinValue(instr.condition());
+    // Relooper evaluates branch conditions in insertion order, giving
+    // first-match case semantics.
+    for (auto const& [label, block]: instr.cases())
+        _pendingBranches.push_back(PendingBranch { .from = _currentBlock,
+                                                   .to = block,
+                                                   .condition = instr.condition(),
+                                                   .caseLabel = label,
+                                                   .matchClass = instr.op() });
+    _pendingBranches.push_back(
+        PendingBranch { .from = _currentBlock, .to = instr.elseBlock(), .condition = nullptr });
+}
+
+BinaryenExpressionRef WasmFunctionLowerer::matchCaseCondition(Value* scrutinee,
+                                                              Constant& caseLabel,
+                                                              MatchClass matchClass)
+{
+    auto* lhs = emitValue(scrutinee);
+    auto* rhs = emitValue(&caseLabel);
+    switch (matchClass)
+    {
+        case MatchClass::Same:
+            // String labels compare by content (the VM keys its match tables
+            // by string value, not by interned pointer identity).
+            if (dynamic_cast<ConstantString*>(&caseLabel) != nullptr)
+            {
+                auto args = std::array { asI64(lhs), asI64(rhs) };
+                return asCond(callRuntime("endo_str_eq", args));
+            }
+            return BinaryenBinary(_module, BinaryenEqInt64(), asI64(lhs), asI64(rhs));
+        case MatchClass::Head: {
+            auto args = std::array { asI64(lhs), asI64(rhs) };
+            return asCond(callRuntime("endo_str_starts_with", args));
+        }
+        case MatchClass::Tail: {
+            auto args = std::array { asI64(lhs), asI64(rhs) };
+            return asCond(callRuntime("endo_str_ends_with", args));
+        }
+        case MatchClass::RegExp: break; // rejected in visit(MatchInstr)
+    }
+    internalError("unexpected match class");
+    return BinaryenConst(_module, BinaryenLiteralInt32(0));
 }
 
 // }}}
@@ -737,50 +798,136 @@ void WasmFunctionLowerer::visit(RegExpGroupInstr& instr)
 
 // }}}
 // {{{ object operations
+//
+// Objects live in linear memory with the unified 8-byte header (see
+// WasmRuntimeABI.hpp); slot/tag/typeId access is inlined address math.
+
+uint32_t WasmFunctionLowerer::pinObjectOperand(Value* object)
+{
+    auto const localIndex = scratchLocal(BinaryenTypeInt64());
+    pushStatement(BinaryenLocalSet(_module, localIndex, asI64(emitValue(object))));
+    return localIndex;
+}
+
+BinaryenExpressionRef WasmFunctionLowerer::pinnedPointer(uint32_t localIndex)
+{
+    return BinaryenUnary(
+        _module, BinaryenWrapInt64(), BinaryenLocalGet(_module, localIndex, BinaryenTypeInt64()));
+}
 
 void WasmFunctionLowerer::visit(ObjAllocInstr& instr)
 {
-    unsupported(instr, "object allocation");
+    auto const typeId = instr.typeId()->get();
+    auto const slotCount = _slotCounts.find(typeId);
+    if (slotCount == _slotCounts.end())
+    {
+        unsupported(instr, std::format("allocation of unknown object type id {}", typeId));
+        return;
+    }
+    auto args = std::array {
+        BinaryenConst(_module, BinaryenLiteralInt64(typeId)),
+        BinaryenConst(_module, BinaryenLiteralInt64(slotCount->second)),
+    };
+    setResult(instr, callRuntime("endo_obj_alloc", args), ResultMode::Ordered);
 }
 
 void WasmFunctionLowerer::visit(ObjRetainInstr& instr)
 {
-    unsupported(instr, "object retain");
+    // No reference counting: the bump allocator never frees. The retain's
+    // result aliases the object operand.
+    setResult(instr, asI64(emitValue(instr.object())), ResultMode::Pure);
 }
 
 void WasmFunctionLowerer::visit(ObjReleaseInstr& instr)
 {
-    unsupported(instr, "object release");
+    // No reference counting (see ObjRetainInstr).
+    (void) instr;
 }
 
 void WasmFunctionLowerer::visit(ObjGetTagInstr& instr)
 {
-    unsupported(instr, "object tag access");
+    auto* tag = BinaryenLoad(_module,
+                             1,
+                             false,
+                             layout::TagOffset,
+                             0,
+                             BinaryenTypeInt32(),
+                             BinaryenUnary(_module, BinaryenWrapInt64(), asI64(emitValue(instr.object()))),
+                             "0");
+    setResult(instr, tag, ResultMode::PinIfUsed);
 }
 
 void WasmFunctionLowerer::visit(ObjSetTagInstr& instr)
 {
-    unsupported(instr, "object tag assignment");
+    auto const object = pinObjectOperand(instr.object());
+    auto* tag = BinaryenUnary(_module, BinaryenWrapInt64(), asI64(emitValue(instr.tag())));
+    pushStatement(BinaryenStore(
+        _module, 1, layout::TagOffset, 0, pinnedPointer(object), tag, BinaryenTypeInt32(), "0"));
+    // The instruction's Object-typed result aliases the object operand.
+    _pinned[&instr] = PinnedValue { .localIndex = object, .type = BinaryenTypeInt64() };
 }
 
 void WasmFunctionLowerer::visit(ObjGetSlotInstr& instr)
 {
-    unsupported(instr, "object slot access");
+    auto const offset =
+        layout::HeaderSize + (layout::SlotSize * static_cast<uint32_t>(instr.slotIndex()->get()));
+    auto* slot = BinaryenLoad(_module,
+                              8,
+                              false,
+                              offset,
+                              0,
+                              BinaryenTypeInt64(),
+                              BinaryenUnary(_module, BinaryenWrapInt64(), asI64(emitValue(instr.object()))),
+                              "0");
+    setResult(instr, slot, ResultMode::PinIfUsed);
 }
 
 void WasmFunctionLowerer::visit(ObjSetSlotInstr& instr)
 {
-    unsupported(instr, "object slot assignment");
+    auto const offset =
+        layout::HeaderSize + (layout::SlotSize * static_cast<uint32_t>(instr.slotIndex()->get()));
+    auto const object = pinObjectOperand(instr.object());
+    pushStatement(BinaryenStore(_module,
+                                8,
+                                offset,
+                                0,
+                                pinnedPointer(object),
+                                asI64(emitValue(instr.value())),
+                                BinaryenTypeInt64(),
+                                "0"));
+    // The instruction's Object-typed result aliases the object operand.
+    _pinned[&instr] = PinnedValue { .localIndex = object, .type = BinaryenTypeInt64() };
 }
 
 void WasmFunctionLowerer::visit(ObjTypeIdInstr& instr)
 {
-    unsupported(instr, "object type-id access");
+    auto* typeId = BinaryenLoad(_module,
+                                2,
+                                false,
+                                layout::TypeIdOffset,
+                                0,
+                                BinaryenTypeInt32(),
+                                BinaryenUnary(_module, BinaryenWrapInt64(), asI64(emitValue(instr.object()))),
+                                "0");
+    setResult(instr, typeId, ResultMode::PinIfUsed);
 }
 
 void WasmFunctionLowerer::visit(ObjIsTypeInstr& instr)
 {
-    unsupported(instr, "object type test");
+    auto* typeId = BinaryenLoad(_module,
+                                2,
+                                false,
+                                layout::TypeIdOffset,
+                                0,
+                                BinaryenTypeInt32(),
+                                BinaryenUnary(_module, BinaryenWrapInt64(), asI64(emitValue(instr.object()))),
+                                "0");
+    auto* test = BinaryenBinary(
+        _module,
+        BinaryenEqInt32(),
+        typeId,
+        BinaryenConst(_module, BinaryenLiteralInt32(static_cast<int32_t>(instr.typeId()->get()))));
+    setResult(instr, test, ResultMode::PinIfUsed);
 }
 
 // }}}

--- a/src/CoreVM/wasm/WasmFunctionLowerer.cpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.cpp
@@ -17,8 +17,13 @@ namespace CoreVM::wasm
 WasmFunctionLowerer::WasmFunctionLowerer(BinaryenModuleRef module,
                                          WasmOptions const& options,
                                          diagnostics::Report& report,
-                                         std::set<RuntimeHelperDef const*>& usedHelpers):
-    _module { module }, _options { options }, _report { report }, _usedHelpers { usedHelpers }
+                                         std::set<RuntimeHelperDef const*>& usedHelpers,
+                                         WasmStringTable& strings):
+    _module { module },
+    _options { options },
+    _report { report },
+    _usedHelpers { usedHelpers },
+    _strings { strings }
 {
 }
 
@@ -128,6 +133,10 @@ BinaryenExpressionRef WasmFunctionLowerer::emitValue(Value* value)
 
     if (auto* constFloat = dynamic_cast<ConstantFloat*>(value))
         return BinaryenConst(_module, BinaryenLiteralFloat64(constFloat->get()));
+
+    if (auto* constString = dynamic_cast<ConstantString*>(value))
+        return BinaryenConst(_module,
+                             BinaryenLiteralInt64(static_cast<int64_t>(_strings.intern(constString->get()))));
 
     if (auto* alloca = dynamic_cast<AllocaInstr*>(value))
     {
@@ -399,6 +408,22 @@ void WasmFunctionLowerer::visit(CallInstr& instr)
             mapDummyResultForUses();
             return;
         case BuiltinInlineOp::Ignore: mapDummyResultForUses(); return;
+        case BuiltinInlineOp::ObjectToString: {
+            // Prefer compile-time type dispatch over the runtime pointer/number
+            // classifier: it is both faster and immune to value aliasing.
+            auto* argument = instr.operands().size() > 1 ? instr.operand(1) : nullptr;
+            auto const argumentType = argument != nullptr ? argument->type() : LiteralType::Void;
+            if (argumentType == LiteralType::String)
+            {
+                setResult(instr, args.empty() ? zeroI64() : args[0], ResultMode::Pure);
+                return;
+            }
+            auto const* helper = (argumentType == LiteralType::Number || argumentType == LiteralType::Boolean)
+                                     ? "endo_i64_to_str"
+                                     : "endo_object_to_string";
+            setResult(instr, callRuntime(helper, args), ResultMode::Ordered);
+            return;
+        }
         case BuiltinInlineOp::None: break;
     }
 
@@ -463,8 +488,14 @@ void WasmFunctionLowerer::visit(BrInstr& instr)
 void WasmFunctionLowerer::visit(RetInstr& instr)
 {
     // RetInstr terminates the *program* (VM: EXIT), not the current function.
+    // Shell semantics (Shell::execute): an exit status set during execution
+    // wins; otherwise the EXIT operand collapses to 1 (non-zero) or 0.
     auto* code = instr.operands().empty() ? zeroI64() : asI64(emitValue(instr.operand(0)));
-    auto exitCode = std::array { BinaryenUnary(_module, BinaryenWrapInt64(), code) };
+    auto const statusName = std::string(layout::ExitStatusGlobal);
+    auto* status = BinaryenGlobalGet(_module, statusName.c_str(), BinaryenTypeInt32());
+    auto* statusAgain = BinaryenGlobalGet(_module, statusName.c_str(), BinaryenTypeInt32());
+    auto* operandNonZero = BinaryenBinary(_module, BinaryenNeInt64(), code, zeroI64());
+    auto exitCode = std::array { BinaryenSelect(_module, status, statusAgain, operandNonZero) };
     pushStatement(BinaryenCall(_module,
                                "proc_exit",
                                exitCode.data(),

--- a/src/CoreVM/wasm/WasmFunctionLowerer.cpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.cpp
@@ -639,7 +639,95 @@ void WasmFunctionLowerer::lowerBinaryOp(Instr& instr, BinaryOperator op)
 
 void WasmFunctionLowerer::visit(CastInstr& instr)
 {
-    unsupported(instr, "type conversion");
+    auto const targetType = instr.type();
+    auto const sourceType = instr.source()->type();
+
+    // Same-type casts are aliases.
+    if (targetType == sourceType)
+    {
+        setResult(instr, emitValue(instr.source()), ResultMode::Pure);
+        return;
+    }
+
+    /// How one (target, source) conversion pair lowers.
+    struct CastRule
+    {
+        enum class Kind : uint8_t
+        {
+            HelperI64, ///< Runtime helper taking the canonical i64 form.
+            HelperF64, ///< Runtime helper taking the f64 view.
+            TruncSat,  ///< f64 -> i64 (non-trapping saturating truncation).
+            Convert,   ///< i64 -> f64 numeric conversion.
+        };
+        Kind kind;
+        std::string_view helper;
+    };
+
+    using Kind = CastRule::Kind;
+
+    // Mirrors TargetCodeGenerator's cast matrix: dynamic types (Void/Object)
+    // are treated as numbers at runtime.
+    static auto const matrix = std::unordered_map<LiteralType, std::unordered_map<LiteralType, CastRule>> {
+        { LiteralType::String,
+          {
+              { LiteralType::Number, { .kind = Kind::HelperI64, .helper = "endo_i64_to_str" } },
+              { LiteralType::Boolean, { .kind = Kind::HelperI64, .helper = "endo_i64_to_str" } },
+              { LiteralType::Void, { .kind = Kind::HelperI64, .helper = "endo_i64_to_str" } },
+              { LiteralType::Object, { .kind = Kind::HelperI64, .helper = "endo_i64_to_str" } },
+              { LiteralType::Float, { .kind = Kind::HelperF64, .helper = "endo_f64_to_str_g" } },
+          } },
+        { LiteralType::Number,
+          {
+              { LiteralType::String, { .kind = Kind::HelperI64, .helper = "endo_str_to_i64" } },
+              { LiteralType::Float, { .kind = Kind::TruncSat } },
+          } },
+        { LiteralType::Float,
+          {
+              { LiteralType::Number, { .kind = Kind::Convert } },
+              { LiteralType::Void, { .kind = Kind::Convert } },
+              { LiteralType::Object, { .kind = Kind::Convert } },
+              { LiteralType::String, { .kind = Kind::HelperI64, .helper = "endo_str_to_f64" } },
+          } },
+    };
+
+    auto const targetIt = matrix.find(targetType);
+    auto const* rule = [&]() -> CastRule const* {
+        if (targetIt == matrix.end())
+            return nullptr;
+        auto const sourceIt = targetIt->second.find(sourceType);
+        return sourceIt != targetIt->second.end() ? &sourceIt->second : nullptr;
+    }();
+    if (rule == nullptr)
+    {
+        unsupported(instr, std::format("conversion from {} to {}", tos(sourceType), tos(targetType)));
+        return;
+    }
+
+    switch (rule->kind)
+    {
+        case Kind::HelperI64: {
+            auto args = std::array { asI64(emitValue(instr.source())) };
+            setResult(instr, callRuntime(rule->helper, args), ResultMode::Ordered);
+            return;
+        }
+        case Kind::HelperF64: {
+            auto args = std::array { asF64(emitValue(instr.source())) };
+            setResult(instr, callRuntime(rule->helper, args), ResultMode::Ordered);
+            return;
+        }
+        case Kind::TruncSat:
+            setResult(
+                instr,
+                BinaryenUnary(_module, BinaryenTruncSatSFloat64ToInt64(), asF64(emitValue(instr.source()))),
+                ResultMode::Pure);
+            return;
+        case Kind::Convert:
+            setResult(
+                instr,
+                BinaryenUnary(_module, BinaryenConvertSInt64ToFloat64(), asI64(emitValue(instr.source()))),
+                ResultMode::Pure);
+            return;
+    }
 }
 
 void WasmFunctionLowerer::visit(RegExpGroupInstr& instr)

--- a/src/CoreVM/wasm/WasmFunctionLowerer.hpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.hpp
@@ -272,6 +272,12 @@ class WasmFunctionLowerer final: public InstructionVisitor
     [[nodiscard]] BinaryenExpressionRef callRuntime(std::string_view helperName,
                                                     std::span<BinaryenExpressionRef const> args);
 
+    /// A fresh i64 zero constant.
+    [[nodiscard]] BinaryenExpressionRef zeroI64();
+
+    /// Lowers a raw-value comparison (VCmp*): compares the canonical i64 forms.
+    void lowerValueCompare(Instr& instr, BinaryenOp compareOp);
+
     /// Coerces an expression to the canonical i64 representation.
     [[nodiscard]] BinaryenExpressionRef asI64(BinaryenExpressionRef expr);
     /// Coerces an expression to f64 (bit-cast from the canonical i64 form).

--- a/src/CoreVM/wasm/WasmFunctionLowerer.hpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.hpp
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <CoreVM/Diagnostics.hpp>
+#include <CoreVM/ir/Instructions.hpp>
+#include <CoreVM/wasm/WasmCodeGenerator.hpp>
+#include <CoreVM/wasm/WasmRuntimeABI.hpp>
+
+#include <cstdint>
+#include <set>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include <binaryen-c.h>
+
+namespace CoreVM
+{
+class BasicBlock;
+class IRFunction;
+} // namespace CoreVM
+
+namespace CoreVM::wasm
+{
+
+/// Lowers a single IRFunction into a WASM function of the module under
+/// construction.
+///
+/// Lowering strategy:
+/// - `transform::materializeCrossBlockValues` runs first, so SSA values never
+///   cross basic-block boundaries except through allocas. Allocas map to WASM
+///   locals, Load/Store to local.get/local.set.
+/// - Every VM-visible value is canonically i64 (see WasmRuntimeABI.hpp).
+///   Expressions are kept at their natural type (i32 comparisons, f64 float
+///   arithmetic) and coerced lazily via asI64/asF64/asCond.
+/// - Within a block, pure single-use values inline as binaryen expression
+///   trees; side-effecting or multiply-used values are pinned to scratch
+///   locals in IR order.
+/// - Control flow is structured with binaryen's relooper: one relooper block
+///   per BasicBlock, branches recorded while visiting terminators.
+class WasmFunctionLowerer final: public InstructionVisitor
+{
+  public:
+    /// @param module      the binaryen module under construction
+    /// @param options     compilation options
+    /// @param report      receives diagnostics (unsupported constructs, internal errors)
+    /// @param usedHelpers accumulates the runtime helpers referenced by generated code
+    WasmFunctionLowerer(BinaryenModuleRef module,
+                        WasmOptions const& options,
+                        diagnostics::Report& report,
+                        std::set<RuntimeHelperDef const*>& usedHelpers);
+
+    /// Lowers @p function and adds it to the module.
+    void lower(IRFunction* function);
+
+    /// Mangles an IR function name (e.g. "@main") into its WASM function name
+    /// (e.g. "fn$@main"), avoiding collisions with runtime helpers and _start.
+    [[nodiscard]] static std::string mangledName(std::string_view irName);
+
+    // misc
+    void visit(NopInstr& instr) override;
+    void visit(AllocaInstr& instr) override;
+    void visit(StoreInstr& instr) override;
+    void visit(LoadInstr& instr) override;
+    void visit(PhiNode& instr) override;
+
+    // calls
+    void visit(CallInstr& instr) override;
+    void visit(FunctionCallInstr& instr) override;
+    void visit(FunctionRetInstr& instr) override;
+    void visit(TailCallInstr& instr) override;
+
+    // terminators
+    void visit(CondBrInstr& instr) override;
+    void visit(BrInstr& instr) override;
+    void visit(RetInstr& instr) override;
+    void visit(MatchInstr& instr) override;
+
+    // regexp
+    void visit(RegExpGroupInstr& instr) override;
+
+    // type cast
+    void visit(CastInstr& instr) override;
+
+    // numeric
+    void visit(INegInstr& instr) override { lowerUnaryOp(instr, instr.op()); }
+
+    void visit(INotInstr& instr) override { lowerUnaryOp(instr, instr.op()); }
+
+    void visit(IAddInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(ISubInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(IMulInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(IDivInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(IRemInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(IPowInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(IAndInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(IOrInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(IXorInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(IShlInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(IShrInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(ICmpEQInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(ICmpNEInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(ICmpLEInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(ICmpGEInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(ICmpLTInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(ICmpGTInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    // boolean
+    void visit(BNotInstr& instr) override { lowerUnaryOp(instr, instr.op()); }
+
+    void visit(BAndInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(BOrInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(BXorInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    // string
+    void visit(SLenInstr& instr) override { lowerUnaryOp(instr, instr.op()); }
+
+    void visit(SIsEmptyInstr& instr) override { lowerUnaryOp(instr, instr.op()); }
+
+    void visit(SAddInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(SSubStrInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(SCmpEQInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(SCmpNEInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(SCmpLEInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(SCmpGEInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(SCmpLTInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(SCmpGTInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(SCmpREInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(SCmpBegInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(SCmpEndInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(SInInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    // ip
+    void visit(PCmpEQInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(PCmpNEInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(PInCidrInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    // float
+    void visit(FNegInstr& instr) override { lowerUnaryOp(instr, instr.op()); }
+
+    void visit(FAddInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(FSubInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(FMulInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(FDivInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(FRemInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(FPowInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(FCmpEQInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(FCmpNEInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(FCmpLEInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(FCmpGEInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(FCmpLTInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    void visit(FCmpGTInstr& instr) override { lowerBinaryOp(instr, instr.op()); }
+
+    // object operations
+    void visit(ObjAllocInstr& instr) override;
+    void visit(ObjRetainInstr& instr) override;
+    void visit(ObjReleaseInstr& instr) override;
+    void visit(ObjGetTagInstr& instr) override;
+    void visit(ObjSetTagInstr& instr) override;
+    void visit(ObjGetSlotInstr& instr) override;
+    void visit(ObjSetSlotInstr& instr) override;
+    void visit(ObjTypeIdInstr& instr) override;
+    void visit(ObjIsTypeInstr& instr) override;
+
+    // dynamic value comparison
+    void visit(VCmpEQInstr& instr) override;
+    void visit(VCmpNEInstr& instr) override;
+    void visit(VCmpLTInstr& instr) override;
+    void visit(VCmpLEInstr& instr) override;
+    void visit(VCmpGTInstr& instr) override;
+    void visit(VCmpGEInstr& instr) override;
+
+    // indirect function calls
+    void visit(IndirectCallInstr& instr) override;
+    void visit(IndirectTailCallInstr& instr) override;
+
+    // lazy evaluation
+    void visit(FunctionRefInstr& instr) override;
+    void visit(LazyForceInstr& instr) override;
+
+  private:
+    /// How an instruction's result expression is integrated into the output.
+    enum class ResultMode : uint8_t
+    {
+        Pure,      ///< No side effects: inline if single-use, pin if multi-use, drop if unused.
+        PinIfUsed, ///< No side effects but order-sensitive (e.g. loads): pin if used, drop if unused.
+        Ordered,   ///< Side effects: evaluate at this program point (pin or Drop).
+    };
+
+    /// A conditional or unconditional edge between two basic blocks, recorded
+    /// while visiting terminators and applied to the relooper afterwards.
+    struct PendingBranch
+    {
+        BasicBlock* from;
+        BasicBlock* to;
+        Value* condition; ///< nullptr for the unconditional/default edge.
+    };
+
+    /// A value pinned into a scratch local.
+    struct PinnedValue
+    {
+        uint32_t localIndex;
+        BinaryenType type;
+    };
+
+    void assignLocals();
+    void lowerBlock(BasicBlock& block);
+
+    /// Materializes an operand as a fresh binaryen expression.
+    [[nodiscard]] BinaryenExpressionRef emitValue(Value* value);
+
+    /// Integrates an instruction result according to @p mode.
+    void setResult(Instr& instr, BinaryenExpressionRef expr, ResultMode mode);
+
+    /// Forces @p value into a scratch local so it can be re-read later
+    /// (used for terminator operands consumed during branch emission).
+    void pinValue(Value* value);
+
+    /// Moves @p expr into a fresh scratch local, recording it for @p value.
+    void pin(Value& value, BinaryenExpressionRef expr);
+
+    /// Allocates a new scratch local of the given type.
+    [[nodiscard]] uint32_t scratchLocal(BinaryenType type);
+
+    void pushStatement(BinaryenExpressionRef expr) { _statements.push_back(expr); }
+
+    /// Emits a call to a runtime helper (recording it as used).
+    [[nodiscard]] BinaryenExpressionRef callRuntime(std::string_view helperName,
+                                                    std::span<BinaryenExpressionRef const> args);
+
+    /// Coerces an expression to the canonical i64 representation.
+    [[nodiscard]] BinaryenExpressionRef asI64(BinaryenExpressionRef expr);
+    /// Coerces an expression to f64 (bit-cast from the canonical i64 form).
+    [[nodiscard]] BinaryenExpressionRef asF64(BinaryenExpressionRef expr);
+    /// Coerces an expression to an i32 branch condition (non-zero test).
+    [[nodiscard]] BinaryenExpressionRef asCond(BinaryenExpressionRef expr);
+
+    void lowerUnaryOp(Instr& instr, UnaryOperator op);
+    void lowerBinaryOp(Instr& instr, BinaryOperator op);
+
+    /// Reports an unsupported-construct diagnostic and poisons the result.
+    void unsupported(Instr& instr, std::string_view what);
+    /// Reports a backend bug (invariant violation), distinct from user-facing limitations.
+    void internalError(std::string_view what);
+
+    BinaryenModuleRef _module;
+    WasmOptions const& _options;
+    diagnostics::Report& _report;
+    std::set<RuntimeHelperDef const*>& _usedHelpers;
+
+    IRFunction* _function = nullptr;
+    BasicBlock* _currentBlock = nullptr;
+    Instr* _currentInstr = nullptr;
+
+    uint32_t _paramCount = 0;
+    std::vector<BinaryenType> _varTypes; ///< Types of non-parameter locals (allocas + scratch).
+    std::unordered_map<AllocaInstr const*, uint32_t> _localIndex;
+    std::unordered_map<Value const*, BinaryenExpressionRef> _valueMap; ///< Un-consumed pure expressions.
+    std::unordered_map<Value const*, PinnedValue> _pinned;
+    std::vector<BinaryenExpressionRef> _statements;
+    std::vector<PendingBranch> _pendingBranches;
+    std::unordered_map<BasicBlock*, RelooperBlockRef> _relooperBlocks;
+};
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmFunctionLowerer.hpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.hpp
@@ -253,7 +253,6 @@ class WasmFunctionLowerer final: public InstructionVisitor
     };
 
     void assignLocals();
-    void lowerBlock(BasicBlock& block);
 
     /// Materializes an operand as a fresh binaryen expression.
     [[nodiscard]] BinaryenExpressionRef emitValue(Value* value);
@@ -275,7 +274,7 @@ class WasmFunctionLowerer final: public InstructionVisitor
 
     /// Emits a call to a runtime helper (recording it as used).
     [[nodiscard]] BinaryenExpressionRef callRuntime(std::string_view helperName,
-                                                    std::span<BinaryenExpressionRef const> args);
+                                                    std::span<BinaryenExpressionRef> args);
 
     /// A fresh i64 zero constant.
     [[nodiscard]] BinaryenExpressionRef zeroI64();
@@ -286,6 +285,13 @@ class WasmFunctionLowerer final: public InstructionVisitor
 
     /// The wrapped i32 pointer view of a pinned object local.
     [[nodiscard]] BinaryenExpressionRef pinnedPointer(uint32_t localIndex);
+
+    /// Loads a header field or slot of an object operand (inlined address math
+    /// over the unified cell header; see WasmRuntimeABI.hpp).
+    [[nodiscard]] BinaryenExpressionRef loadObjectField(Value* object,
+                                                        uint32_t bytes,
+                                                        uint32_t offset,
+                                                        BinaryenType type);
 
     /// Builds the i32 condition for one MatchInstr case edge.
     [[nodiscard]] BinaryenExpressionRef matchCaseCondition(Value* scrutinee,

--- a/src/CoreVM/wasm/WasmFunctionLowerer.hpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.hpp
@@ -52,7 +52,8 @@ class WasmFunctionLowerer final: public InstructionVisitor
                         WasmOptions const& options,
                         diagnostics::Report& report,
                         std::set<RuntimeHelperDef const*>& usedHelpers,
-                        WasmStringTable& strings);
+                        WasmStringTable& strings,
+                        std::unordered_map<int64_t, int64_t> const& slotCounts);
 
     /// Lowers @p function and adds it to the module.
     void lower(IRFunction* function);
@@ -237,9 +238,11 @@ class WasmFunctionLowerer final: public InstructionVisitor
     /// while visiting terminators and applied to the relooper afterwards.
     struct PendingBranch
     {
-        BasicBlock* from;
-        BasicBlock* to;
-        Value* condition; ///< nullptr for the unconditional/default edge.
+        BasicBlock* from = nullptr;
+        BasicBlock* to = nullptr;
+        Value* condition = nullptr;               ///< nullptr for the unconditional/default edge.
+        Constant* caseLabel = nullptr;            ///< MatchInstr case: compare condition against this.
+        MatchClass matchClass = MatchClass::Same; ///< MatchInstr case: comparison kind.
     };
 
     /// A value pinned into a scratch local.
@@ -277,6 +280,18 @@ class WasmFunctionLowerer final: public InstructionVisitor
     /// A fresh i64 zero constant.
     [[nodiscard]] BinaryenExpressionRef zeroI64();
 
+    /// Pins an object operand into a fresh i64 scratch local and returns its
+    /// index, so the pointer can be used for a store and aliased as a result.
+    [[nodiscard]] uint32_t pinObjectOperand(Value* object);
+
+    /// The wrapped i32 pointer view of a pinned object local.
+    [[nodiscard]] BinaryenExpressionRef pinnedPointer(uint32_t localIndex);
+
+    /// Builds the i32 condition for one MatchInstr case edge.
+    [[nodiscard]] BinaryenExpressionRef matchCaseCondition(Value* scrutinee,
+                                                           Constant& caseLabel,
+                                                           MatchClass matchClass);
+
     /// Lowers a raw-value comparison (VCmp*): compares the canonical i64 forms.
     void lowerValueCompare(Instr& instr, BinaryenOp compareOp);
 
@@ -300,6 +315,7 @@ class WasmFunctionLowerer final: public InstructionVisitor
     diagnostics::Report& _report;
     std::set<RuntimeHelperDef const*>& _usedHelpers;
     WasmStringTable& _strings;
+    std::unordered_map<int64_t, int64_t> const& _slotCounts; ///< Object typeId -> slot count.
 
     IRFunction* _function = nullptr;
     BasicBlock* _currentBlock = nullptr;

--- a/src/CoreVM/wasm/WasmFunctionLowerer.hpp
+++ b/src/CoreVM/wasm/WasmFunctionLowerer.hpp
@@ -5,6 +5,7 @@
 #include <CoreVM/ir/Instructions.hpp>
 #include <CoreVM/wasm/WasmCodeGenerator.hpp>
 #include <CoreVM/wasm/WasmRuntimeABI.hpp>
+#include <CoreVM/wasm/WasmStringTable.hpp>
 
 #include <cstdint>
 #include <set>
@@ -50,7 +51,8 @@ class WasmFunctionLowerer final: public InstructionVisitor
     WasmFunctionLowerer(BinaryenModuleRef module,
                         WasmOptions const& options,
                         diagnostics::Report& report,
-                        std::set<RuntimeHelperDef const*>& usedHelpers);
+                        std::set<RuntimeHelperDef const*>& usedHelpers,
+                        WasmStringTable& strings);
 
     /// Lowers @p function and adds it to the module.
     void lower(IRFunction* function);
@@ -297,6 +299,7 @@ class WasmFunctionLowerer final: public InstructionVisitor
     WasmOptions const& _options;
     diagnostics::Report& _report;
     std::set<RuntimeHelperDef const*>& _usedHelpers;
+    WasmStringTable& _strings;
 
     IRFunction* _function = nullptr;
     BasicBlock* _currentBlock = nullptr;

--- a/src/CoreVM/wasm/WasmOpTables.cpp
+++ b/src/CoreVM/wasm/WasmOpTables.cpp
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <CoreVM/wasm/WasmOpTables.hpp>
+
+#include <unordered_map>
+
+namespace CoreVM::wasm
+{
+
+namespace
+{
+    using BKind = BinaryOpLowering::Kind;
+    using UKind = UnaryOpLowering::Kind;
+
+    // BinaryenOp values are only obtainable through function calls, so the
+    // tables are function-local statics instead of constexpr arrays.
+    std::unordered_map<BinaryOperator, BinaryOpLowering> makeBinaryOpTable()
+    {
+        return {
+            // numerical
+            { BinaryOperator::IAdd, { .kind = BKind::DirectOp, .op = &BinaryenAddInt64 } },
+            { BinaryOperator::ISub, { .kind = BKind::DirectOp, .op = &BinaryenSubInt64 } },
+            { BinaryOperator::IMul, { .kind = BKind::DirectOp, .op = &BinaryenMulInt64 } },
+            { BinaryOperator::IDiv, { .kind = BKind::HelperCall, .helper = "endo_i64_div" } },
+            { BinaryOperator::IRem, { .kind = BKind::HelperCall, .helper = "endo_i64_rem" } },
+            { BinaryOperator::IPow, { .kind = BKind::HelperCall, .helper = "endo_i64_pow" } },
+            { BinaryOperator::IAnd, { .kind = BKind::DirectOp, .op = &BinaryenAndInt64 } },
+            { BinaryOperator::IOr, { .kind = BKind::DirectOp, .op = &BinaryenOrInt64 } },
+            { BinaryOperator::IXor, { .kind = BKind::DirectOp, .op = &BinaryenXorInt64 } },
+            { BinaryOperator::IShl, { .kind = BKind::DirectOp, .op = &BinaryenShlInt64 } },
+            { BinaryOperator::IShr, { .kind = BKind::DirectOp, .op = &BinaryenShrSInt64 } },
+            { BinaryOperator::ICmpEQ, { .kind = BKind::DirectOp, .op = &BinaryenEqInt64 } },
+            { BinaryOperator::ICmpNE, { .kind = BKind::DirectOp, .op = &BinaryenNeInt64 } },
+            { BinaryOperator::ICmpLE, { .kind = BKind::DirectOp, .op = &BinaryenLeSInt64 } },
+            { BinaryOperator::ICmpGE, { .kind = BKind::DirectOp, .op = &BinaryenGeSInt64 } },
+            { BinaryOperator::ICmpLT, { .kind = BKind::DirectOp, .op = &BinaryenLtSInt64 } },
+            { BinaryOperator::ICmpGT, { .kind = BKind::DirectOp, .op = &BinaryenGtSInt64 } },
+            // boolean (canonical 0/1 i64 values)
+            { BinaryOperator::BAnd, { .kind = BKind::DirectOp, .op = &BinaryenAndInt64 } },
+            { BinaryOperator::BOr, { .kind = BKind::DirectOp, .op = &BinaryenOrInt64 } },
+            { BinaryOperator::BXor, { .kind = BKind::DirectOp, .op = &BinaryenXorInt64 } },
+            // string
+            { BinaryOperator::SAdd, { .kind = BKind::HelperCall, .helper = "endo_str_concat" } },
+            { BinaryOperator::SSubStr, { .kind = BKind::HelperCall, .helper = "endo_str_substr" } },
+            { BinaryOperator::SCmpEQ, { .kind = BKind::HelperCall, .helper = "endo_str_eq" } },
+            { BinaryOperator::SCmpNE,
+              { .kind = BKind::HelperCmp0, .op = &BinaryenEqInt64, .helper = "endo_str_eq" } },
+            { BinaryOperator::SCmpLE,
+              { .kind = BKind::HelperCmp0, .op = &BinaryenLeSInt64, .helper = "endo_str_cmp" } },
+            { BinaryOperator::SCmpGE,
+              { .kind = BKind::HelperCmp0, .op = &BinaryenGeSInt64, .helper = "endo_str_cmp" } },
+            { BinaryOperator::SCmpLT,
+              { .kind = BKind::HelperCmp0, .op = &BinaryenLtSInt64, .helper = "endo_str_cmp" } },
+            { BinaryOperator::SCmpGT,
+              { .kind = BKind::HelperCmp0, .op = &BinaryenGtSInt64, .helper = "endo_str_cmp" } },
+            { BinaryOperator::SCmpRE,
+              { .kind = BKind::Unsupported, .unsupportedWhat = "regular expression matching" } },
+            { BinaryOperator::SCmpBeg, { .kind = BKind::HelperCall, .helper = "endo_str_starts_with" } },
+            { BinaryOperator::SCmpEnd, { .kind = BKind::HelperCall, .helper = "endo_str_ends_with" } },
+            { BinaryOperator::SIn, { .kind = BKind::HelperCall, .helper = "endo_str_contains" } },
+            // float
+            { BinaryOperator::FAdd,
+              { .kind = BKind::DirectOp, .op = &BinaryenAddFloat64, .floatOperands = true } },
+            { BinaryOperator::FSub,
+              { .kind = BKind::DirectOp, .op = &BinaryenSubFloat64, .floatOperands = true } },
+            { BinaryOperator::FMul,
+              { .kind = BKind::DirectOp, .op = &BinaryenMulFloat64, .floatOperands = true } },
+            { BinaryOperator::FDiv,
+              { .kind = BKind::DirectOp, .op = &BinaryenDivFloat64, .floatOperands = true } },
+            { BinaryOperator::FRem,
+              { .kind = BKind::HelperCall, .helper = "endo_f64_rem", .floatOperands = true } },
+            { BinaryOperator::FPow,
+              { .kind = BKind::HelperCall, .helper = "endo_f64_pow", .floatOperands = true } },
+            { BinaryOperator::FCmpEQ,
+              { .kind = BKind::DirectOp, .op = &BinaryenEqFloat64, .floatOperands = true } },
+            { BinaryOperator::FCmpNE,
+              { .kind = BKind::DirectOp, .op = &BinaryenNeFloat64, .floatOperands = true } },
+            { BinaryOperator::FCmpLE,
+              { .kind = BKind::DirectOp, .op = &BinaryenLeFloat64, .floatOperands = true } },
+            { BinaryOperator::FCmpGE,
+              { .kind = BKind::DirectOp, .op = &BinaryenGeFloat64, .floatOperands = true } },
+            { BinaryOperator::FCmpLT,
+              { .kind = BKind::DirectOp, .op = &BinaryenLtFloat64, .floatOperands = true } },
+            { BinaryOperator::FCmpGT,
+              { .kind = BKind::DirectOp, .op = &BinaryenGtFloat64, .floatOperands = true } },
+            // ip
+            { BinaryOperator::PCmpEQ,
+              { .kind = BKind::Unsupported, .unsupportedWhat = "IP address comparison" } },
+            { BinaryOperator::PCmpNE,
+              { .kind = BKind::Unsupported, .unsupportedWhat = "IP address comparison" } },
+            { BinaryOperator::PInCidr,
+              { .kind = BKind::Unsupported, .unsupportedWhat = "CIDR containment test" } },
+        };
+    }
+
+    std::unordered_map<UnaryOperator, UnaryOpLowering> makeUnaryOpTable()
+    {
+        return {
+            { UnaryOperator::INeg, { .kind = UKind::SubFromZero } },
+            { UnaryOperator::INot, { .kind = UKind::XorImmediate, .immediate = -1 } },
+            { UnaryOperator::BNot, { .kind = UKind::XorImmediate, .immediate = 1 } },
+            { UnaryOperator::FNeg,
+              { .kind = UKind::DirectOp, .op = &BinaryenNegFloat64, .floatOperand = true } },
+            { UnaryOperator::SLen, { .kind = UKind::HelperCall, .helper = "endo_str_len" } },
+            { UnaryOperator::SIsEmpty, { .kind = UKind::HelperIsZero, .helper = "endo_str_len" } },
+        };
+    }
+} // namespace
+
+BinaryOpLowering const& binaryOpLowering(BinaryOperator op)
+{
+    static auto const table = makeBinaryOpTable();
+    static auto const unsupportedFallback =
+        BinaryOpLowering { .kind = BKind::Unsupported, .unsupportedWhat = "this operator" };
+    auto const it = table.find(op);
+    return it != table.end() ? it->second : unsupportedFallback;
+}
+
+UnaryOpLowering const& unaryOpLowering(UnaryOperator op)
+{
+    static auto const table = makeUnaryOpTable();
+    static auto const unsupportedFallback =
+        UnaryOpLowering { .kind = UKind::Unsupported, .unsupportedWhat = "this operator" };
+    auto const it = table.find(op);
+    return it != table.end() ? it->second : unsupportedFallback;
+}
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmOpTables.cpp
+++ b/src/CoreVM/wasm/WasmOpTables.cpp
@@ -40,7 +40,10 @@ namespace
             { BinaryOperator::BXor, { .kind = BKind::DirectOp, .op = &BinaryenXorInt64 } },
             // string
             { BinaryOperator::SAdd, { .kind = BKind::HelperCall, .helper = "endo_str_concat" } },
-            { BinaryOperator::SSubStr, { .kind = BKind::HelperCall, .helper = "endo_str_substr" } },
+            // SSubStrInstr is never emitted by the frontend (no IRBuilder factory), and
+            // its two operands do not match the VM's three-operand SSUBSTR semantics.
+            { BinaryOperator::SSubStr,
+              { .kind = BKind::Unsupported, .unsupportedWhat = "substring extraction" } },
             { BinaryOperator::SCmpEQ, { .kind = BKind::HelperCall, .helper = "endo_str_eq" } },
             { BinaryOperator::SCmpNE,
               { .kind = BKind::HelperCmp0, .op = &BinaryenEqInt64, .helper = "endo_str_eq" } },

--- a/src/CoreVM/wasm/WasmOpTables.cpp
+++ b/src/CoreVM/wasm/WasmOpTables.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <CoreVM/wasm/WasmOpTables.hpp>
 
+#include <array>
 #include <unordered_map>
 
 namespace CoreVM::wasm
@@ -125,6 +126,30 @@ UnaryOpLowering const& unaryOpLowering(UnaryOperator op)
         UnaryOpLowering { .kind = UKind::Unsupported, .unsupportedWhat = "this operator" };
     auto const it = table.find(op);
     return it != table.end() ? it->second : unsupportedFallback;
+}
+
+CastLowering const* castLowering(LiteralType target, LiteralType source)
+{
+    using Kind = CastLowering::Kind;
+    using LT = LiteralType;
+    static constexpr auto CastMatrix = std::to_array<CastLowering>({
+        { .target = LT::String, .source = LT::Number, .kind = Kind::HelperI64, .helper = "endo_i64_to_str" },
+        { .target = LT::String, .source = LT::Boolean, .kind = Kind::HelperI64, .helper = "endo_i64_to_str" },
+        { .target = LT::String, .source = LT::Void, .kind = Kind::HelperI64, .helper = "endo_i64_to_str" },
+        { .target = LT::String, .source = LT::Object, .kind = Kind::HelperI64, .helper = "endo_i64_to_str" },
+        { .target = LT::String, .source = LT::Float, .kind = Kind::HelperF64, .helper = "endo_f64_to_str_g" },
+        { .target = LT::Number, .source = LT::String, .kind = Kind::HelperI64, .helper = "endo_str_to_i64" },
+        { .target = LT::Number, .source = LT::Float, .kind = Kind::TruncSat },
+        { .target = LT::Float, .source = LT::Number, .kind = Kind::Convert },
+        { .target = LT::Float, .source = LT::Void, .kind = Kind::Convert },
+        { .target = LT::Float, .source = LT::Object, .kind = Kind::Convert },
+        { .target = LT::Float, .source = LT::String, .kind = Kind::HelperI64, .helper = "endo_str_to_f64" },
+    });
+
+    for (auto const& row: CastMatrix)
+        if (row.target == target && row.source == source)
+            return &row;
+    return nullptr;
 }
 
 } // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmOpTables.hpp
+++ b/src/CoreVM/wasm/WasmOpTables.hpp
@@ -55,10 +55,33 @@ struct UnaryOpLowering
     std::string_view unsupportedWhat; ///< Unsupported: user-facing description.
 };
 
+/// How one (target, source) type conversion lowers to WASM. Mirrors
+/// TargetCodeGenerator's cast matrix: dynamic types (Void/Object) are treated
+/// as numbers at runtime.
+struct CastLowering
+{
+    enum class Kind : uint8_t
+    {
+        HelperI64, ///< Runtime helper taking the canonical i64 form.
+        HelperF64, ///< Runtime helper taking the f64 view.
+        TruncSat,  ///< f64 -> i64 (non-trapping saturating truncation).
+        Convert,   ///< i64 -> f64 numeric conversion.
+    };
+
+    LiteralType target;
+    LiteralType source;
+    Kind kind;
+    std::string_view helper; ///< HelperI64/HelperF64: runtime helper name.
+};
+
 /// Looks up the lowering for a binary operator. Never returns nullptr.
 [[nodiscard]] BinaryOpLowering const& binaryOpLowering(BinaryOperator op);
 
 /// Looks up the lowering for a unary operator. Never returns nullptr.
 [[nodiscard]] UnaryOpLowering const& unaryOpLowering(UnaryOperator op);
+
+/// Looks up the lowering for a type conversion.
+/// @return the matching row, or nullptr if the conversion is unsupported.
+[[nodiscard]] CastLowering const* castLowering(LiteralType target, LiteralType source);
 
 } // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmOpTables.hpp
+++ b/src/CoreVM/wasm/WasmOpTables.hpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <CoreVM/enums.hpp>
+
+#include <cstdint>
+#include <string_view>
+
+#include <binaryen-c.h>
+
+/// @file
+/// Data-driven lowering tables for the IR operator families (I*, B*, S*, F*,
+/// P*). Adding or changing an operator lowering means changing a table row,
+/// not writing new visitor logic.
+
+namespace CoreVM::wasm
+{
+
+/// How one IR binary operator lowers to WASM.
+struct BinaryOpLowering
+{
+    enum class Kind : uint8_t
+    {
+        DirectOp,    ///< One binaryen instruction (op).
+        HelperCall,  ///< Call a runtime helper (helper).
+        HelperCmp0,  ///< helper(lhs, rhs) <op> 0 — for three-way comparison helpers.
+        Unsupported, ///< Clean compile-time error (unsupportedWhat).
+    };
+
+    Kind kind = Kind::Unsupported;
+    BinaryenOp (*op)() = nullptr;     ///< DirectOp: the instruction; HelperCmp0: the comparison.
+    std::string_view helper;          ///< HelperCall/HelperCmp0: runtime helper name.
+    bool floatOperands = false;       ///< Coerce operands to f64 instead of i64.
+    std::string_view unsupportedWhat; ///< Unsupported: user-facing description.
+};
+
+/// How one IR unary operator lowers to WASM.
+struct UnaryOpLowering
+{
+    enum class Kind : uint8_t
+    {
+        DirectOp,     ///< One binaryen unary instruction (op).
+        SubFromZero,  ///< i64.sub(0, x) — integer negation.
+        XorImmediate, ///< i64.xor(x, immediate) — bitwise/boolean not.
+        HelperCall,   ///< Call a runtime helper (helper).
+        HelperIsZero, ///< i64.eqz(helper(x)) — e.g. string emptiness via length.
+        Unsupported,  ///< Clean compile-time error (unsupportedWhat).
+    };
+
+    Kind kind = Kind::Unsupported;
+    BinaryenOp (*op)() = nullptr;     ///< DirectOp: the instruction.
+    std::string_view helper;          ///< HelperCall/HelperIsZero: runtime helper name.
+    int64_t immediate = 0;            ///< XorImmediate: the constant.
+    bool floatOperand = false;        ///< Coerce the operand to f64 instead of i64.
+    std::string_view unsupportedWhat; ///< Unsupported: user-facing description.
+};
+
+/// Looks up the lowering for a binary operator. Never returns nullptr.
+[[nodiscard]] BinaryOpLowering const& binaryOpLowering(BinaryOperator op);
+
+/// Looks up the lowering for a unary operator. Never returns nullptr.
+[[nodiscard]] UnaryOpLowering const& unaryOpLowering(UnaryOperator op);
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmRuntime.cpp
+++ b/src/CoreVM/wasm/WasmRuntime.cpp
@@ -262,6 +262,19 @@ void WasmRuntime::require(std::string_view name)
         { "endo_result_str", &WasmRuntime::buildResultStr },
         { "endo_tuple2_str", &WasmRuntime::buildTuple2Str },
         { "endo_tuple3_str", &WasmRuntime::buildTuple3Str },
+        { "endo_display_result", &WasmRuntime::buildDisplayResult },
+        { "endo_cons", &WasmRuntime::buildCons },
+        { "endo_some", &WasmRuntime::buildSome },
+        { "endo_list_length", &WasmRuntime::buildListLength },
+        { "endo_list_is_empty", &WasmRuntime::buildListIsEmpty },
+        { "endo_list_head", &WasmRuntime::buildListHead },
+        { "endo_list_tail", &WasmRuntime::buildListTail },
+        { "endo_list_nth", &WasmRuntime::buildListNth },
+        { "endo_list_concat", &WasmRuntime::buildListConcat },
+        { "endo_f64_rem", &WasmRuntime::buildF64Rem },
+        { "endo_f64_pow", &WasmRuntime::buildF64Pow },
+        { "endo_str_to_f64", &WasmRuntime::buildStrToF64 },
+        { "endo_f64_to_str_g", &WasmRuntime::buildF64ToStrG },
     };
 
     if (auto const it = builders.find(name); it != builders.end())
@@ -1300,6 +1313,564 @@ void WasmRuntime::buildTuple3Str()
     });
 
     e.addFunction("endo_tuple3_str", { I64() }, I64(), { I32(), I64() }, body);
+}
+
+// endo_display_result(v: i64) — println of the recursively formatted value.
+void WasmRuntime::buildDisplayResult()
+{
+    require("endo_value_to_str");
+    require("endo_println");
+    auto e = Emit { _module };
+    auto* body = e.callVoid("endo_println", { e.call("endo_value_to_str", { e.get64(0) }, I64()) });
+    e.addFunction("endo_display_result", { I64() }, BinaryenTypeNone(), {}, body);
+}
+
+// endo_cons(head: i64, tail: i64, elemType: i64) -> i64 — allocates one
+// List cons cell (typeId 5, tag 1; slots: head, tail, element type).
+void WasmRuntime::buildCons()
+{
+    require("endo_obj_alloc");
+    auto e = Emit { _module };
+
+    // params: 0=head, 1=tail, 2=elemType; locals: 3=p
+    auto* body = e.block({
+        e.set(3, e.wrap(e.call("endo_obj_alloc", { e.i64(TypeIdList), e.i64(3) }, I64()))),
+        e.store8(e.get32(3), e.i32(1), layout::TagOffset),
+        e.store64(e.get32(3), e.get64(0), layout::HeaderSize),
+        e.store64(e.get32(3), e.get64(1), layout::HeaderSize + layout::SlotSize),
+        e.store64(e.get32(3), e.get64(2), layout::HeaderSize + (2 * layout::SlotSize)),
+        e.ret(e.extendU(e.get32(3))),
+    });
+
+    e.addFunction("endo_cons", { I64(), I64(), I64() }, I64(), { I32() }, body);
+}
+
+// endo_some(value: i64, innerType: i64) -> i64 — allocates Some(value)
+// (Option typeId 1, tag 1; slots: value, inner type).
+void WasmRuntime::buildSome()
+{
+    require("endo_obj_alloc");
+    auto e = Emit { _module };
+
+    // params: 0=value, 1=innerType; locals: 2=p
+    auto* body = e.block({
+        e.set(2, e.wrap(e.call("endo_obj_alloc", { e.i64(TypeIdOption), e.i64(2) }, I64()))),
+        e.store8(e.get32(2), e.i32(1), layout::TagOffset),
+        e.store64(e.get32(2), e.get64(0), layout::HeaderSize),
+        e.store64(e.get32(2), e.get64(1), layout::HeaderSize + layout::SlotSize),
+        e.ret(e.extendU(e.get32(2))),
+    });
+
+    e.addFunction("endo_some", { I64(), I64() }, I64(), { I32() }, body);
+}
+
+namespace
+{
+    /// Condition: local #index holds a pointer to a Cons cell (non-null, tag 1).
+    BinaryenExpressionRef isConsCell(Emit const& e, BinaryenIndex index)
+    {
+        return e.bin(BinaryenAndInt32(),
+                     e.bin(BinaryenNeInt32(), e.get32(index), e.i32(0)),
+                     e.bin(BinaryenEqInt32(), e.load8u(e.get32(index), layout::TagOffset), e.i32(1)));
+    }
+} // namespace
+
+// endo_list_length(list: i64) -> i64
+void WasmRuntime::buildListLength()
+{
+    auto e = Emit { _module };
+
+    // params: 0=list; locals: 1=cur i32, 2=count i64
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.block({ e.loop("walk",
+                         e.block({
+                             e.brIf("walk.done", e.un(BinaryenEqZInt32(), isConsCell(e, 1))),
+                             e.set(2, e.bin(BinaryenAddInt64(), e.get64(2), e.i64(1))),
+                             e.set(1, e.wrap(e.load64(e.get32(1), layout::HeaderSize + layout::SlotSize))),
+                             e.br("walk"),
+                         })) },
+                "walk.done"),
+        e.ret(e.get64(2)),
+    });
+
+    e.addFunction("endo_list_length", { I64() }, I64(), { I32(), I64() }, body);
+}
+
+// endo_list_is_empty(list: i64) -> i64 — true for null or Nil.
+void WasmRuntime::buildListIsEmpty()
+{
+    auto e = Emit { _module };
+    // params: 0=list; locals: 1=p
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.ret(e.extendU(e.un(BinaryenEqZInt32(), isConsCell(e, 1)))),
+    });
+    e.addFunction("endo_list_is_empty", { I64() }, I64(), { I32() }, body);
+}
+
+// endo_list_head(list: i64) -> i64 — Some(head) or None.
+void WasmRuntime::buildListHead()
+{
+    require("endo_obj_alloc");
+    require("endo_some");
+    auto e = Emit { _module };
+
+    // params: 0=list; locals: 1=p
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        // empty: a fresh Option cell with tag 0 (zeroed slots) is None
+        e.ifThen(e.un(BinaryenEqZInt32(), isConsCell(e, 1)),
+                 e.ret(e.call("endo_obj_alloc", { e.i64(TypeIdOption), e.i64(2) }, I64()))),
+        e.ret(e.call("endo_some",
+                     { e.load64(e.get32(1), layout::HeaderSize),
+                       e.load64(e.get32(1), layout::HeaderSize + (2 * layout::SlotSize)) },
+                     I64())),
+    });
+
+    e.addFunction("endo_list_head", { I64() }, I64(), { I32() }, body);
+}
+
+// endo_list_tail(list: i64) -> i64 — the tail list, or Nil for empty input.
+void WasmRuntime::buildListTail()
+{
+    require("endo_obj_alloc");
+    auto e = Emit { _module };
+
+    // params: 0=list; locals: 1=p
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        // empty: a fresh List cell with tag 0 (zeroed slots) is Nil
+        e.ifThen(e.un(BinaryenEqZInt32(), isConsCell(e, 1)),
+                 e.ret(e.call("endo_obj_alloc", { e.i64(TypeIdList), e.i64(3) }, I64()))),
+        e.ret(e.load64(e.get32(1), layout::HeaderSize + layout::SlotSize)),
+    });
+
+    e.addFunction("endo_list_tail", { I64() }, I64(), { I32() }, body);
+}
+
+// endo_list_nth(index: i64, list: i64) -> i64 — Some(element) or None.
+// (Argument order matches the VM callback: index first.)
+void WasmRuntime::buildListNth()
+{
+    require("endo_obj_alloc");
+    require("endo_some");
+    auto e = Emit { _module };
+
+    // params: 0=index, 1=list; locals: 2=cur i32, 3=i i64
+    auto* body = e.block({
+        e.set(2, e.wrap(e.get64(1))),
+        e.block({ e.loop("walk",
+                         e.block({
+                             e.brIf("walk.done", e.un(BinaryenEqZInt32(), isConsCell(e, 2))),
+                             e.brIf("walk.done", e.bin(BinaryenGeSInt64(), e.get64(3), e.get64(0))),
+                             e.set(2, e.wrap(e.load64(e.get32(2), layout::HeaderSize + layout::SlotSize))),
+                             e.set(3, e.bin(BinaryenAddInt64(), e.get64(3), e.i64(1))),
+                             e.br("walk"),
+                         })) },
+                "walk.done"),
+        e.ifThen(
+            e.bin(BinaryenAndInt32(), isConsCell(e, 2), e.bin(BinaryenEqInt64(), e.get64(3), e.get64(0))),
+            e.ret(e.call("endo_some",
+                         { e.load64(e.get32(2), layout::HeaderSize),
+                           e.load64(e.get32(2), layout::HeaderSize + (2 * layout::SlotSize)) },
+                         I64()))),
+        e.ret(e.call("endo_obj_alloc", { e.i64(TypeIdOption), e.i64(2) }, I64())),
+    });
+
+    e.addFunction("endo_list_nth", { I64(), I64() }, I64(), { I32(), I64() }, body);
+}
+
+// endo_list_concat(left: i64, right: i64) -> i64 — copies the left list's
+// cells in front of the right list (recursively; depth = |left|).
+void WasmRuntime::buildListConcat()
+{
+    require("endo_cons");
+    auto e = Emit { _module };
+
+    // params: 0=left, 1=right; locals: 2=p
+    auto* body = e.block({
+        e.set(2, e.wrap(e.get64(0))),
+        e.ifThen(e.un(BinaryenEqZInt32(), isConsCell(e, 2)), e.ret(e.get64(1))),
+        e.ret(e.call("endo_cons",
+                     { e.load64(e.get32(2), layout::HeaderSize),
+                       e.call("endo_list_concat",
+                              { e.load64(e.get32(2), layout::HeaderSize + layout::SlotSize), e.get64(1) },
+                              I64()),
+                       e.load64(e.get32(2), layout::HeaderSize + (2 * layout::SlotSize)) },
+                     I64())),
+    });
+
+    e.addFunction("endo_list_concat", { I64(), I64() }, I64(), { I32() }, body);
+}
+
+// endo_f64_rem(a, b) -> f64 — a - trunc(a/b)*b. Matches std::fmod for
+// typical magnitudes; extreme a/b ratios may differ in the last ulp
+// (documented deviation). fmod(x, 0) yields nan as in the VM.
+void WasmRuntime::buildF64Rem()
+{
+    auto e = Emit { _module };
+    auto* body =
+        e.ret(e.bin(BinaryenSubFloat64(),
+                    e.getF64(0),
+                    e.bin(BinaryenMulFloat64(),
+                          e.un(BinaryenTruncFloat64(), e.bin(BinaryenDivFloat64(), e.getF64(0), e.getF64(1))),
+                          e.getF64(1))));
+    e.addFunction(
+        "endo_f64_rem", { BinaryenTypeFloat64(), BinaryenTypeFloat64() }, BinaryenTypeFloat64(), {}, body);
+}
+
+// endo_f64_pow(base, exp) -> f64 — square-and-multiply for integral
+// exponents (negative via reciprocal); non-integral exponents are a
+// runtime error (no exp/log in this runtime yet).
+void WasmRuntime::buildF64Pow()
+{
+    require("endo_panic");
+    auto e = Emit { _module };
+    auto const nonIntegral =
+        static_cast<int64_t>(_strings->intern("float ** with a non-integer exponent is not supported"));
+
+    // params: 0=base f64, 1=exp f64; locals: 2=n i64, 3=result f64, 4=b f64
+    auto* body = e.block({
+        e.set(2, e.un(BinaryenTruncSatSFloat64ToInt64(), e.getF64(1))),
+        e.ifThen(e.bin(BinaryenNeFloat64(), e.un(BinaryenConvertSInt64ToFloat64(), e.get64(2)), e.getF64(1)),
+                 e.callVoid("endo_panic", { e.i64(nonIntegral) })),
+        e.set(4, e.getF64(0)),
+        e.ifThen(e.bin(BinaryenLtSInt64(), e.get64(2), e.i64(0)),
+                 e.block({
+                     e.set(4, e.bin(BinaryenDivFloat64(), e.f64(1.0), e.getF64(4))),
+                     e.set(2, e.bin(BinaryenSubInt64(), e.i64(0), e.get64(2))),
+                 })),
+        e.set(3, e.f64(1.0)),
+        e.block({ e.loop("pow",
+                         e.block({
+                             e.brIf("pow.done", e.un(BinaryenEqZInt64(), e.get64(2))),
+                             e.ifThen(e.wrap(e.bin(BinaryenAndInt64(), e.get64(2), e.i64(1))),
+                                      e.set(3, e.bin(BinaryenMulFloat64(), e.getF64(3), e.getF64(4)))),
+                             e.set(4, e.bin(BinaryenMulFloat64(), e.getF64(4), e.getF64(4))),
+                             e.set(2, e.bin(BinaryenShrUInt64(), e.get64(2), e.i64(1))),
+                             e.br("pow"),
+                         })) },
+                "pow.done"),
+        e.ret(e.getF64(3)),
+    });
+
+    e.addFunction("endo_f64_pow",
+                  { BinaryenTypeFloat64(), BinaryenTypeFloat64() },
+                  BinaryenTypeFloat64(),
+                  { I64(), BinaryenTypeFloat64(), BinaryenTypeFloat64() },
+                  body);
+}
+
+// endo_str_to_f64(s: i64) -> f64 — parses [+-]?digits[.digits][e[+-]digits];
+// anything unparsable yields 0.0 (matching the VM's catch -> 0.0).
+void WasmRuntime::buildStrToF64()
+{
+    auto e = Emit { _module };
+    auto const headerSize = static_cast<int32_t>(layout::HeaderSize);
+
+    // params: 0=s
+    // locals: 1=p i32, 2=len i32, 3=i i32, 4=c i32, 5=neg i32,
+    //         6=acc f64, 7=scale f64, 8=expNeg i32, 9=exp i64
+    auto const currentChar = [&]() {
+        return e.load8u(
+            e.bin(BinaryenAddInt32(), e.bin(BinaryenAddInt32(), e.get32(1), e.i32(headerSize)), e.get32(3)));
+    };
+    auto const atEnd = [&]() {
+        return e.bin(BinaryenGeUInt32(), e.get32(3), e.get32(2));
+    };
+    auto const advance = [&]() {
+        return e.set(3, e.bin(BinaryenAddInt32(), e.get32(3), e.i32(1)));
+    };
+    auto const isDigit = [&]() {
+        return e.bin(BinaryenAndInt32(),
+                     e.bin(BinaryenGeUInt32(), e.get32(4), e.i32('0')),
+                     e.bin(BinaryenLeUInt32(), e.get32(4), e.i32('9')));
+    };
+    auto const digitF64 = [&]() {
+        return e.un(BinaryenConvertSInt32ToFloat64(), e.bin(BinaryenSubInt32(), e.get32(4), e.i32('0')));
+    };
+
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.set(2, e.load32(e.get32(1), layout::LengthOffset)),
+        // optional sign
+        e.ifThen(e.un(BinaryenEqZInt32(), atEnd()),
+                 e.block({
+                     e.set(4, currentChar()),
+                     e.ifThen(e.bin(BinaryenEqInt32(), e.get32(4), e.i32('-')),
+                              e.block({ e.set(5, e.i32(1)), advance() })),
+                     e.ifThen(e.bin(BinaryenEqInt32(), e.get32(4), e.i32('+')), advance()),
+                 })),
+        // integer digits
+        e.block({ e.loop("ipart",
+                         e.block({
+                             e.brIf("ipart.done", atEnd()),
+                             e.set(4, currentChar()),
+                             e.brIf("ipart.done", e.un(BinaryenEqZInt32(), isDigit())),
+                             e.set(6,
+                                   e.bin(BinaryenAddFloat64(),
+                                         e.bin(BinaryenMulFloat64(), e.getF64(6), e.f64(10.0)),
+                                         digitF64())),
+                             advance(),
+                             e.br("ipart"),
+                         })) },
+                "ipart.done"),
+        // fraction
+        e.set(7, e.f64(1.0)),
+        e.ifThen(e.bin(BinaryenAndInt32(),
+                       e.un(BinaryenEqZInt32(), atEnd()),
+                       e.bin(BinaryenEqInt32(), currentChar(), e.i32('.'))),
+                 e.block({
+                     advance(),
+                     e.block({ e.loop("frac",
+                                      e.block({
+                                          e.brIf("frac.done", atEnd()),
+                                          e.set(4, currentChar()),
+                                          e.brIf("frac.done", e.un(BinaryenEqZInt32(), isDigit())),
+                                          e.set(7, e.bin(BinaryenDivFloat64(), e.getF64(7), e.f64(10.0))),
+                                          e.set(6,
+                                                e.bin(BinaryenAddFloat64(),
+                                                      e.getF64(6),
+                                                      e.bin(BinaryenMulFloat64(), digitF64(), e.getF64(7)))),
+                                          advance(),
+                                          e.br("frac"),
+                                      })) },
+                             "frac.done"),
+                 })),
+        // exponent
+        e.ifThen(
+            e.bin(BinaryenAndInt32(),
+                  e.un(BinaryenEqZInt32(), atEnd()),
+                  e.bin(BinaryenOrInt32(),
+                        e.bin(BinaryenEqInt32(), currentChar(), e.i32('e')),
+                        e.bin(BinaryenEqInt32(), currentChar(), e.i32('E')))),
+            e.block({
+                advance(),
+                e.ifThen(e.un(BinaryenEqZInt32(), atEnd()),
+                         e.block({
+                             e.set(4, currentChar()),
+                             e.ifThen(e.bin(BinaryenEqInt32(), e.get32(4), e.i32('-')),
+                                      e.block({ e.set(8, e.i32(1)), advance() })),
+                             e.ifThen(e.bin(BinaryenEqInt32(), e.get32(4), e.i32('+')), advance()),
+                         })),
+                e.block(
+                    { e.loop("edig",
+                             e.block({
+                                 e.brIf("edig.done", atEnd()),
+                                 e.set(4, currentChar()),
+                                 e.brIf("edig.done", e.un(BinaryenEqZInt32(), isDigit())),
+                                 e.set(9,
+                                       e.bin(BinaryenAddInt64(),
+                                             e.bin(BinaryenMulInt64(), e.get64(9), e.i64(10)),
+                                             e.extendU(e.bin(BinaryenSubInt32(), e.get32(4), e.i32('0'))))),
+                                 advance(),
+                                 e.br("edig"),
+                             })) },
+                    "edig.done"),
+                e.block(
+                    { e.loop("escale",
+                             e.block({
+                                 e.brIf("escale.done", e.un(BinaryenEqZInt64(), e.get64(9))),
+                                 e.set(6,
+                                       BinaryenSelect(_module,
+                                                      e.get32(8),
+                                                      e.bin(BinaryenDivFloat64(), e.getF64(6), e.f64(10.0)),
+                                                      e.bin(BinaryenMulFloat64(), e.getF64(6), e.f64(10.0)))),
+                                 e.set(9, e.bin(BinaryenSubInt64(), e.get64(9), e.i64(1))),
+                                 e.br("escale"),
+                             })) },
+                    "escale.done"),
+            })),
+        e.ifThen(e.get32(5), e.set(6, e.un(BinaryenNegFloat64(), e.getF64(6)))),
+        e.ret(e.getF64(6)),
+    });
+
+    e.addFunction(
+        "endo_str_to_f64",
+        { I64() },
+        BinaryenTypeFloat64(),
+        { I32(), I32(), I32(), I32(), I32(), BinaryenTypeFloat64(), BinaryenTypeFloat64(), I32(), I64() },
+        body);
+}
+
+// endo_f64_to_str_g(f: f64) -> i64 — printf %g-style formatting at 6
+// significant digits (fixed notation for exponents in [-4, 6), scientific
+// otherwise, trailing zeros stripped), approximating std::format("{:g}").
+void WasmRuntime::buildF64ToStrG()
+{
+    require("endo_i64_to_str");
+    require("endo_str_concat");
+    require("endo_str_slice");
+    auto e = Emit { _module };
+    auto const nan = static_cast<int64_t>(_strings->intern("nan"));
+    auto const inf = static_cast<int64_t>(_strings->intern("inf"));
+    auto const negInf = static_cast<int64_t>(_strings->intern("-inf"));
+    auto const zero = static_cast<int64_t>(_strings->intern("0"));
+    auto const minus = static_cast<int64_t>(_strings->intern("-"));
+    auto const dot = static_cast<int64_t>(_strings->intern("."));
+    auto const zeroDot = static_cast<int64_t>(_strings->intern("0."));
+    auto const zeroDigit = static_cast<int64_t>(_strings->intern("0"));
+    auto const expPlus = static_cast<int64_t>(_strings->intern("e+"));
+    auto const expMinus = static_cast<int64_t>(_strings->intern("e-"));
+    auto const infinity = std::numeric_limits<double>::infinity();
+
+    // params: 0=f
+    // locals: 1=a f64, 2=e10 i64, 3=m i64 (6 significant digits),
+    //         4=mStr i64, 5=result i64, 6=keep i32, 7=mPtr i32, 8=k i64
+    auto const concat = [&](BinaryenExpressionRef a, BinaryenExpressionRef b) {
+        return e.call("endo_str_concat", { a, b }, I64());
+    };
+
+    // Trims trailing '0' bytes of the digit substring mStr[start .. start+keep):
+    // local 8 holds the (runtime) start offset, local 6 the length to keep.
+    auto trimLabelCounter = 0;
+    auto const trimLoop = [&]() {
+        auto const loopLabel = "trim" + std::to_string(trimLabelCounter);
+        auto const doneLabel = "trim.done" + std::to_string(trimLabelCounter);
+        ++trimLabelCounter;
+        auto const lastByte = [&]() {
+            return e.load8u(e.bin(
+                BinaryenAddInt32(),
+                e.bin(BinaryenAddInt32(),
+                      e.bin(BinaryenAddInt32(), e.get32(7), e.i32(static_cast<int32_t>(layout::HeaderSize))),
+                      e.wrap(e.get64(8))),
+                e.bin(BinaryenSubInt32(), e.get32(6), e.i32(1))));
+        };
+        return e.block(
+            { e.loop(loopLabel.c_str(),
+                     e.block({
+                         e.brIf(doneLabel.c_str(), e.bin(BinaryenLeSInt32(), e.get32(6), e.i32(0))),
+                         e.brIf(doneLabel.c_str(), e.bin(BinaryenNeInt32(), lastByte(), e.i32('0'))),
+                         e.set(6, e.bin(BinaryenSubInt32(), e.get32(6), e.i32(1))),
+                         e.br(loopLabel.c_str()),
+                     })) },
+            doneLabel.c_str());
+    };
+
+    auto* body = e.block({
+        e.ifThen(e.bin(BinaryenNeFloat64(), e.getF64(0), e.getF64(0)), e.ret(e.i64(nan))),
+        e.ifThen(e.bin(BinaryenEqFloat64(), e.getF64(0), e.f64(infinity)), e.ret(e.i64(inf))),
+        e.ifThen(e.bin(BinaryenEqFloat64(), e.getF64(0), e.f64(-infinity)), e.ret(e.i64(negInf))),
+        e.ifThen(e.bin(BinaryenEqFloat64(), e.getF64(0), e.f64(0.0)), e.ret(e.i64(zero))),
+        e.set(1, e.un(BinaryenAbsFloat64(), e.getF64(0))),
+        // normalize a into [1, 10) tracking the decimal exponent
+        e.block({ e.loop("normdown",
+                         e.block({
+                             e.brIf("normdown.done", e.bin(BinaryenLtFloat64(), e.getF64(1), e.f64(10.0))),
+                             e.set(1, e.bin(BinaryenDivFloat64(), e.getF64(1), e.f64(10.0))),
+                             e.set(2, e.bin(BinaryenAddInt64(), e.get64(2), e.i64(1))),
+                             e.br("normdown"),
+                         })) },
+                "normdown.done"),
+        e.block({ e.loop("normup",
+                         e.block({
+                             e.brIf("normup.done", e.bin(BinaryenGeFloat64(), e.getF64(1), e.f64(1.0))),
+                             e.set(1, e.bin(BinaryenMulFloat64(), e.getF64(1), e.f64(10.0))),
+                             e.set(2, e.bin(BinaryenSubInt64(), e.get64(2), e.i64(1))),
+                             e.br("normup"),
+                         })) },
+                "normup.done"),
+        // m = round(a * 1e5): six significant digits in [100000, 1000000]
+        e.set(3,
+              e.un(BinaryenTruncSatSFloat64ToInt64(),
+                   e.bin(BinaryenAddFloat64(),
+                         e.bin(BinaryenMulFloat64(), e.getF64(1), e.f64(100'000.0)),
+                         e.f64(0.5)))),
+        e.ifThen(e.bin(BinaryenGeSInt64(), e.get64(3), e.i64(1'000'000)),
+                 e.block({
+                     e.set(3, e.i64(100'000)),
+                     e.set(2, e.bin(BinaryenAddInt64(), e.get64(2), e.i64(1))),
+                 })),
+        e.set(4, e.call("endo_i64_to_str", { e.get64(3) }, I64())),
+        e.set(7, e.wrap(e.get64(4))),
+        // fixed notation for -4 <= e10 < 6, scientific otherwise
+        e.ifElse(
+            e.bin(BinaryenAndInt32(),
+                  e.bin(BinaryenGeSInt64(), e.get64(2), e.i64(-4)),
+                  e.bin(BinaryenLtSInt64(), e.get64(2), e.i64(6))),
+            e.block({
+                e.ifElse(
+                    e.bin(BinaryenGeSInt64(), e.get64(2), e.i64(0)),
+                    e.block({
+                        // DDD.DDD — integer part is the first e10+1 digits
+                        e.set(
+                            5,
+                            e.call("endo_str_slice",
+                                   { e.get64(4), e.i64(0), e.bin(BinaryenAddInt64(), e.get64(2), e.i64(1)) },
+                                   I64())),
+                        // fraction: remaining digits, trailing zeros stripped
+                        e.set(6, e.wrap(e.bin(BinaryenSubInt64(), e.i64(5), e.get64(2)))),
+                        e.set(8, e.bin(BinaryenAddInt64(), e.get64(2), e.i64(1))), // frac start
+                        trimLoop(),
+                        e.ifThen(e.bin(BinaryenGtSInt32(), e.get32(6), e.i32(0)),
+                                 e.block({
+                                     e.set(5, concat(e.get64(5), e.i64(dot))),
+                                     e.set(5,
+                                           concat(e.get64(5),
+                                                  e.call("endo_str_slice",
+                                                         { e.get64(4), e.get64(8), e.extendU(e.get32(6)) },
+                                                         I64()))),
+                                 })),
+                    }),
+                    e.block({
+                        // 0.000DDDDDD — leading zeros then all six digits
+                        e.set(5, e.i64(zeroDot)),
+                        e.set(8, e.bin(BinaryenSubInt64(), e.i64(-1), e.get64(2))), // zeros to insert
+                        e.block({ e.loop("zeros",
+                                         e.block({
+                                             e.brIf("zeros.done", e.un(BinaryenEqZInt64(), e.get64(8))),
+                                             e.set(5, concat(e.get64(5), e.i64(zeroDigit))),
+                                             e.set(8, e.bin(BinaryenSubInt64(), e.get64(8), e.i64(1))),
+                                             e.br("zeros"),
+                                         })) },
+                                "zeros.done"),
+                        e.set(6, e.i32(6)), // local 8 is 0 after the zeros loop
+                        trimLoop(),
+                        e.set(5,
+                              concat(e.get64(5),
+                                     e.call("endo_str_slice",
+                                            { e.get64(4), e.i64(0), e.extendU(e.get32(6)) },
+                                            I64()))),
+                    })),
+            }),
+            e.block({
+                // scientific: D[.DDDDD]e±XX
+                e.set(5, e.call("endo_str_slice", { e.get64(4), e.i64(0), e.i64(1) }, I64())),
+                e.set(6, e.i32(5)),
+                e.set(8, e.i64(1)),
+                trimLoop(),
+                e.ifThen(e.bin(BinaryenGtSInt32(), e.get32(6), e.i32(0)),
+                         e.block({
+                             e.set(5, concat(e.get64(5), e.i64(dot))),
+                             e.set(5,
+                                   concat(e.get64(5),
+                                          e.call("endo_str_slice",
+                                                 { e.get64(4), e.i64(1), e.extendU(e.get32(6)) },
+                                                 I64()))),
+                         })),
+                e.set(5,
+                      concat(e.get64(5),
+                             BinaryenSelect(_module,
+                                            e.bin(BinaryenLtSInt64(), e.get64(2), e.i64(0)),
+                                            e.i64(expMinus),
+                                            e.i64(expPlus)))),
+                e.ifThen(e.bin(BinaryenLtSInt64(), e.get64(2), e.i64(0)),
+                         e.set(2, e.bin(BinaryenSubInt64(), e.i64(0), e.get64(2)))),
+                e.ifThen(e.bin(BinaryenLtSInt64(), e.get64(2), e.i64(10)),
+                         e.set(5, concat(e.get64(5), e.i64(zeroDigit)))),
+                e.set(5, concat(e.get64(5), e.call("endo_i64_to_str", { e.get64(2) }, I64()))),
+            })),
+        e.ifThen(e.bin(BinaryenLtFloat64(), e.getF64(0), e.f64(0.0)),
+                 e.set(5, concat(e.i64(minus), e.get64(5)))),
+        e.ret(e.get64(5)),
+    });
+
+    e.addFunction("endo_f64_to_str_g",
+                  { BinaryenTypeFloat64() },
+                  I64(),
+                  { BinaryenTypeFloat64(), I64(), I64(), I64(), I64(), I32(), I32(), I64() },
+                  body);
 }
 
 } // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmRuntime.cpp
+++ b/src/CoreVM/wasm/WasmRuntime.cpp
@@ -1,0 +1,566 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <CoreVM/wasm/WasmRuntime.hpp>
+#include <CoreVM/wasm/WasmStringTable.hpp>
+
+#include <array>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <binaryen-c.h>
+
+namespace CoreVM::wasm
+{
+
+namespace
+{
+    /// Terse expression-building facade over the binaryen C API, used to keep
+    /// the runtime function bodies readable. All member functions build fresh
+    /// expression nodes (binaryen expressions are single-use tree nodes).
+    struct Emit
+    {
+        BinaryenModuleRef m;
+
+        // constants
+        [[nodiscard]] BinaryenExpressionRef i32(int32_t v) const
+        {
+            return BinaryenConst(m, BinaryenLiteralInt32(v));
+        }
+
+        [[nodiscard]] BinaryenExpressionRef i64(int64_t v) const
+        {
+            return BinaryenConst(m, BinaryenLiteralInt64(v));
+        }
+
+        // locals (indices count parameters first)
+        [[nodiscard]] BinaryenExpressionRef get32(BinaryenIndex i) const
+        {
+            return BinaryenLocalGet(m, i, BinaryenTypeInt32());
+        }
+
+        [[nodiscard]] BinaryenExpressionRef get64(BinaryenIndex i) const
+        {
+            return BinaryenLocalGet(m, i, BinaryenTypeInt64());
+        }
+
+        [[nodiscard]] BinaryenExpressionRef set(BinaryenIndex i, BinaryenExpressionRef v) const
+        {
+            return BinaryenLocalSet(m, i, v);
+        }
+
+        // integer narrowing/widening
+        [[nodiscard]] BinaryenExpressionRef wrap(BinaryenExpressionRef v) const
+        {
+            return un(BinaryenWrapInt64(), v);
+        }
+
+        [[nodiscard]] BinaryenExpressionRef extendU(BinaryenExpressionRef v) const
+        {
+            return un(BinaryenExtendUInt32(), v);
+        }
+
+        // memory (32-bit addresses)
+        [[nodiscard]] BinaryenExpressionRef load8u(BinaryenExpressionRef ptr, uint32_t offset = 0) const
+        {
+            return BinaryenLoad(m, 1, false, offset, 0, BinaryenTypeInt32(), ptr, "0");
+        }
+
+        [[nodiscard]] BinaryenExpressionRef load32(BinaryenExpressionRef ptr, uint32_t offset = 0) const
+        {
+            return BinaryenLoad(m, 4, false, offset, 0, BinaryenTypeInt32(), ptr, "0");
+        }
+
+        [[nodiscard]] BinaryenExpressionRef store8(BinaryenExpressionRef ptr,
+                                                   BinaryenExpressionRef v,
+                                                   uint32_t offset = 0) const
+        {
+            return BinaryenStore(m, 1, offset, 0, ptr, v, BinaryenTypeInt32(), "0");
+        }
+
+        [[nodiscard]] BinaryenExpressionRef store32(BinaryenExpressionRef ptr,
+                                                    BinaryenExpressionRef v,
+                                                    uint32_t offset = 0) const
+        {
+            return BinaryenStore(m, 4, offset, 0, ptr, v, BinaryenTypeInt32(), "0");
+        }
+
+        // operators
+        [[nodiscard]] BinaryenExpressionRef un(BinaryenOp op, BinaryenExpressionRef v) const
+        {
+            return BinaryenUnary(m, op, v);
+        }
+
+        [[nodiscard]] BinaryenExpressionRef bin(BinaryenOp op,
+                                                BinaryenExpressionRef l,
+                                                BinaryenExpressionRef r) const
+        {
+            return BinaryenBinary(m, op, l, r);
+        }
+
+        // control flow
+        [[nodiscard]] BinaryenExpressionRef block(std::vector<BinaryenExpressionRef> stmts,
+                                                  char const* name = nullptr) const
+        {
+            return BinaryenBlock(
+                m, name, stmts.data(), static_cast<BinaryenIndex>(stmts.size()), BinaryenTypeAuto());
+        }
+
+        [[nodiscard]] BinaryenExpressionRef loop(char const* name, BinaryenExpressionRef body) const
+        {
+            return BinaryenLoop(m, name, body);
+        }
+
+        [[nodiscard]] BinaryenExpressionRef brIf(char const* label, BinaryenExpressionRef condition) const
+        {
+            return BinaryenBreak(m, label, condition, nullptr);
+        }
+
+        [[nodiscard]] BinaryenExpressionRef br(char const* label) const
+        {
+            return BinaryenBreak(m, label, nullptr, nullptr);
+        }
+
+        [[nodiscard]] BinaryenExpressionRef ifThen(BinaryenExpressionRef cond,
+                                                   BinaryenExpressionRef then) const
+        {
+            return BinaryenIf(m, cond, then, nullptr);
+        }
+
+        [[nodiscard]] BinaryenExpressionRef ifElse(BinaryenExpressionRef cond,
+                                                   BinaryenExpressionRef then,
+                                                   BinaryenExpressionRef otherwise) const
+        {
+            return BinaryenIf(m, cond, then, otherwise);
+        }
+
+        [[nodiscard]] BinaryenExpressionRef ret(BinaryenExpressionRef v = nullptr) const
+        {
+            return BinaryenReturn(m, v);
+        }
+
+        [[nodiscard]] BinaryenExpressionRef call(char const* target,
+                                                 std::vector<BinaryenExpressionRef> args,
+                                                 BinaryenType resultType) const
+        {
+            return BinaryenCall(m, target, args.data(), static_cast<BinaryenIndex>(args.size()), resultType);
+        }
+
+        [[nodiscard]] BinaryenExpressionRef callVoid(char const* target,
+                                                     std::vector<BinaryenExpressionRef> args) const
+        {
+            return call(target, std::move(args), BinaryenTypeNone());
+        }
+
+        [[nodiscard]] BinaryenExpressionRef heapPtr() const
+        {
+            return BinaryenGlobalGet(m, std::string(layout::HeapPointerGlobal).c_str(), BinaryenTypeInt32());
+        }
+
+        [[nodiscard]] BinaryenExpressionRef setHeapPtr(BinaryenExpressionRef v) const
+        {
+            return BinaryenGlobalSet(m, std::string(layout::HeapPointerGlobal).c_str(), v);
+        }
+
+        void addFunction(char const* name,
+                         std::vector<BinaryenType> params,
+                         BinaryenType result,
+                         std::vector<BinaryenType> locals,
+                         BinaryenExpressionRef body) const
+        {
+            auto const paramsType =
+                params.empty() ? BinaryenTypeNone()
+                               : BinaryenTypeCreate(params.data(), static_cast<BinaryenIndex>(params.size()));
+            BinaryenAddFunction(
+                m, name, paramsType, result, locals.data(), static_cast<BinaryenIndex>(locals.size()), body);
+        }
+    };
+
+    constexpr auto I32 = BinaryenTypeInt32;
+    constexpr auto I64 = BinaryenTypeInt64;
+} // namespace
+
+void WasmRuntime::provide(BinaryenModuleRef module,
+                          std::set<RuntimeHelperDef const*> const& usedHelpers,
+                          WasmStringTable& strings)
+{
+    _module = module;
+    _strings = &strings;
+    for (auto const* helper: usedHelpers)
+        require(helper->name);
+}
+
+void WasmRuntime::require(std::string_view name)
+{
+    if (_built.contains(name))
+        return;
+    _built.emplace(name);
+
+    using Builder = void (WasmRuntime::*)();
+    static auto const builders = std::unordered_map<std::string_view, Builder> {
+        { "endo_alloc", &WasmRuntime::buildAlloc },
+        { "endo_str_alloc", &WasmRuntime::buildStrAlloc },
+        { "endo_write_all", &WasmRuntime::buildWriteAll },
+        { "endo_print", &WasmRuntime::buildPrint },
+        { "endo_println", &WasmRuntime::buildPrintln },
+        { "endo_panic", &WasmRuntime::buildPanic },
+        { "endo_i64_to_str", &WasmRuntime::buildI64ToStr },
+        { "endo_object_to_string", &WasmRuntime::buildObjectToString },
+        { "endo_i64_div", &WasmRuntime::buildI64Div },
+        { "endo_i64_rem", &WasmRuntime::buildI64Rem },
+        { "endo_i64_pow", &WasmRuntime::buildI64Pow },
+    };
+
+    if (auto const it = builders.find(name); it != builders.end())
+        (this->*(it->second))();
+    else
+        importHelper(name);
+}
+
+void WasmRuntime::requireFdWrite()
+{
+    if (_built.contains("fd_write"))
+        return;
+    _built.emplace("fd_write");
+    auto params = std::array { I32(), I32(), I32(), I32() };
+    BinaryenAddFunctionImport(_module,
+                              "fd_write",
+                              "wasi_snapshot_preview1",
+                              "fd_write",
+                              BinaryenTypeCreate(params.data(), static_cast<BinaryenIndex>(params.size())),
+                              I32());
+}
+
+void WasmRuntime::importHelper(std::string_view name)
+{
+    auto const* def = findRuntimeHelper(name);
+    if (def == nullptr)
+        return; // unknown internal name: leave for module validation to catch
+    auto const functionName = std::string(name);
+    BinaryenAddFunctionImport(_module,
+                              functionName.c_str(),
+                              "endo",
+                              functionName.c_str(),
+                              binaryenParamsType(*def),
+                              binaryenResultType(*def));
+}
+
+// endo_alloc(size: i32) -> i32 — bump allocation with memory.grow on demand.
+void WasmRuntime::buildAlloc()
+{
+    require("endo_panic");
+    auto e = Emit { _module };
+    auto const oom = static_cast<int64_t>(_strings->intern("out of memory"));
+
+    // params: 0=size; locals: 1=ptr, 2=newPtr, 3=pages
+    auto* body = e.block({
+        // size = (size + 7) & ~7
+        e.set(0, e.bin(BinaryenAndInt32(), e.bin(BinaryenAddInt32(), e.get32(0), e.i32(7)), e.i32(~7))),
+        e.set(1, e.heapPtr()),
+        e.set(2, e.bin(BinaryenAddInt32(), e.get32(1), e.get32(0))),
+        // if (newPtr > memory.size << 16) grow
+        e.ifThen(
+            e.bin(BinaryenGtUInt32(),
+                  e.get32(2),
+                  e.bin(BinaryenShlInt32(), BinaryenMemorySize(_module, "0", false), e.i32(16))),
+            e.block({
+                // pages = ((newPtr - (memory.size << 16)) >> 16) + 1, at least 16
+                e.set(3,
+                      e.bin(BinaryenAddInt32(),
+                            e.bin(BinaryenShrUInt32(),
+                                  e.bin(BinaryenSubInt32(),
+                                        e.get32(2),
+                                        e.bin(BinaryenShlInt32(),
+                                              BinaryenMemorySize(_module, "0", false),
+                                              e.i32(16))),
+                                  e.i32(16)),
+                            e.i32(1))),
+                e.ifThen(e.bin(BinaryenLtUInt32(), e.get32(3), e.i32(16)), e.set(3, e.i32(16))),
+                e.ifThen(
+                    e.bin(BinaryenEqInt32(), BinaryenMemoryGrow(_module, e.get32(3), "0", false), e.i32(-1)),
+                    e.callVoid("endo_panic", { e.i64(oom) })),
+            })),
+        e.setHeapPtr(e.get32(2)),
+        e.ret(e.get32(1)),
+    });
+
+    e.addFunction("endo_alloc", { I32() }, I32(), { I32(), I32(), I32() }, body);
+}
+
+// endo_str_alloc(len: i32) -> i32 — allocates a string cell (header + payload).
+void WasmRuntime::buildStrAlloc()
+{
+    require("endo_alloc");
+    auto e = Emit { _module };
+
+    // params: 0=len; locals: 1=p
+    auto* body = e.block({
+        e.set(
+            1,
+            e.call("endo_alloc",
+                   { e.bin(BinaryenAddInt32(), e.i32(static_cast<int32_t>(layout::HeaderSize)), e.get32(0)) },
+                   I32())),
+        e.store8(e.get32(1), e.i32(layout::KindString)),
+        e.store32(e.get32(1), e.get32(0), layout::LengthOffset),
+        e.ret(e.get32(1)),
+    });
+
+    e.addFunction("endo_str_alloc", { I32() }, I32(), { I32() }, body);
+}
+
+// endo_write_all(fd: i32, buf: i32, len: i32) — fd_write loop handling
+// partial writes; write errors are silently dropped (matching VM print).
+void WasmRuntime::buildWriteAll()
+{
+    requireFdWrite();
+    auto e = Emit { _module };
+    auto const iovec = static_cast<int32_t>(layout::ScratchIovec0);
+    auto const nwritten = static_cast<int32_t>(layout::ScratchNWritten);
+
+    // params: 0=fd, 1=buf, 2=len; locals: 3=n
+    auto* body = e.block(
+        { e.loop(
+            "write",
+            e.block({
+                e.brIf("done", e.un(BinaryenEqZInt32(), e.get32(2))),
+                e.store32(e.i32(iovec), e.get32(1)),
+                e.store32(e.i32(iovec), e.get32(2), 4),
+                e.brIf("done",
+                       e.call("fd_write", { e.get32(0), e.i32(iovec), e.i32(1), e.i32(nwritten) }, I32())),
+                e.set(3, e.load32(e.i32(nwritten))),
+                e.brIf("done", e.un(BinaryenEqZInt32(), e.get32(3))),
+                e.set(1, e.bin(BinaryenAddInt32(), e.get32(1), e.get32(3))),
+                e.set(2, e.bin(BinaryenSubInt32(), e.get32(2), e.get32(3))),
+                e.br("write"),
+            })) },
+        "done");
+
+    e.addFunction("endo_write_all", { I32(), I32(), I32() }, BinaryenTypeNone(), { I32() }, body);
+}
+
+// endo_print(s: i64) — writes the string bytes to stdout.
+void WasmRuntime::buildPrint()
+{
+    require("endo_write_all");
+    auto e = Emit { _module };
+
+    // params: 0=s; locals: 1=p
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.callVoid("endo_write_all",
+                   { e.i32(1),
+                     e.bin(BinaryenAddInt32(), e.get32(1), e.i32(static_cast<int32_t>(layout::HeaderSize))),
+                     e.load32(e.get32(1), layout::LengthOffset) }),
+    });
+
+    e.addFunction("endo_print", { I64() }, BinaryenTypeNone(), { I32() }, body);
+}
+
+// endo_println(s: i64) — print followed by a newline.
+void WasmRuntime::buildPrintln()
+{
+    require("endo_print");
+    auto e = Emit { _module };
+    auto const newline = static_cast<int32_t>(_strings->intern("\n"));
+
+    auto* body = e.block({
+        e.callVoid("endo_print", { e.get64(0) }),
+        e.callVoid("endo_write_all",
+                   { e.i32(1), e.i32(newline + static_cast<int32_t>(layout::HeaderSize)), e.i32(1) }),
+    });
+
+    e.addFunction("endo_println", { I64() }, BinaryenTypeNone(), {}, body);
+}
+
+// endo_panic(msg: i64) — "endo: runtime error: <msg>\n" to stderr, exit 1.
+void WasmRuntime::buildPanic()
+{
+    require("endo_write_all");
+    auto e = Emit { _module };
+    auto const prefixText = std::string_view { "endo: runtime error: " };
+    auto const prefix = static_cast<int32_t>(_strings->intern(prefixText));
+    auto const newline = static_cast<int32_t>(_strings->intern("\n"));
+    auto const headerSize = static_cast<int32_t>(layout::HeaderSize);
+
+    // params: 0=msg; locals: 1=p
+    auto* body = e.block({
+        e.callVoid("endo_write_all",
+                   { e.i32(2), e.i32(prefix + headerSize), e.i32(static_cast<int32_t>(prefixText.size())) }),
+        e.set(1, e.wrap(e.get64(0))),
+        e.callVoid("endo_write_all",
+                   { e.i32(2),
+                     e.bin(BinaryenAddInt32(), e.get32(1), e.i32(headerSize)),
+                     e.load32(e.get32(1), layout::LengthOffset) }),
+        e.callVoid("endo_write_all", { e.i32(2), e.i32(newline + headerSize), e.i32(1) }),
+        e.callVoid("proc_exit", { e.i32(1) }),
+        BinaryenUnreachable(_module),
+    });
+
+    e.addFunction("endo_panic", { I64() }, BinaryenTypeNone(), { I32() }, body);
+}
+
+// endo_i64_to_str(v: i64) -> i64 — decimal formatting, INT64_MIN-safe
+// (digits are produced in negative space).
+void WasmRuntime::buildI64ToStr()
+{
+    require("endo_str_alloc");
+    auto e = Emit { _module };
+    auto const bufEnd = static_cast<int32_t>(layout::ScratchNumberBuffer) + 40;
+
+    // params: 0=v; locals: 1=pos i32, 2=neg i32, 3=str i32, 4=len i32
+    auto* digitsLoop = e.block(
+        { e.loop("digits",
+                 e.block({
+                     e.brIf("digits.done", e.un(BinaryenEqZInt64(), e.get64(0))),
+                     e.set(1, e.bin(BinaryenSubInt32(), e.get32(1), e.i32(1))),
+                     // *pos = '0' + (0 - (v % 10))   [v <= 0, so v%10 in (-9..0]]
+                     e.store8(e.get32(1),
+                              e.bin(BinaryenAddInt32(),
+                                    e.i32('0'),
+                                    e.wrap(e.bin(BinaryenSubInt64(),
+                                                 e.i64(0),
+                                                 e.bin(BinaryenRemSInt64(), e.get64(0), e.i64(10)))))),
+                     e.set(0, e.bin(BinaryenDivSInt64(), e.get64(0), e.i64(10))),
+                     e.br("digits"),
+                 })) },
+        "digits.done");
+
+    auto* body = e.block({
+        e.set(1, e.i32(bufEnd)),
+        // neg = v < 0; then continue with v <= 0 (v = neg ? v : -v)
+        e.set(2, e.bin(BinaryenLtSInt64(), e.get64(0), e.i64(0))),
+        e.ifThen(e.un(BinaryenEqZInt32(), e.get32(2)),
+                 e.set(0, e.bin(BinaryenSubInt64(), e.i64(0), e.get64(0)))),
+        e.ifElse(e.un(BinaryenEqZInt64(), e.get64(0)),
+                 e.block({
+                     e.set(1, e.bin(BinaryenSubInt32(), e.get32(1), e.i32(1))),
+                     e.store8(e.get32(1), e.i32('0')),
+                 }),
+                 e.block({
+                     digitsLoop,
+                     e.ifThen(e.get32(2),
+                              e.block({
+                                  e.set(1, e.bin(BinaryenSubInt32(), e.get32(1), e.i32(1))),
+                                  e.store8(e.get32(1), e.i32('-')),
+                              })),
+                 })),
+        e.set(4, e.bin(BinaryenSubInt32(), e.i32(bufEnd), e.get32(1))),
+        e.set(3, e.call("endo_str_alloc", { e.get32(4) }, I32())),
+        BinaryenMemoryCopy(
+            _module,
+            e.bin(BinaryenAddInt32(), e.get32(3), e.i32(static_cast<int32_t>(layout::HeaderSize))),
+            e.get32(1),
+            e.get32(4),
+            "0",
+            "0"),
+        e.ret(e.extendU(e.get32(3))),
+    });
+
+    e.addFunction("endo_i64_to_str", { I64() }, I64(), { I32(), I32(), I32(), I32() }, body);
+}
+
+// endo_object_to_string(v: i64) -> i64 — runtime classification of a
+// dynamically typed value: known string cells pass through, object cells get
+// a placeholder (replaced by the real composite formatter in a later
+// milestone), everything else formats as a decimal number.
+void WasmRuntime::buildObjectToString()
+{
+    require("endo_i64_to_str");
+    auto e = Emit { _module };
+    auto const placeholder = static_cast<int64_t>(_strings->intern("<object>"));
+
+    // params: 0=v; locals: 1=p
+    auto* const plausiblePointer =
+        e.bin(BinaryenAndInt32(),
+              e.bin(BinaryenGeUInt32(), e.get32(1), e.i32(static_cast<int32_t>(layout::DataBase))),
+              e.bin(BinaryenAndInt32(),
+                    e.un(BinaryenEqZInt32(), e.bin(BinaryenAndInt32(), e.get32(1), e.i32(7))),
+                    e.bin(BinaryenLtUInt32(), e.get32(1), e.heapPtr())));
+
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.ifThen(plausiblePointer,
+                 e.block({
+                     e.ifThen(e.bin(BinaryenEqInt32(), e.load8u(e.get32(1)), e.i32(layout::KindString)),
+                              e.ret(e.get64(0))),
+                     e.ifThen(e.bin(BinaryenEqInt32(), e.load8u(e.get32(1)), e.i32(layout::KindObject)),
+                              e.ret(e.i64(placeholder))),
+                 })),
+        e.ret(e.call("endo_i64_to_str", { e.get64(0) }, I64())),
+    });
+
+    e.addFunction("endo_object_to_string", { I64() }, I64(), { I32() }, body);
+}
+
+// endo_i64_div(a, b) -> i64 — VM semantics: division by zero is a runtime
+// error; INT64_MIN / -1 yields INT64_MIN instead of trapping.
+void WasmRuntime::buildI64Div()
+{
+    require("endo_panic");
+    auto e = Emit { _module };
+    auto const divByZero = static_cast<int64_t>(_strings->intern("division by zero"));
+
+    auto* body = e.block({
+        e.ifThen(e.un(BinaryenEqZInt64(), e.get64(1)), e.callVoid("endo_panic", { e.i64(divByZero) })),
+        e.ifThen(e.bin(BinaryenAndInt32(),
+                       e.bin(BinaryenEqInt64(), e.get64(0), e.i64(INT64_MIN)),
+                       e.bin(BinaryenEqInt64(), e.get64(1), e.i64(-1))),
+                 e.ret(e.i64(INT64_MIN))),
+        e.ret(e.bin(BinaryenDivSInt64(), e.get64(0), e.get64(1))),
+    });
+
+    e.addFunction("endo_i64_div", { I64(), I64() }, I64(), {}, body);
+}
+
+// endo_i64_rem(a, b) -> i64 — VM semantics: remainder by zero is a runtime
+// error. (i64.rem_s never traps on INT64_MIN % -1; it yields 0.)
+void WasmRuntime::buildI64Rem()
+{
+    require("endo_panic");
+    auto e = Emit { _module };
+    auto const divByZero = static_cast<int64_t>(_strings->intern("division by zero"));
+
+    auto* body = e.block({
+        e.ifThen(e.un(BinaryenEqZInt64(), e.get64(1)), e.callVoid("endo_panic", { e.i64(divByZero) })),
+        e.ret(e.bin(BinaryenRemSInt64(), e.get64(0), e.get64(1))),
+    });
+
+    e.addFunction("endo_i64_rem", { I64(), I64() }, I64(), {}, body);
+}
+
+// endo_i64_pow(base, exp) -> i64 — square-and-multiply; negative exponents
+// follow integer-power semantics (only |base| == 1 yields non-zero).
+void WasmRuntime::buildI64Pow()
+{
+    auto e = Emit { _module };
+
+    // params: 0=base, 1=exp; locals: 2=result
+    auto* body = e.block({
+        e.ifThen(e.bin(BinaryenLtSInt64(), e.get64(1), e.i64(0)),
+                 e.block({
+                     e.ifThen(e.bin(BinaryenEqInt64(), e.get64(0), e.i64(1)), e.ret(e.i64(1))),
+                     e.ifThen(e.bin(BinaryenEqInt64(), e.get64(0), e.i64(-1)),
+                              e.ret(e.bin(BinaryenSubInt64(),
+                                          e.i64(1),
+                                          e.bin(BinaryenShlInt64(),
+                                                e.bin(BinaryenAndInt64(), e.get64(1), e.i64(1)),
+                                                e.i64(1))))),
+                     e.ret(e.i64(0)),
+                 })),
+        e.set(2, e.i64(1)),
+        e.block({ e.loop("pow",
+                         e.block({
+                             e.brIf("pow.done", e.un(BinaryenEqZInt64(), e.get64(1))),
+                             e.ifThen(e.wrap(e.bin(BinaryenAndInt64(), e.get64(1), e.i64(1))),
+                                      e.set(2, e.bin(BinaryenMulInt64(), e.get64(2), e.get64(0)))),
+                             e.set(0, e.bin(BinaryenMulInt64(), e.get64(0), e.get64(0))),
+                             e.set(1, e.bin(BinaryenShrUInt64(), e.get64(1), e.i64(1))),
+                             e.br("pow"),
+                         })) },
+                "pow.done"),
+        e.ret(e.get64(2)),
+    });
+
+    e.addFunction("endo_i64_pow", { I64(), I64() }, I64(), { I64() }, body);
+}
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmRuntime.cpp
+++ b/src/CoreVM/wasm/WasmRuntime.cpp
@@ -208,6 +208,15 @@ void WasmRuntime::require(std::string_view name)
         { "endo_i64_div", &WasmRuntime::buildI64Div },
         { "endo_i64_rem", &WasmRuntime::buildI64Rem },
         { "endo_i64_pow", &WasmRuntime::buildI64Pow },
+        { "endo_mem_eq", &WasmRuntime::buildMemEq },
+        { "endo_str_concat", &WasmRuntime::buildStrConcat },
+        { "endo_str_len", &WasmRuntime::buildStrLen },
+        { "endo_str_eq", &WasmRuntime::buildStrEq },
+        { "endo_str_cmp", &WasmRuntime::buildStrCmp },
+        { "endo_str_starts_with", &WasmRuntime::buildStrStartsWith },
+        { "endo_str_ends_with", &WasmRuntime::buildStrEndsWith },
+        { "endo_str_contains", &WasmRuntime::buildStrContains },
+        { "endo_str_to_i64", &WasmRuntime::buildStrToI64 },
     };
 
     if (auto const it = builders.find(name); it != builders.end())
@@ -561,6 +570,295 @@ void WasmRuntime::buildI64Pow()
     });
 
     e.addFunction("endo_i64_pow", { I64(), I64() }, I64(), { I64() }, body);
+}
+
+// endo_mem_eq(a: i32, b: i32, n: i32) -> i32 — byte-wise memory equality.
+void WasmRuntime::buildMemEq()
+{
+    auto e = Emit { _module };
+
+    // params: 0=a, 1=b, 2=n; locals: 3=i
+    auto* body =
+        e.block({ e.loop("cmp",
+                         e.block({
+                             e.ifThen(e.bin(BinaryenGeUInt32(), e.get32(3), e.get32(2)), e.ret(e.i32(1))),
+                             e.ifThen(e.bin(BinaryenNeInt32(),
+                                            e.load8u(e.bin(BinaryenAddInt32(), e.get32(0), e.get32(3))),
+                                            e.load8u(e.bin(BinaryenAddInt32(), e.get32(1), e.get32(3)))),
+                                      e.ret(e.i32(0))),
+                             e.set(3, e.bin(BinaryenAddInt32(), e.get32(3), e.i32(1))),
+                             e.br("cmp"),
+                         })) });
+
+    e.addFunction("endo_mem_eq", { I32(), I32(), I32() }, I32(), { I32() }, body);
+}
+
+// endo_str_concat(a: i64, b: i64) -> i64
+void WasmRuntime::buildStrConcat()
+{
+    require("endo_str_alloc");
+    auto e = Emit { _module };
+    auto const headerSize = static_cast<int32_t>(layout::HeaderSize);
+
+    // params: 0=a, 1=b; locals: 2=pa, 3=pb, 4=la, 5=lb, 6=p
+    auto* body = e.block({
+        e.set(2, e.wrap(e.get64(0))),
+        e.set(3, e.wrap(e.get64(1))),
+        e.set(4, e.load32(e.get32(2), layout::LengthOffset)),
+        e.set(5, e.load32(e.get32(3), layout::LengthOffset)),
+        e.set(6, e.call("endo_str_alloc", { e.bin(BinaryenAddInt32(), e.get32(4), e.get32(5)) }, I32())),
+        BinaryenMemoryCopy(_module,
+                           e.bin(BinaryenAddInt32(), e.get32(6), e.i32(headerSize)),
+                           e.bin(BinaryenAddInt32(), e.get32(2), e.i32(headerSize)),
+                           e.get32(4),
+                           "0",
+                           "0"),
+        BinaryenMemoryCopy(
+            _module,
+            e.bin(BinaryenAddInt32(), e.bin(BinaryenAddInt32(), e.get32(6), e.i32(headerSize)), e.get32(4)),
+            e.bin(BinaryenAddInt32(), e.get32(3), e.i32(headerSize)),
+            e.get32(5),
+            "0",
+            "0"),
+        e.ret(e.extendU(e.get32(6))),
+    });
+
+    e.addFunction("endo_str_concat", { I64(), I64() }, I64(), { I32(), I32(), I32(), I32(), I32() }, body);
+}
+
+// endo_str_len(s: i64) -> i64
+void WasmRuntime::buildStrLen()
+{
+    auto e = Emit { _module };
+    auto* body = e.ret(e.extendU(e.load32(e.wrap(e.get64(0)), layout::LengthOffset)));
+    e.addFunction("endo_str_len", { I64() }, I64(), {}, body);
+}
+
+// endo_str_eq(a: i64, b: i64) -> i64 — content equality (0/1).
+void WasmRuntime::buildStrEq()
+{
+    require("endo_mem_eq");
+    auto e = Emit { _module };
+    auto const headerSize = static_cast<int32_t>(layout::HeaderSize);
+
+    // params: 0=a, 1=b; locals: 2=pa, 3=pb, 4=la
+    auto* body = e.block({
+        e.set(2, e.wrap(e.get64(0))),
+        e.set(3, e.wrap(e.get64(1))),
+        e.ifThen(e.bin(BinaryenEqInt32(), e.get32(2), e.get32(3)), e.ret(e.i64(1))),
+        e.set(4, e.load32(e.get32(2), layout::LengthOffset)),
+        e.ifThen(e.bin(BinaryenNeInt32(), e.get32(4), e.load32(e.get32(3), layout::LengthOffset)),
+                 e.ret(e.i64(0))),
+        e.ret(e.extendU(e.call("endo_mem_eq",
+                               { e.bin(BinaryenAddInt32(), e.get32(2), e.i32(headerSize)),
+                                 e.bin(BinaryenAddInt32(), e.get32(3), e.i32(headerSize)),
+                                 e.get32(4) },
+                               I32()))),
+    });
+
+    e.addFunction("endo_str_eq", { I64(), I64() }, I64(), { I32(), I32(), I32() }, body);
+}
+
+// endo_str_cmp(a: i64, b: i64) -> i64 — three-way lexicographic byte order
+// with length tie-break (std::string ordering).
+void WasmRuntime::buildStrCmp()
+{
+    auto e = Emit { _module };
+    auto const headerSize = static_cast<int32_t>(layout::HeaderSize);
+
+    // params: 0=a, 1=b; locals: 2=pa, 3=pb, 4=la, 5=lb, 6=n, 7=i, 8=ca, 9=cb
+    auto* body = e.block({
+        e.set(2, e.wrap(e.get64(0))),
+        e.set(3, e.wrap(e.get64(1))),
+        e.set(4, e.load32(e.get32(2), layout::LengthOffset)),
+        e.set(5, e.load32(e.get32(3), layout::LengthOffset)),
+        e.set(6,
+              BinaryenSelect(
+                  _module, e.bin(BinaryenLtUInt32(), e.get32(4), e.get32(5)), e.get32(4), e.get32(5))),
+        e.block({ e.loop("cmp",
+                         e.block({
+                             e.brIf("cmp.done", e.bin(BinaryenGeUInt32(), e.get32(7), e.get32(6))),
+                             e.set(8,
+                                   e.load8u(e.bin(BinaryenAddInt32(),
+                                                  e.bin(BinaryenAddInt32(), e.get32(2), e.i32(headerSize)),
+                                                  e.get32(7)))),
+                             e.set(9,
+                                   e.load8u(e.bin(BinaryenAddInt32(),
+                                                  e.bin(BinaryenAddInt32(), e.get32(3), e.i32(headerSize)),
+                                                  e.get32(7)))),
+                             e.ifThen(e.bin(BinaryenLtUInt32(), e.get32(8), e.get32(9)), e.ret(e.i64(-1))),
+                             e.ifThen(e.bin(BinaryenGtUInt32(), e.get32(8), e.get32(9)), e.ret(e.i64(1))),
+                             e.set(7, e.bin(BinaryenAddInt32(), e.get32(7), e.i32(1))),
+                             e.br("cmp"),
+                         })) },
+                "cmp.done"),
+        e.ifThen(e.bin(BinaryenLtUInt32(), e.get32(4), e.get32(5)), e.ret(e.i64(-1))),
+        e.ifThen(e.bin(BinaryenGtUInt32(), e.get32(4), e.get32(5)), e.ret(e.i64(1))),
+        e.ret(e.i64(0)),
+    });
+
+    e.addFunction("endo_str_cmp",
+                  { I64(), I64() },
+                  I64(),
+                  { I32(), I32(), I32(), I32(), I32(), I32(), I32(), I32() },
+                  body);
+}
+
+// endo_str_starts_with(s: i64, prefix: i64) -> i64
+void WasmRuntime::buildStrStartsWith()
+{
+    require("endo_mem_eq");
+    auto e = Emit { _module };
+    auto const headerSize = static_cast<int32_t>(layout::HeaderSize);
+
+    // params: 0=s, 1=prefix; locals: 2=ps, 3=pp, 4=lp
+    auto* body = e.block({
+        e.set(2, e.wrap(e.get64(0))),
+        e.set(3, e.wrap(e.get64(1))),
+        e.set(4, e.load32(e.get32(3), layout::LengthOffset)),
+        e.ifThen(e.bin(BinaryenGtUInt32(), e.get32(4), e.load32(e.get32(2), layout::LengthOffset)),
+                 e.ret(e.i64(0))),
+        e.ret(e.extendU(e.call("endo_mem_eq",
+                               { e.bin(BinaryenAddInt32(), e.get32(2), e.i32(headerSize)),
+                                 e.bin(BinaryenAddInt32(), e.get32(3), e.i32(headerSize)),
+                                 e.get32(4) },
+                               I32()))),
+    });
+
+    e.addFunction("endo_str_starts_with", { I64(), I64() }, I64(), { I32(), I32(), I32() }, body);
+}
+
+// endo_str_ends_with(s: i64, suffix: i64) -> i64
+void WasmRuntime::buildStrEndsWith()
+{
+    require("endo_mem_eq");
+    auto e = Emit { _module };
+    auto const headerSize = static_cast<int32_t>(layout::HeaderSize);
+
+    // params: 0=s, 1=suffix; locals: 2=ps, 3=pq, 4=lq, 5=ls
+    auto* body = e.block({
+        e.set(2, e.wrap(e.get64(0))),
+        e.set(3, e.wrap(e.get64(1))),
+        e.set(4, e.load32(e.get32(3), layout::LengthOffset)),
+        e.set(5, e.load32(e.get32(2), layout::LengthOffset)),
+        e.ifThen(e.bin(BinaryenGtUInt32(), e.get32(4), e.get32(5)), e.ret(e.i64(0))),
+        e.ret(e.extendU(e.call("endo_mem_eq",
+                               { e.bin(BinaryenSubInt32(),
+                                       e.bin(BinaryenAddInt32(),
+                                             e.bin(BinaryenAddInt32(), e.get32(2), e.i32(headerSize)),
+                                             e.get32(5)),
+                                       e.get32(4)),
+                                 e.bin(BinaryenAddInt32(), e.get32(3), e.i32(headerSize)),
+                                 e.get32(4) },
+                               I32()))),
+    });
+
+    e.addFunction("endo_str_ends_with", { I64(), I64() }, I64(), { I32(), I32(), I32(), I32() }, body);
+}
+
+// endo_str_contains(s: i64, needle: i64) -> i64 — naive substring search.
+void WasmRuntime::buildStrContains()
+{
+    require("endo_mem_eq");
+    auto e = Emit { _module };
+    auto const headerSize = static_cast<int32_t>(layout::HeaderSize);
+
+    // params: 0=s, 1=needle; locals: 2=ps, 3=pn, 4=ls, 5=ln, 6=start
+    auto* body = e.block({
+        e.set(2, e.wrap(e.get64(0))),
+        e.set(3, e.wrap(e.get64(1))),
+        e.set(4, e.load32(e.get32(2), layout::LengthOffset)),
+        e.set(5, e.load32(e.get32(3), layout::LengthOffset)),
+        e.ifThen(e.un(BinaryenEqZInt32(), e.get32(5)), e.ret(e.i64(1))),
+        e.ifThen(e.bin(BinaryenGtUInt32(), e.get32(5), e.get32(4)), e.ret(e.i64(0))),
+        e.block({ e.loop("scan",
+                         e.block({
+                             e.brIf("scan.done",
+                                    e.bin(BinaryenGtUInt32(),
+                                          e.bin(BinaryenAddInt32(), e.get32(6), e.get32(5)),
+                                          e.get32(4))),
+                             e.ifThen(e.call("endo_mem_eq",
+                                             { e.bin(BinaryenAddInt32(),
+                                                     e.bin(BinaryenAddInt32(), e.get32(2), e.i32(headerSize)),
+                                                     e.get32(6)),
+                                               e.bin(BinaryenAddInt32(), e.get32(3), e.i32(headerSize)),
+                                               e.get32(5) },
+                                             I32()),
+                                      e.ret(e.i64(1))),
+                             e.set(6, e.bin(BinaryenAddInt32(), e.get32(6), e.i32(1))),
+                             e.br("scan"),
+                         })) },
+                "scan.done"),
+        e.ret(e.i64(0)),
+    });
+
+    e.addFunction("endo_str_contains", { I64(), I64() }, I64(), { I32(), I32(), I32(), I32(), I32() }, body);
+}
+
+// endo_str_to_i64(s: i64) -> i64 — permissive decimal parse: optional
+// leading whitespace and sign, digits until the first non-digit, else 0.
+void WasmRuntime::buildStrToI64()
+{
+    auto e = Emit { _module };
+    auto const headerSize = static_cast<int32_t>(layout::HeaderSize);
+
+    // params: 0=s; locals: 1=p, 2=len, 3=i, 4=c, 5=neg, 6=acc(i64)
+    auto const currentChar = [&]() {
+        return e.load8u(
+            e.bin(BinaryenAddInt32(), e.bin(BinaryenAddInt32(), e.get32(1), e.i32(headerSize)), e.get32(3)));
+    };
+    auto const atEnd = [&]() {
+        return e.bin(BinaryenGeUInt32(), e.get32(3), e.get32(2));
+    };
+
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.set(2, e.load32(e.get32(1), layout::LengthOffset)),
+        // skip leading spaces and tabs
+        e.block({ e.loop("ws",
+                         e.block({
+                             e.brIf("ws.done", atEnd()),
+                             e.set(4, currentChar()),
+                             e.brIf("ws.done",
+                                    e.bin(BinaryenAndInt32(),
+                                          e.bin(BinaryenNeInt32(), e.get32(4), e.i32(' ')),
+                                          e.bin(BinaryenNeInt32(), e.get32(4), e.i32('\t')))),
+                             e.set(3, e.bin(BinaryenAddInt32(), e.get32(3), e.i32(1))),
+                             e.br("ws"),
+                         })) },
+                "ws.done"),
+        // optional sign
+        e.ifThen(e.un(BinaryenEqZInt32(), atEnd()),
+                 e.block({
+                     e.set(4, currentChar()),
+                     e.ifThen(e.bin(BinaryenEqInt32(), e.get32(4), e.i32('-')),
+                              e.block({
+                                  e.set(5, e.i32(1)),
+                                  e.set(3, e.bin(BinaryenAddInt32(), e.get32(3), e.i32(1))),
+                              })),
+                     e.ifThen(e.bin(BinaryenEqInt32(), e.get32(4), e.i32('+')),
+                              e.set(3, e.bin(BinaryenAddInt32(), e.get32(3), e.i32(1)))),
+                 })),
+        // digits
+        e.block({ e.loop("digits",
+                         e.block({
+                             e.brIf("digits.done", atEnd()),
+                             e.set(4, currentChar()),
+                             e.brIf("digits.done", e.bin(BinaryenLtUInt32(), e.get32(4), e.i32('0'))),
+                             e.brIf("digits.done", e.bin(BinaryenGtUInt32(), e.get32(4), e.i32('9'))),
+                             e.set(6,
+                                   e.bin(BinaryenAddInt64(),
+                                         e.bin(BinaryenMulInt64(), e.get64(6), e.i64(10)),
+                                         e.extendU(e.bin(BinaryenSubInt32(), e.get32(4), e.i32('0'))))),
+                             e.set(3, e.bin(BinaryenAddInt32(), e.get32(3), e.i32(1))),
+                             e.br("digits"),
+                         })) },
+                "digits.done"),
+        e.ifThen(e.get32(5), e.set(6, e.bin(BinaryenSubInt64(), e.i64(0), e.get64(6)))),
+        e.ret(e.get64(6)),
+    });
+
+    e.addFunction("endo_str_to_i64", { I64() }, I64(), { I32(), I32(), I32(), I32(), I32(), I64() }, body);
 }
 
 } // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmRuntime.cpp
+++ b/src/CoreVM/wasm/WasmRuntime.cpp
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+#include <CoreVM/enums.hpp>
+#include <CoreVM/types/TypeDescriptor.hpp>
 #include <CoreVM/wasm/WasmRuntime.hpp>
 #include <CoreVM/wasm/WasmStringTable.hpp>
 
@@ -188,12 +190,12 @@ namespace
 
         [[nodiscard]] BinaryenExpressionRef heapPtr() const
         {
-            return BinaryenGlobalGet(m, std::string(layout::HeapPointerGlobal).c_str(), BinaryenTypeInt32());
+            return BinaryenGlobalGet(m, layout::HeapPointerGlobal, BinaryenTypeInt32());
         }
 
         [[nodiscard]] BinaryenExpressionRef setHeapPtr(BinaryenExpressionRef v) const
         {
-            return BinaryenGlobalSet(m, std::string(layout::HeapPointerGlobal).c_str(), v);
+            return BinaryenGlobalSet(m, layout::HeapPointerGlobal, v);
         }
 
         void addFunction(char const* name,
@@ -240,6 +242,7 @@ void WasmRuntime::require(std::string_view name)
         { "endo_panic", &WasmRuntime::buildPanic },
         { "endo_i64_to_str", &WasmRuntime::buildI64ToStr },
         { "endo_object_to_string", &WasmRuntime::buildObjectToString },
+        { "endo_exit", &WasmRuntime::buildExit },
         { "endo_i64_div", &WasmRuntime::buildI64Div },
         { "endo_i64_rem", &WasmRuntime::buildI64Rem },
         { "endo_i64_pow", &WasmRuntime::buildI64Pow },
@@ -302,13 +305,7 @@ void WasmRuntime::importHelper(std::string_view name)
     auto const* def = findRuntimeHelper(name);
     if (def == nullptr)
         return; // unknown internal name: leave for module validation to catch
-    auto const functionName = std::string(name);
-    BinaryenAddFunctionImport(_module,
-                              functionName.c_str(),
-                              "endo",
-                              functionName.c_str(),
-                              binaryenParamsType(*def),
-                              binaryenResultType(*def));
+    addEndoImport(_module, *def);
 }
 
 // endo_alloc(size: i32) -> i32 — bump allocation with memory.grow on demand.
@@ -533,6 +530,24 @@ void WasmRuntime::buildObjectToString()
     auto e = Emit { _module };
     auto* body = e.ret(e.call("endo_value_to_str", { e.get64(0) }, I64()));
     e.addFunction("endo_object_to_string", { I64() }, I64(), {}, body);
+}
+
+// endo_exit(code: i64) — terminates the program with shell exit-status
+// semantics (Shell::execute): an exit status set during execution wins;
+// otherwise the EXIT operand collapses to 1 (non-zero) or 0.
+void WasmRuntime::buildExit()
+{
+    auto e = Emit { _module };
+    auto* status = BinaryenGlobalGet(_module, layout::ExitStatusGlobal, BinaryenTypeInt32());
+    auto* statusAgain = BinaryenGlobalGet(_module, layout::ExitStatusGlobal, BinaryenTypeInt32());
+
+    auto* body = e.block({
+        e.ifThen(status, e.callVoid("proc_exit", { statusAgain })),
+        e.callVoid("proc_exit", { e.bin(BinaryenNeInt64(), e.get64(0), e.i64(0)) }),
+        BinaryenUnreachable(_module),
+    });
+
+    e.addFunction("endo_exit", { I64() }, BinaryenTypeNone(), {}, body);
 }
 
 // endo_i64_div(a, b) -> i64 — VM semantics: division by zero is a runtime
@@ -1024,18 +1039,18 @@ void WasmRuntime::buildF64ToStrFixed()
 
 namespace
 {
-    // LiteralType values baked into formatter dispatch (see CoreVM/enums.hpp).
-    constexpr int32_t LiteralBoolean = 1;
-    constexpr int32_t LiteralNumber = 2;
-    constexpr int32_t LiteralString = 3;
-    constexpr int32_t LiteralFloat = 17;
+    // LiteralType / BuiltinTypeId values baked into the generated formatter
+    // dispatch, derived from the real enums so renumbering cannot drift.
+    constexpr auto LiteralBoolean = static_cast<int32_t>(LiteralType::Boolean);
+    constexpr auto LiteralNumber = static_cast<int32_t>(LiteralType::Number);
+    constexpr auto LiteralString = static_cast<int32_t>(LiteralType::String);
+    constexpr auto LiteralFloat = static_cast<int32_t>(LiteralType::Float);
 
-    // BuiltinTypeId values (see CoreVM/types/TypeDescriptor.hpp).
-    constexpr int32_t TypeIdOption = 1;
-    constexpr int32_t TypeIdResult = 2;
-    constexpr int32_t TypeIdTuple2 = 3;
-    constexpr int32_t TypeIdTuple3 = 4;
-    constexpr int32_t TypeIdList = 5;
+    constexpr auto TypeIdOption = static_cast<int32_t>(BuiltinTypeId::Option);
+    constexpr auto TypeIdResult = static_cast<int32_t>(BuiltinTypeId::Result);
+    constexpr auto TypeIdTuple2 = static_cast<int32_t>(BuiltinTypeId::Tuple2);
+    constexpr auto TypeIdTuple3 = static_cast<int32_t>(BuiltinTypeId::Tuple3);
+    constexpr auto TypeIdList = static_cast<int32_t>(BuiltinTypeId::List);
 } // namespace
 
 // endo_slot_to_str(v: i64, litType: i64, quote: i64) -> i64 — renders one
@@ -1234,9 +1249,9 @@ void WasmRuntime::buildResultStr()
     e.addFunction("endo_result_str", { I64() }, I64(), { I32() }, body);
 }
 
-// endo_tuple2_str(v: i64) -> i64 — "(a, b)"; element types are packed one
-// byte each into slot 2.
-void WasmRuntime::buildTuple2Str()
+// endo_tupleN_str(v: i64) -> i64 — "(a, b[, c])"; element LiteralTypes are
+// packed one byte each into the slot at index `arity`.
+void WasmRuntime::buildTupleStr(char const* name, uint32_t arity)
 {
     require("endo_str_concat");
     require("endo_slot_to_str");
@@ -1251,7 +1266,7 @@ void WasmRuntime::buildTuple2Str()
     auto const packedType = [&](uint32_t index) {
         return e.bin(BinaryenAndInt64(),
                      e.bin(BinaryenShrUInt64(),
-                           e.load64(e.get32(1), layout::HeaderSize + (2 * layout::SlotSize)),
+                           e.load64(e.get32(1), layout::HeaderSize + (arity * layout::SlotSize)),
                            e.i64(8L * index)),
                      e.i64(0xFF));
     };
@@ -1263,56 +1278,28 @@ void WasmRuntime::buildTuple2Str()
     };
 
     // params: 0=v; locals: 1=p, 2=result i64
-    auto* body = e.block({
+    auto statements = std::vector<BinaryenExpressionRef> {
         e.set(1, e.wrap(e.get64(0))),
         e.set(2, concat(e.i64(lparen), element(0))),
-        e.set(2, concat(e.get64(2), e.i64(comma))),
-        e.set(2, concat(e.get64(2), element(1))),
-        e.ret(concat(e.get64(2), e.i64(rparen))),
-    });
+    };
+    for (uint32_t index = 1; index < arity; ++index)
+    {
+        statements.push_back(e.set(2, concat(e.get64(2), e.i64(comma))));
+        statements.push_back(e.set(2, concat(e.get64(2), element(index))));
+    }
+    statements.push_back(e.ret(concat(e.get64(2), e.i64(rparen))));
 
-    e.addFunction("endo_tuple2_str", { I64() }, I64(), { I32(), I64() }, body);
+    e.addFunction(name, { I64() }, I64(), { I32(), I64() }, e.block(std::move(statements)));
 }
 
-// endo_tuple3_str(v: i64) -> i64 — "(a, b, c)"; packed types in slot 3.
+void WasmRuntime::buildTuple2Str()
+{
+    buildTupleStr("endo_tuple2_str", 2);
+}
+
 void WasmRuntime::buildTuple3Str()
 {
-    require("endo_str_concat");
-    require("endo_slot_to_str");
-    auto e = Emit { _module };
-    auto const lparen = static_cast<int64_t>(_strings->intern("("));
-    auto const rparen = static_cast<int64_t>(_strings->intern(")"));
-    auto const comma = static_cast<int64_t>(_strings->intern(", "));
-
-    auto const slotValue = [&](uint32_t index) {
-        return e.load64(e.get32(1), layout::HeaderSize + (index * layout::SlotSize));
-    };
-    auto const packedType = [&](uint32_t index) {
-        return e.bin(BinaryenAndInt64(),
-                     e.bin(BinaryenShrUInt64(),
-                           e.load64(e.get32(1), layout::HeaderSize + (3 * layout::SlotSize)),
-                           e.i64(8L * index)),
-                     e.i64(0xFF));
-    };
-    auto const concat = [&](BinaryenExpressionRef a, BinaryenExpressionRef b) {
-        return e.call("endo_str_concat", { a, b }, I64());
-    };
-    auto const element = [&](uint32_t index) {
-        return e.call("endo_slot_to_str", { slotValue(index), packedType(index), e.i64(1) }, I64());
-    };
-
-    // params: 0=v; locals: 1=p, 2=result i64
-    auto* body = e.block({
-        e.set(1, e.wrap(e.get64(0))),
-        e.set(2, concat(e.i64(lparen), element(0))),
-        e.set(2, concat(e.get64(2), e.i64(comma))),
-        e.set(2, concat(e.get64(2), element(1))),
-        e.set(2, concat(e.get64(2), e.i64(comma))),
-        e.set(2, concat(e.get64(2), element(2))),
-        e.ret(concat(e.get64(2), e.i64(rparen))),
-    });
-
-    e.addFunction("endo_tuple3_str", { I64() }, I64(), { I32(), I64() }, body);
+    buildTupleStr("endo_tuple3_str", 3);
 }
 
 // endo_display_result(v: i64) — println of the recursively formatted value.
@@ -1710,7 +1697,6 @@ void WasmRuntime::buildF64ToStrG()
     auto const minus = static_cast<int64_t>(_strings->intern("-"));
     auto const dot = static_cast<int64_t>(_strings->intern("."));
     auto const zeroDot = static_cast<int64_t>(_strings->intern("0."));
-    auto const zeroDigit = static_cast<int64_t>(_strings->intern("0"));
     auto const expPlus = static_cast<int64_t>(_strings->intern("e+"));
     auto const expMinus = static_cast<int64_t>(_strings->intern("e-"));
     auto const infinity = std::numeric_limits<double>::infinity();
@@ -1820,7 +1806,7 @@ void WasmRuntime::buildF64ToStrG()
                         e.block({ e.loop("zeros",
                                          e.block({
                                              e.brIf("zeros.done", e.un(BinaryenEqZInt64(), e.get64(8))),
-                                             e.set(5, concat(e.get64(5), e.i64(zeroDigit))),
+                                             e.set(5, concat(e.get64(5), e.i64(zero))),
                                              e.set(8, e.bin(BinaryenSubInt64(), e.get64(8), e.i64(1))),
                                              e.br("zeros"),
                                          })) },
@@ -1858,7 +1844,7 @@ void WasmRuntime::buildF64ToStrG()
                 e.ifThen(e.bin(BinaryenLtSInt64(), e.get64(2), e.i64(0)),
                          e.set(2, e.bin(BinaryenSubInt64(), e.i64(0), e.get64(2)))),
                 e.ifThen(e.bin(BinaryenLtSInt64(), e.get64(2), e.i64(10)),
-                         e.set(5, concat(e.get64(5), e.i64(zeroDigit)))),
+                         e.set(5, concat(e.get64(5), e.i64(zero)))),
                 e.set(5, concat(e.get64(5), e.call("endo_i64_to_str", { e.get64(2) }, I64()))),
             })),
         e.ifThen(e.bin(BinaryenLtFloat64(), e.getF64(0), e.f64(0.0)),

--- a/src/CoreVM/wasm/WasmRuntime.cpp
+++ b/src/CoreVM/wasm/WasmRuntime.cpp
@@ -3,6 +3,7 @@
 #include <CoreVM/wasm/WasmStringTable.hpp>
 
 #include <array>
+#include <limits>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -59,10 +60,44 @@ namespace
             return un(BinaryenExtendUInt32(), v);
         }
 
+        [[nodiscard]] BinaryenExpressionRef f64(double v) const
+        {
+            return BinaryenConst(m, BinaryenLiteralFloat64(v));
+        }
+
+        [[nodiscard]] BinaryenExpressionRef getF64(BinaryenIndex i) const
+        {
+            return BinaryenLocalGet(m, i, BinaryenTypeFloat64());
+        }
+
         // memory (32-bit addresses)
         [[nodiscard]] BinaryenExpressionRef load8u(BinaryenExpressionRef ptr, uint32_t offset = 0) const
         {
             return BinaryenLoad(m, 1, false, offset, 0, BinaryenTypeInt32(), ptr, "0");
+        }
+
+        [[nodiscard]] BinaryenExpressionRef load16u(BinaryenExpressionRef ptr, uint32_t offset = 0) const
+        {
+            return BinaryenLoad(m, 2, false, offset, 0, BinaryenTypeInt32(), ptr, "0");
+        }
+
+        [[nodiscard]] BinaryenExpressionRef load64(BinaryenExpressionRef ptr, uint32_t offset = 0) const
+        {
+            return BinaryenLoad(m, 8, false, offset, 0, BinaryenTypeInt64(), ptr, "0");
+        }
+
+        [[nodiscard]] BinaryenExpressionRef store16(BinaryenExpressionRef ptr,
+                                                    BinaryenExpressionRef v,
+                                                    uint32_t offset = 0) const
+        {
+            return BinaryenStore(m, 2, offset, 0, ptr, v, BinaryenTypeInt32(), "0");
+        }
+
+        [[nodiscard]] BinaryenExpressionRef store64(BinaryenExpressionRef ptr,
+                                                    BinaryenExpressionRef v,
+                                                    uint32_t offset = 0) const
+        {
+            return BinaryenStore(m, 8, offset, 0, ptr, v, BinaryenTypeInt64(), "0");
         }
 
         [[nodiscard]] BinaryenExpressionRef load32(BinaryenExpressionRef ptr, uint32_t offset = 0) const
@@ -217,6 +252,16 @@ void WasmRuntime::require(std::string_view name)
         { "endo_str_ends_with", &WasmRuntime::buildStrEndsWith },
         { "endo_str_contains", &WasmRuntime::buildStrContains },
         { "endo_str_to_i64", &WasmRuntime::buildStrToI64 },
+        { "endo_str_slice", &WasmRuntime::buildStrSlice },
+        { "endo_obj_alloc", &WasmRuntime::buildObjAlloc },
+        { "endo_f64_to_str_fixed", &WasmRuntime::buildF64ToStrFixed },
+        { "endo_slot_to_str", &WasmRuntime::buildSlotToStr },
+        { "endo_value_to_str", &WasmRuntime::buildValueToStr },
+        { "endo_list_to_string", &WasmRuntime::buildListToString },
+        { "endo_option_str", &WasmRuntime::buildOptionStr },
+        { "endo_result_str", &WasmRuntime::buildResultStr },
+        { "endo_tuple2_str", &WasmRuntime::buildTuple2Str },
+        { "endo_tuple3_str", &WasmRuntime::buildTuple3Str },
     };
 
     if (auto const it = builders.find(name); it != builders.end())
@@ -467,37 +512,14 @@ void WasmRuntime::buildI64ToStr()
     e.addFunction("endo_i64_to_str", { I64() }, I64(), { I32(), I32(), I32(), I32() }, body);
 }
 
-// endo_object_to_string(v: i64) -> i64 — runtime classification of a
-// dynamically typed value: known string cells pass through, object cells get
-// a placeholder (replaced by the real composite formatter in a later
-// milestone), everything else formats as a decimal number.
+// endo_object_to_string(v: i64) -> i64 — public entry for the builtin
+// object_to_string(I)S: delegates to the recursive value classifier.
 void WasmRuntime::buildObjectToString()
 {
-    require("endo_i64_to_str");
+    require("endo_value_to_str");
     auto e = Emit { _module };
-    auto const placeholder = static_cast<int64_t>(_strings->intern("<object>"));
-
-    // params: 0=v; locals: 1=p
-    auto* const plausiblePointer =
-        e.bin(BinaryenAndInt32(),
-              e.bin(BinaryenGeUInt32(), e.get32(1), e.i32(static_cast<int32_t>(layout::DataBase))),
-              e.bin(BinaryenAndInt32(),
-                    e.un(BinaryenEqZInt32(), e.bin(BinaryenAndInt32(), e.get32(1), e.i32(7))),
-                    e.bin(BinaryenLtUInt32(), e.get32(1), e.heapPtr())));
-
-    auto* body = e.block({
-        e.set(1, e.wrap(e.get64(0))),
-        e.ifThen(plausiblePointer,
-                 e.block({
-                     e.ifThen(e.bin(BinaryenEqInt32(), e.load8u(e.get32(1)), e.i32(layout::KindString)),
-                              e.ret(e.get64(0))),
-                     e.ifThen(e.bin(BinaryenEqInt32(), e.load8u(e.get32(1)), e.i32(layout::KindObject)),
-                              e.ret(e.i64(placeholder))),
-                 })),
-        e.ret(e.call("endo_i64_to_str", { e.get64(0) }, I64())),
-    });
-
-    e.addFunction("endo_object_to_string", { I64() }, I64(), { I32() }, body);
+    auto* body = e.ret(e.call("endo_value_to_str", { e.get64(0) }, I64()));
+    e.addFunction("endo_object_to_string", { I64() }, I64(), {}, body);
 }
 
 // endo_i64_div(a, b) -> i64 — VM semantics: division by zero is a runtime
@@ -859,6 +881,425 @@ void WasmRuntime::buildStrToI64()
     });
 
     e.addFunction("endo_str_to_i64", { I64() }, I64(), { I32(), I32(), I32(), I32(), I32(), I64() }, body);
+}
+
+// endo_str_slice(s: i64, start: i64, len: i64) -> i64 — copies a byte range
+// into a fresh string (bounds are the caller's responsibility).
+void WasmRuntime::buildStrSlice()
+{
+    require("endo_str_alloc");
+    auto e = Emit { _module };
+    auto const headerSize = static_cast<int32_t>(layout::HeaderSize);
+
+    // params: 0=s, 1=start, 2=len; locals: 3=p
+    auto* body = e.block({
+        e.set(3, e.call("endo_str_alloc", { e.wrap(e.get64(2)) }, I32())),
+        BinaryenMemoryCopy(_module,
+                           e.bin(BinaryenAddInt32(), e.get32(3), e.i32(headerSize)),
+                           e.bin(BinaryenAddInt32(),
+                                 e.bin(BinaryenAddInt32(), e.wrap(e.get64(0)), e.i32(headerSize)),
+                                 e.wrap(e.get64(1))),
+                           e.wrap(e.get64(2)),
+                           "0",
+                           "0"),
+        e.ret(e.extendU(e.get32(3))),
+    });
+
+    e.addFunction("endo_str_slice", { I64(), I64(), I64() }, I64(), { I32() }, body);
+}
+
+// endo_obj_alloc(typeId: i64, slotCount: i64) -> i64 — allocates an object
+// cell; slots are zero (fresh memory, never reused).
+void WasmRuntime::buildObjAlloc()
+{
+    require("endo_alloc");
+    auto e = Emit { _module };
+
+    // params: 0=typeId, 1=slotCount; locals: 2=p
+    auto* body = e.block({
+        e.set(2,
+              e.call("endo_alloc",
+                     { e.bin(BinaryenAddInt32(),
+                             e.i32(static_cast<int32_t>(layout::HeaderSize)),
+                             e.bin(BinaryenShlInt32(), e.wrap(e.get64(1)), e.i32(3))) },
+                     I32())),
+        e.store8(e.get32(2), e.i32(layout::KindObject)),
+        e.store16(e.get32(2), e.wrap(e.get64(0)), layout::TypeIdOffset),
+        e.ret(e.extendU(e.get32(2))),
+    });
+
+    e.addFunction("endo_obj_alloc", { I64(), I64() }, I64(), { I32() }, body);
+}
+
+// endo_f64_to_str_fixed(f: f64) -> i64 — %f-style formatting with 6
+// fractional digits and trailing-zero trimming (at least one digit kept),
+// replicating slotValueToString's Float branch. Magnitudes beyond the i64
+// range degrade to a saturated integer part (documented deviation).
+void WasmRuntime::buildF64ToStrFixed()
+{
+    require("endo_i64_to_str");
+    require("endo_str_concat");
+    require("endo_str_slice");
+    auto e = Emit { _module };
+    auto const nan = static_cast<int64_t>(_strings->intern("nan"));
+    auto const inf = static_cast<int64_t>(_strings->intern("inf"));
+    auto const negInf = static_cast<int64_t>(_strings->intern("-inf"));
+    auto const minus = static_cast<int64_t>(_strings->intern("-"));
+    auto const dot = static_cast<int64_t>(_strings->intern("."));
+    auto const infinity = std::numeric_limits<double>::infinity();
+
+    // params: 0=f; locals: 1=abs f64, 2=ip i64, 3=micro i64, 4=intStr i64,
+    //                      5=fracStr i64, 6=keep i32, 7=fracPtr i32
+    auto* body = e.block({
+        e.ifThen(e.bin(BinaryenNeFloat64(), e.getF64(0), e.getF64(0)), e.ret(e.i64(nan))),
+        e.ifThen(e.bin(BinaryenEqFloat64(), e.getF64(0), e.f64(infinity)), e.ret(e.i64(inf))),
+        e.ifThen(e.bin(BinaryenEqFloat64(), e.getF64(0), e.f64(-infinity)), e.ret(e.i64(negInf))),
+        e.set(1, e.un(BinaryenAbsFloat64(), e.getF64(0))),
+        // integer part and rounded 6-digit fraction
+        e.set(2, e.un(BinaryenTruncSatSFloat64ToInt64(), e.getF64(1))),
+        e.set(3,
+              e.un(BinaryenTruncSatSFloat64ToInt64(),
+                   e.bin(BinaryenAddFloat64(),
+                         e.bin(BinaryenMulFloat64(),
+                               e.bin(BinaryenSubFloat64(),
+                                     e.getF64(1),
+                                     e.un(BinaryenConvertSInt64ToFloat64(), e.get64(2))),
+                               e.f64(1'000'000.0)),
+                         e.f64(0.5)))),
+        e.ifThen(e.bin(BinaryenGeSInt64(), e.get64(3), e.i64(1'000'000)),
+                 e.block({
+                     e.set(2, e.bin(BinaryenAddInt64(), e.get64(2), e.i64(1))),
+                     e.set(3, e.i64(0)),
+                 })),
+        e.set(4, e.call("endo_i64_to_str", { e.get64(2) }, I64())),
+        e.ifThen(e.bin(BinaryenLtFloat64(), e.getF64(0), e.f64(0.0)),
+                 e.set(4, e.call("endo_str_concat", { e.i64(minus), e.get64(4) }, I64()))),
+        // "1DDDDDD" gives six zero-padded fraction digits after the first char
+        e.set(5,
+              e.call("endo_i64_to_str", { e.bin(BinaryenAddInt64(), e.get64(3), e.i64(1'000'000)) }, I64())),
+        e.set(7, e.wrap(e.get64(5))),
+        e.set(6, e.i32(6)),
+        e.block(
+            { e.loop("trim",
+                     e.block({
+                         e.brIf("trim.done", e.bin(BinaryenLeUInt32(), e.get32(6), e.i32(1))),
+                         e.brIf("trim.done",
+                                e.bin(BinaryenNeInt32(),
+                                      e.load8u(e.bin(BinaryenAddInt32(),
+                                                     e.bin(BinaryenAddInt32(),
+                                                           e.get32(7),
+                                                           e.i32(static_cast<int32_t>(layout::HeaderSize))),
+                                                     e.get32(6))),
+                                      e.i32('0'))),
+                         e.set(6, e.bin(BinaryenSubInt32(), e.get32(6), e.i32(1))),
+                         e.br("trim"),
+                     })) },
+            "trim.done"),
+        e.set(4, e.call("endo_str_concat", { e.get64(4), e.i64(dot) }, I64())),
+        e.ret(e.call(
+            "endo_str_concat",
+            { e.get64(4), e.call("endo_str_slice", { e.get64(5), e.i64(1), e.extendU(e.get32(6)) }, I64()) },
+            I64())),
+    });
+
+    e.addFunction("endo_f64_to_str_fixed",
+                  { BinaryenTypeFloat64() },
+                  I64(),
+                  { BinaryenTypeFloat64(), I64(), I64(), I64(), I64(), I32(), I32() },
+                  body);
+}
+
+namespace
+{
+    // LiteralType values baked into formatter dispatch (see CoreVM/enums.hpp).
+    constexpr int32_t LiteralBoolean = 1;
+    constexpr int32_t LiteralNumber = 2;
+    constexpr int32_t LiteralString = 3;
+    constexpr int32_t LiteralFloat = 17;
+
+    // BuiltinTypeId values (see CoreVM/types/TypeDescriptor.hpp).
+    constexpr int32_t TypeIdOption = 1;
+    constexpr int32_t TypeIdResult = 2;
+    constexpr int32_t TypeIdTuple2 = 3;
+    constexpr int32_t TypeIdTuple3 = 4;
+    constexpr int32_t TypeIdList = 5;
+} // namespace
+
+// endo_slot_to_str(v: i64, litType: i64, quote: i64) -> i64 — renders one
+// container slot according to its element LiteralType, mirroring
+// slotValueToString (strings quoted inside containers).
+void WasmRuntime::buildSlotToStr()
+{
+    require("endo_i64_to_str");
+    require("endo_str_concat");
+    require("endo_f64_to_str_fixed");
+    require("endo_value_to_str");
+    auto e = Emit { _module };
+    auto const nullStr = static_cast<int64_t>(_strings->intern("(null)"));
+    auto const quoteStr = static_cast<int64_t>(_strings->intern("\""));
+    auto const trueStr = static_cast<int64_t>(_strings->intern("true"));
+    auto const falseStr = static_cast<int64_t>(_strings->intern("false"));
+
+    // params: 0=v, 1=litType, 2=quote; locals: 3=lt i32
+    auto* body = e.block({
+        e.set(3, e.wrap(e.get64(1))),
+        e.ifThen(e.bin(BinaryenEqInt32(), e.get32(3), e.i32(LiteralString)),
+                 e.block({
+                     e.ifThen(e.un(BinaryenEqZInt32(), e.wrap(e.get64(0))), e.ret(e.i64(nullStr))),
+                     e.ifThen(e.un(BinaryenEqZInt64(), e.get64(2)), e.ret(e.get64(0))),
+                     e.ret(e.call("endo_str_concat",
+                                  { e.call("endo_str_concat", { e.i64(quoteStr), e.get64(0) }, I64()),
+                                    e.i64(quoteStr) },
+                                  I64())),
+                 })),
+        e.ifThen(e.bin(BinaryenEqInt32(), e.get32(3), e.i32(LiteralBoolean)),
+                 e.ret(BinaryenSelect(
+                     _module, e.un(BinaryenEqZInt64(), e.get64(0)), e.i64(falseStr), e.i64(trueStr)))),
+        e.ifThen(e.bin(BinaryenEqInt32(), e.get32(3), e.i32(LiteralNumber)),
+                 e.ret(e.call("endo_i64_to_str", { e.get64(0) }, I64()))),
+        e.ifThen(
+            e.bin(BinaryenEqInt32(), e.get32(3), e.i32(LiteralFloat)),
+            e.ret(e.call("endo_f64_to_str_fixed", { e.un(BinaryenReinterpretInt64(), e.get64(0)) }, I64()))),
+        e.ret(e.call("endo_value_to_str", { e.get64(0) }, I64())),
+    });
+
+    e.addFunction("endo_slot_to_str", { I64(), I64(), I64() }, I64(), { I32() }, body);
+}
+
+// endo_value_to_str(v: i64) -> i64 — the recursive dynamic-value classifier
+// behind object_to_string: strings pass through, known composite objects
+// dispatch to their formatter, everything else formats as a number.
+void WasmRuntime::buildValueToStr()
+{
+    require("endo_i64_to_str");
+    require("endo_list_to_string");
+    require("endo_option_str");
+    require("endo_result_str");
+    require("endo_tuple2_str");
+    require("endo_tuple3_str");
+    auto e = Emit { _module };
+    auto const placeholder = static_cast<int64_t>(_strings->intern("<object>"));
+
+    // params: 0=v; locals: 1=p, 2=typeId
+    auto* const plausiblePointer =
+        e.bin(BinaryenAndInt32(),
+              e.bin(BinaryenGeUInt32(), e.get32(1), e.i32(static_cast<int32_t>(layout::DataBase))),
+              e.bin(BinaryenAndInt32(),
+                    e.un(BinaryenEqZInt32(), e.bin(BinaryenAndInt32(), e.get32(1), e.i32(7))),
+                    e.bin(BinaryenLtUInt32(), e.get32(1), e.heapPtr())));
+
+    auto const dispatch = [&](int32_t typeId, char const* formatter) {
+        return e.ifThen(e.bin(BinaryenEqInt32(), e.get32(2), e.i32(typeId)),
+                        e.ret(e.call(formatter, { e.get64(0) }, I64())));
+    };
+
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.ifThen(plausiblePointer,
+                 e.block({
+                     e.ifThen(e.bin(BinaryenEqInt32(), e.load8u(e.get32(1)), e.i32(layout::KindString)),
+                              e.ret(e.get64(0))),
+                     e.ifThen(e.bin(BinaryenEqInt32(), e.load8u(e.get32(1)), e.i32(layout::KindObject)),
+                              e.block({
+                                  e.set(2, e.load16u(e.get32(1), layout::TypeIdOffset)),
+                                  dispatch(TypeIdList, "endo_list_to_string"),
+                                  dispatch(TypeIdOption, "endo_option_str"),
+                                  dispatch(TypeIdResult, "endo_result_str"),
+                                  dispatch(TypeIdTuple2, "endo_tuple2_str"),
+                                  dispatch(TypeIdTuple3, "endo_tuple3_str"),
+                                  e.ret(e.i64(placeholder)),
+                              })),
+                 })),
+        e.ret(e.call("endo_i64_to_str", { e.get64(0) }, I64())),
+    });
+
+    e.addFunction("endo_value_to_str", { I64() }, I64(), { I32(), I32() }, body);
+}
+
+// endo_list_to_string(v: i64) -> i64 — "[e; e; e]" with the element type
+// from cons-cell slot 2 (see formatList in TypeFormatters.cpp).
+void WasmRuntime::buildListToString()
+{
+    require("endo_str_concat");
+    require("endo_slot_to_str");
+    auto e = Emit { _module };
+    auto const headerSize = layout::HeaderSize;
+    auto const lbracket = static_cast<int64_t>(_strings->intern("["));
+    auto const rbracket = static_cast<int64_t>(_strings->intern("]"));
+    auto const separator = static_cast<int64_t>(_strings->intern("; "));
+
+    // params: 0=v; locals: 1=cur i32, 2=result i64, 3=elemType i64, 4=first i32
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.set(2, e.i64(lbracket)),
+        e.set(4, e.i32(1)),
+        e.ifThen(e.get32(1), e.set(3, e.load64(e.get32(1), headerSize + (2 * layout::SlotSize)))),
+        e.block(
+            { e.loop(
+                "cells",
+                e.block({
+                    // continue only while cur is a Cons cell of a List
+                    e.brIf("cells.done", e.un(BinaryenEqZInt32(), e.get32(1))),
+                    e.brIf("cells.done",
+                           e.bin(BinaryenNeInt32(), e.load8u(e.get32(1)), e.i32(layout::KindObject))),
+                    e.brIf("cells.done",
+                           e.bin(BinaryenNeInt32(),
+                                 e.load16u(e.get32(1), layout::TypeIdOffset),
+                                 e.i32(TypeIdList))),
+                    e.brIf("cells.done",
+                           e.bin(BinaryenNeInt32(), e.load8u(e.get32(1), layout::TagOffset), e.i32(1))),
+                    e.ifThen(e.un(BinaryenEqZInt32(), e.get32(4)),
+                             e.set(2, e.call("endo_str_concat", { e.get64(2), e.i64(separator) }, I64()))),
+                    e.set(4, e.i32(0)),
+                    e.set(2,
+                          e.call("endo_str_concat",
+                                 { e.get64(2),
+                                   e.call("endo_slot_to_str",
+                                          { e.load64(e.get32(1), headerSize), e.get64(3), e.i64(1) },
+                                          I64()) },
+                                 I64())),
+                    e.set(1, e.wrap(e.load64(e.get32(1), headerSize + layout::SlotSize))),
+                    e.br("cells"),
+                })) },
+            "cells.done"),
+        e.ret(e.call("endo_str_concat", { e.get64(2), e.i64(rbracket) }, I64())),
+    });
+
+    e.addFunction("endo_list_to_string", { I64() }, I64(), { I32(), I64(), I64(), I32() }, body);
+}
+
+// endo_option_str(v: i64) -> i64 — "None" or "Some <slot0>" (inner type in slot 1).
+void WasmRuntime::buildOptionStr()
+{
+    require("endo_str_concat");
+    require("endo_slot_to_str");
+    auto e = Emit { _module };
+    auto const none = static_cast<int64_t>(_strings->intern("None"));
+    auto const some = static_cast<int64_t>(_strings->intern("Some "));
+
+    // params: 0=v; locals: 1=p
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.ifThen(e.un(BinaryenEqZInt32(), e.load8u(e.get32(1), layout::TagOffset)), e.ret(e.i64(none))),
+        e.ret(e.call("endo_str_concat",
+                     { e.i64(some),
+                       e.call("endo_slot_to_str",
+                              { e.load64(e.get32(1), layout::HeaderSize),
+                                e.load64(e.get32(1), layout::HeaderSize + layout::SlotSize),
+                                e.i64(1) },
+                              I64()) },
+                     I64())),
+    });
+
+    e.addFunction("endo_option_str", { I64() }, I64(), { I32() }, body);
+}
+
+// endo_result_str(v: i64) -> i64 — "Ok <slot0>" / "Error <slot0>".
+void WasmRuntime::buildResultStr()
+{
+    require("endo_str_concat");
+    require("endo_slot_to_str");
+    auto e = Emit { _module };
+    auto const okPrefix = static_cast<int64_t>(_strings->intern("Ok "));
+    auto const errorPrefix = static_cast<int64_t>(_strings->intern("Error "));
+
+    // params: 0=v; locals: 1=p
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.ret(e.call(
+            "endo_str_concat",
+            { BinaryenSelect(
+                  _module, e.load8u(e.get32(1), layout::TagOffset), e.i64(okPrefix), e.i64(errorPrefix)),
+              e.call("endo_slot_to_str",
+                     { e.load64(e.get32(1), layout::HeaderSize),
+                       e.load64(e.get32(1), layout::HeaderSize + layout::SlotSize),
+                       e.i64(1) },
+                     I64()) },
+            I64())),
+    });
+
+    e.addFunction("endo_result_str", { I64() }, I64(), { I32() }, body);
+}
+
+// endo_tuple2_str(v: i64) -> i64 — "(a, b)"; element types are packed one
+// byte each into slot 2.
+void WasmRuntime::buildTuple2Str()
+{
+    require("endo_str_concat");
+    require("endo_slot_to_str");
+    auto e = Emit { _module };
+    auto const lparen = static_cast<int64_t>(_strings->intern("("));
+    auto const rparen = static_cast<int64_t>(_strings->intern(")"));
+    auto const comma = static_cast<int64_t>(_strings->intern(", "));
+
+    auto const slotValue = [&](uint32_t index) {
+        return e.load64(e.get32(1), layout::HeaderSize + (index * layout::SlotSize));
+    };
+    auto const packedType = [&](uint32_t index) {
+        return e.bin(BinaryenAndInt64(),
+                     e.bin(BinaryenShrUInt64(),
+                           e.load64(e.get32(1), layout::HeaderSize + (2 * layout::SlotSize)),
+                           e.i64(8L * index)),
+                     e.i64(0xFF));
+    };
+    auto const concat = [&](BinaryenExpressionRef a, BinaryenExpressionRef b) {
+        return e.call("endo_str_concat", { a, b }, I64());
+    };
+    auto const element = [&](uint32_t index) {
+        return e.call("endo_slot_to_str", { slotValue(index), packedType(index), e.i64(1) }, I64());
+    };
+
+    // params: 0=v; locals: 1=p, 2=result i64
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.set(2, concat(e.i64(lparen), element(0))),
+        e.set(2, concat(e.get64(2), e.i64(comma))),
+        e.set(2, concat(e.get64(2), element(1))),
+        e.ret(concat(e.get64(2), e.i64(rparen))),
+    });
+
+    e.addFunction("endo_tuple2_str", { I64() }, I64(), { I32(), I64() }, body);
+}
+
+// endo_tuple3_str(v: i64) -> i64 — "(a, b, c)"; packed types in slot 3.
+void WasmRuntime::buildTuple3Str()
+{
+    require("endo_str_concat");
+    require("endo_slot_to_str");
+    auto e = Emit { _module };
+    auto const lparen = static_cast<int64_t>(_strings->intern("("));
+    auto const rparen = static_cast<int64_t>(_strings->intern(")"));
+    auto const comma = static_cast<int64_t>(_strings->intern(", "));
+
+    auto const slotValue = [&](uint32_t index) {
+        return e.load64(e.get32(1), layout::HeaderSize + (index * layout::SlotSize));
+    };
+    auto const packedType = [&](uint32_t index) {
+        return e.bin(BinaryenAndInt64(),
+                     e.bin(BinaryenShrUInt64(),
+                           e.load64(e.get32(1), layout::HeaderSize + (3 * layout::SlotSize)),
+                           e.i64(8L * index)),
+                     e.i64(0xFF));
+    };
+    auto const concat = [&](BinaryenExpressionRef a, BinaryenExpressionRef b) {
+        return e.call("endo_str_concat", { a, b }, I64());
+    };
+    auto const element = [&](uint32_t index) {
+        return e.call("endo_slot_to_str", { slotValue(index), packedType(index), e.i64(1) }, I64());
+    };
+
+    // params: 0=v; locals: 1=p, 2=result i64
+    auto* body = e.block({
+        e.set(1, e.wrap(e.get64(0))),
+        e.set(2, concat(e.i64(lparen), element(0))),
+        e.set(2, concat(e.get64(2), e.i64(comma))),
+        e.set(2, concat(e.get64(2), element(1))),
+        e.set(2, concat(e.get64(2), e.i64(comma))),
+        e.set(2, concat(e.get64(2), element(2))),
+        e.ret(concat(e.get64(2), e.i64(rparen))),
+    });
+
+    e.addFunction("endo_tuple3_str", { I64() }, I64(), { I32(), I64() }, body);
 }
 
 } // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmRuntime.hpp
+++ b/src/CoreVM/wasm/WasmRuntime.hpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <CoreVM/wasm/WasmRuntimeABI.hpp>
+
+#include <set>
+#include <string>
+#include <string_view>
+
+namespace CoreVM::wasm
+{
+
+class WasmStringTable;
+
+/// The real WASM-side runtime: builds the $endo_* helper function bodies
+/// (bump allocator, string operations, number formatting, WASI-based I/O)
+/// directly into the module using the binaryen C API.
+///
+/// Helpers are emitted lazily: only the ones referenced by generated code,
+/// plus their transitive dependencies, land in the module. ABI helpers whose
+/// native implementation does not exist yet degrade to imports (the module
+/// still validates; instantiation then fails with a clear missing-import
+/// error naming the helper).
+class WasmRuntime final: public WasmRuntimeProvider
+{
+  public:
+    void provide(BinaryenModuleRef module,
+                 std::set<RuntimeHelperDef const*> const& usedHelpers,
+                 WasmStringTable& strings) override;
+
+  private:
+    /// Ensures the named function exists in the module (building it and its
+    /// dependencies on first use).
+    void require(std::string_view name);
+
+    /// Ensures the WASI fd_write import is present.
+    void requireFdWrite();
+
+    /// Declares an ABI helper as an import (fallback for helpers without a
+    /// native builder yet).
+    void importHelper(std::string_view name);
+
+    // Helper body builders. Each corresponds to one runtime function; see
+    // WasmRuntimeABI.hpp for the value-level signatures.
+    void buildAlloc();
+    void buildStrAlloc();
+    void buildWriteAll();
+    void buildPrint();
+    void buildPrintln();
+    void buildPanic();
+    void buildI64ToStr();
+    void buildObjectToString();
+    void buildI64Div();
+    void buildI64Rem();
+    void buildI64Pow();
+
+    BinaryenModuleRef _module = nullptr;
+    WasmStringTable* _strings = nullptr;
+    std::set<std::string, std::less<>> _built;
+};
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmRuntime.hpp
+++ b/src/CoreVM/wasm/WasmRuntime.hpp
@@ -72,6 +72,19 @@ class WasmRuntime final: public WasmRuntimeProvider
     void buildResultStr();
     void buildTuple2Str();
     void buildTuple3Str();
+    void buildDisplayResult();
+    void buildCons();
+    void buildSome();
+    void buildListLength();
+    void buildListIsEmpty();
+    void buildListHead();
+    void buildListTail();
+    void buildListNth();
+    void buildListConcat();
+    void buildF64Rem();
+    void buildF64Pow();
+    void buildStrToF64();
+    void buildF64ToStrG();
 
     BinaryenModuleRef _module = nullptr;
     WasmStringTable* _strings = nullptr;

--- a/src/CoreVM/wasm/WasmRuntime.hpp
+++ b/src/CoreVM/wasm/WasmRuntime.hpp
@@ -53,6 +53,15 @@ class WasmRuntime final: public WasmRuntimeProvider
     void buildI64Div();
     void buildI64Rem();
     void buildI64Pow();
+    void buildMemEq();
+    void buildStrConcat();
+    void buildStrLen();
+    void buildStrEq();
+    void buildStrCmp();
+    void buildStrStartsWith();
+    void buildStrEndsWith();
+    void buildStrContains();
+    void buildStrToI64();
 
     BinaryenModuleRef _module = nullptr;
     WasmStringTable* _strings = nullptr;

--- a/src/CoreVM/wasm/WasmRuntime.hpp
+++ b/src/CoreVM/wasm/WasmRuntime.hpp
@@ -50,6 +50,7 @@ class WasmRuntime final: public WasmRuntimeProvider
     void buildPanic();
     void buildI64ToStr();
     void buildObjectToString();
+    void buildExit();
     void buildI64Div();
     void buildI64Rem();
     void buildI64Pow();
@@ -70,6 +71,7 @@ class WasmRuntime final: public WasmRuntimeProvider
     void buildListToString();
     void buildOptionStr();
     void buildResultStr();
+    void buildTupleStr(char const* name, uint32_t arity);
     void buildTuple2Str();
     void buildTuple3Str();
     void buildDisplayResult();

--- a/src/CoreVM/wasm/WasmRuntime.hpp
+++ b/src/CoreVM/wasm/WasmRuntime.hpp
@@ -62,6 +62,16 @@ class WasmRuntime final: public WasmRuntimeProvider
     void buildStrEndsWith();
     void buildStrContains();
     void buildStrToI64();
+    void buildStrSlice();
+    void buildObjAlloc();
+    void buildF64ToStrFixed();
+    void buildSlotToStr();
+    void buildValueToStr();
+    void buildListToString();
+    void buildOptionStr();
+    void buildResultStr();
+    void buildTuple2Str();
+    void buildTuple3Str();
 
     BinaryenModuleRef _module = nullptr;
     WasmStringTable* _strings = nullptr;

--- a/src/CoreVM/wasm/WasmRuntimeABI.hpp
+++ b/src/CoreVM/wasm/WasmRuntimeABI.hpp
@@ -126,6 +126,13 @@ inline constexpr auto RuntimeHelpers = std::to_array<RuntimeHelperDef>({
     { .name = "endo_str_to_f64", .params = detail::I64x1, .result = ValType::F64 },
     // objects
     { .name = "endo_obj_alloc", .params = detail::I64x2, .result = ValType::I64 },
+    // lists
+    { .name = "endo_list_length", .params = detail::I64x1, .result = ValType::I64 },
+    { .name = "endo_list_is_empty", .params = detail::I64x1, .result = ValType::I64 },
+    { .name = "endo_list_head", .params = detail::I64x1, .result = ValType::I64 },
+    { .name = "endo_list_tail", .params = detail::I64x1, .result = ValType::I64 },
+    { .name = "endo_list_nth", .params = detail::I64x2, .result = ValType::I64 },
+    { .name = "endo_list_concat", .params = detail::I64x2, .result = ValType::I64 },
     // value formatting (composite display)
     { .name = "endo_object_to_string", .params = detail::I64x1, .result = ValType::I64 },
     { .name = "endo_list_to_string", .params = detail::I64x1, .result = ValType::I64 },
@@ -133,6 +140,7 @@ inline constexpr auto RuntimeHelpers = std::to_array<RuntimeHelperDef>({
     // I/O
     { .name = "endo_print", .params = detail::I64x1, .result = std::nullopt },
     { .name = "endo_println", .params = detail::I64x1, .result = std::nullopt },
+    { .name = "endo_display_result", .params = detail::I64x1, .result = std::nullopt },
     { .name = "endo_panic", .params = detail::I64x1, .result = std::nullopt, .noReturn = true },
 });
 

--- a/src/CoreVM/wasm/WasmRuntimeABI.hpp
+++ b/src/CoreVM/wasm/WasmRuntimeABI.hpp
@@ -162,6 +162,8 @@ inline constexpr auto RuntimeHelpers = std::to_array<RuntimeHelperDef>({
     return def.result ? toBinaryenType(*def.result) : BinaryenTypeNone();
 }
 
+class WasmStringTable;
+
 /// Dependency-injection seam between the code generator and the WASM-side
 /// runtime: the generator lowers user code and records which runtime helpers
 /// it referenced; the provider then materializes those helpers into the module.
@@ -173,11 +175,15 @@ class WasmRuntimeProvider
     /// Materializes all used runtime helpers into the module.
     ///
     /// Called once per module, after all user code has been lowered and
-    /// before validation.
+    /// before the memory layout is finalized (providers may intern further
+    /// strings, e.g. diagnostic messages).
     ///
     /// @param module      the module under construction
     /// @param usedHelpers helpers referenced by the generated code
-    virtual void provide(BinaryenModuleRef module, std::set<RuntimeHelperDef const*> const& usedHelpers) = 0;
+    /// @param strings     the module's string constant table
+    virtual void provide(BinaryenModuleRef module,
+                         std::set<RuntimeHelperDef const*> const& usedHelpers,
+                         WasmStringTable& strings) = 0;
 };
 
 /// Declares every used helper as a function import from module "endo".
@@ -188,7 +194,9 @@ class WasmRuntimeProvider
 class ImportOnlyRuntimeProvider final: public WasmRuntimeProvider
 {
   public:
-    void provide(BinaryenModuleRef module, std::set<RuntimeHelperDef const*> const& usedHelpers) override
+    void provide(BinaryenModuleRef module,
+                 std::set<RuntimeHelperDef const*> const& usedHelpers,
+                 WasmStringTable& /*strings*/) override
     {
         for (auto const* helper: usedHelpers)
         {

--- a/src/CoreVM/wasm/WasmRuntimeABI.hpp
+++ b/src/CoreVM/wasm/WasmRuntimeABI.hpp
@@ -48,9 +48,10 @@ namespace layout
     constexpr uint8_t KindString = 0xE5; ///< Header kind byte for strings.
     constexpr uint8_t KindObject = 0xE6; ///< Header kind byte for objects.
 
-    constexpr std::string_view MemoryExportName = "memory";           ///< WASI requires this export.
-    constexpr std::string_view HeapPointerGlobal = "endo_heap_ptr";   ///< Mutable i32 bump pointer.
-    constexpr std::string_view ExitStatusGlobal = "endo_exit_status"; ///< Mutable i32 exit status.
+    // Consumed as C strings by the binaryen API, hence char const*.
+    constexpr char const* MemoryExportName = "memory";           ///< WASI requires this export.
+    constexpr char const* HeapPointerGlobal = "endo_heap_ptr";   ///< Mutable i32 bump pointer.
+    constexpr char const* ExitStatusGlobal = "endo_exit_status"; ///< Mutable i32 exit status.
 } // namespace layout
 
 /// WASM value type in runtime-helper signatures. This is a constexpr-friendly
@@ -81,10 +82,9 @@ enum class ValType : uint8_t
 /// value-level parameters and results are ValType::I64.
 struct RuntimeHelperDef
 {
-    std::string_view name;           ///< Function name inside the module, e.g. "endo_str_concat".
+    char const* name;                ///< Function name inside the module, e.g. "endo_str_concat".
     std::span<ValType const> params; ///< Parameter types.
     std::optional<ValType> result;   ///< Result type; nullopt for no result.
-    bool noReturn = false;           ///< True if the helper never returns (traps/exits).
 };
 
 namespace detail
@@ -111,7 +111,6 @@ inline constexpr auto RuntimeHelpers = std::to_array<RuntimeHelperDef>({
     { .name = "endo_f64_pow", .params = detail::F64x2, .result = ValType::F64 },
     // strings
     { .name = "endo_str_concat", .params = detail::I64x2, .result = ValType::I64 },
-    { .name = "endo_str_substr", .params = detail::I64x3, .result = ValType::I64 },
     { .name = "endo_str_len", .params = detail::I64x1, .result = ValType::I64 },
     { .name = "endo_str_eq", .params = detail::I64x2, .result = ValType::I64 },
     { .name = "endo_str_cmp", .params = detail::I64x2, .result = ValType::I64 },
@@ -121,7 +120,6 @@ inline constexpr auto RuntimeHelpers = std::to_array<RuntimeHelperDef>({
     // number <-> string conversion
     { .name = "endo_i64_to_str", .params = detail::I64x1, .result = ValType::I64 },
     { .name = "endo_f64_to_str_g", .params = detail::F64x1, .result = ValType::I64 },
-    { .name = "endo_f64_to_str_fixed", .params = detail::F64x1, .result = ValType::I64 },
     { .name = "endo_str_to_i64", .params = detail::I64x1, .result = ValType::I64 },
     { .name = "endo_str_to_f64", .params = detail::I64x1, .result = ValType::F64 },
     // objects
@@ -136,12 +134,12 @@ inline constexpr auto RuntimeHelpers = std::to_array<RuntimeHelperDef>({
     // value formatting (composite display)
     { .name = "endo_object_to_string", .params = detail::I64x1, .result = ValType::I64 },
     { .name = "endo_list_to_string", .params = detail::I64x1, .result = ValType::I64 },
-    { .name = "endo_value_to_str", .params = detail::I64x1, .result = ValType::I64 },
     // I/O
     { .name = "endo_print", .params = detail::I64x1, .result = std::nullopt },
     { .name = "endo_println", .params = detail::I64x1, .result = std::nullopt },
     { .name = "endo_display_result", .params = detail::I64x1, .result = std::nullopt },
-    { .name = "endo_panic", .params = detail::I64x1, .result = std::nullopt, .noReturn = true },
+    // program exit (never returns): shell exit-status policy in one place
+    { .name = "endo_exit", .params = detail::I64x1, .result = std::nullopt },
 });
 
 /// Looks up a runtime helper by name.
@@ -149,7 +147,7 @@ inline constexpr auto RuntimeHelpers = std::to_array<RuntimeHelperDef>({
 [[nodiscard]] inline RuntimeHelperDef const* findRuntimeHelper(std::string_view name)
 {
     for (auto const& helper: RuntimeHelpers)
-        if (helper.name == name)
+        if (std::string_view(helper.name) == name)
             return &helper;
     return nullptr;
 }
@@ -168,6 +166,13 @@ inline constexpr auto RuntimeHelpers = std::to_array<RuntimeHelperDef>({
 [[nodiscard]] inline BinaryenType binaryenResultType(RuntimeHelperDef const& def)
 {
     return def.result ? toBinaryenType(*def.result) : BinaryenTypeNone();
+}
+
+/// Declares @p def as a function import from module "endo".
+inline void addEndoImport(BinaryenModuleRef module, RuntimeHelperDef const& def)
+{
+    BinaryenAddFunctionImport(
+        module, def.name, "endo", def.name, binaryenParamsType(def), binaryenResultType(def));
 }
 
 class WasmStringTable;
@@ -207,15 +212,7 @@ class ImportOnlyRuntimeProvider final: public WasmRuntimeProvider
                  WasmStringTable& /*strings*/) override
     {
         for (auto const* helper: usedHelpers)
-        {
-            auto const name = std::string(helper->name);
-            BinaryenAddFunctionImport(module,
-                                      name.c_str(),
-                                      "endo",
-                                      name.c_str(),
-                                      binaryenParamsType(*helper),
-                                      binaryenResultType(*helper));
-        }
+            addEndoImport(module, *helper);
     }
 };
 

--- a/src/CoreVM/wasm/WasmRuntimeABI.hpp
+++ b/src/CoreVM/wasm/WasmRuntimeABI.hpp
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <set>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include <binaryen-c.h>
+
+/// @file
+/// The ABI contract between the WASM code generator (WasmCodeGenerator /
+/// WasmFunctionLowerer) and the WASM-side runtime implementation
+/// (WasmRuntime): linear-memory layout, the unified cell header, and the
+/// signatures of all runtime helper functions the generated code may call.
+
+namespace CoreVM::wasm
+{
+
+/// Linear-memory layout of a compiled endo module.
+///
+/// ```
+/// 0x0000 .. 0x03FF   null-pointer guard (never written)
+/// 0x0400 .. 0x07FF   runtime scratch (iovecs, number formatting)
+/// 0x0800 .. dataEnd  data segments (interned string constants)
+/// heapBase .. ∞      bump-allocated heap (heapBase = align8(dataEnd))
+/// ```
+namespace layout
+{
+    constexpr uint32_t NullGuardSize = 0x0400;       ///< Bytes reserved as null-pointer guard.
+    constexpr uint32_t ScratchIovec0 = 0x0400;       ///< First WASI iovec (buf, buf_len).
+    constexpr uint32_t ScratchIovec1 = 0x0408;       ///< Second WASI iovec (println newline).
+    constexpr uint32_t ScratchNWritten = 0x0410;     ///< fd_write nwritten output slot.
+    constexpr uint32_t ScratchNumberBuffer = 0x0440; ///< Number-formatting buffer (512 bytes).
+    constexpr uint32_t DataBase = 0x0800;            ///< First byte of the constant data segment.
+
+    /// Every heap or data cell (string or object) starts with this 8-byte header:
+    /// byte 0: kind; byte 1: tag; bytes 2-3: typeId (u16 LE);
+    /// bytes 4-7 (u32 LE): strings: byte length, objects: refcount (reserved).
+    constexpr uint32_t HeaderSize = 8;
+    constexpr uint32_t TagOffset = 1;    ///< Sum-type variant tag (u8).
+    constexpr uint32_t TypeIdOffset = 2; ///< Object type id (u16 LE).
+    constexpr uint32_t LengthOffset = 4; ///< String byte length (u32 LE).
+    constexpr uint32_t SlotSize = 8;     ///< Object slot width in bytes.
+    constexpr uint8_t KindString = 0xE5; ///< Header kind byte for strings.
+    constexpr uint8_t KindObject = 0xE6; ///< Header kind byte for objects.
+
+    constexpr std::string_view MemoryExportName = "memory";           ///< WASI requires this export.
+    constexpr std::string_view HeapPointerGlobal = "endo_heap_ptr";   ///< Mutable i32 bump pointer.
+    constexpr std::string_view ExitStatusGlobal = "endo_exit_status"; ///< Mutable i32 exit status.
+} // namespace layout
+
+/// WASM value type in runtime-helper signatures. This is a constexpr-friendly
+/// mirror of BinaryenType, whose values are only obtainable via function calls.
+enum class ValType : uint8_t
+{
+    I32,
+    I64,
+    F64,
+};
+
+/// Converts a ValType to the corresponding BinaryenType.
+[[nodiscard]] inline BinaryenType toBinaryenType(ValType type)
+{
+    switch (type)
+    {
+        case ValType::I32: return BinaryenTypeInt32();
+        case ValType::I64: return BinaryenTypeInt64();
+        case ValType::F64: return BinaryenTypeFloat64();
+    }
+    return BinaryenTypeNone();
+}
+
+/// Signature descriptor of one in-module runtime helper function.
+///
+/// All VM-visible values use the uniform i64 representation (numbers as-is,
+/// floats bit-cast, booleans 0/1, string/object pointers zero-extended), so
+/// value-level parameters and results are ValType::I64.
+struct RuntimeHelperDef
+{
+    std::string_view name;           ///< Function name inside the module, e.g. "endo_str_concat".
+    std::span<ValType const> params; ///< Parameter types.
+    std::optional<ValType> result;   ///< Result type; nullopt for no result.
+    bool noReturn = false;           ///< True if the helper never returns (traps/exits).
+};
+
+namespace detail
+{
+    inline constexpr auto I64x1 = std::to_array({ ValType::I64 });
+    inline constexpr auto I64x2 = std::to_array({ ValType::I64, ValType::I64 });
+    inline constexpr auto I64x3 = std::to_array({ ValType::I64, ValType::I64, ValType::I64 });
+    inline constexpr auto F64x1 = std::to_array({ ValType::F64 });
+    inline constexpr auto F64x2 = std::to_array({ ValType::F64, ValType::F64 });
+} // namespace detail
+
+/// All runtime helpers callable from generated code. This table is the single
+/// source of truth: the code generator emits calls against these signatures
+/// and the runtime provider (real or import-only) materializes matching
+/// functions. Adding a helper means adding a row here plus a body builder in
+/// WasmRuntime.
+inline constexpr auto RuntimeHelpers = std::to_array<RuntimeHelperDef>({
+    // integer math
+    { .name = "endo_i64_div", .params = detail::I64x2, .result = ValType::I64 },
+    { .name = "endo_i64_rem", .params = detail::I64x2, .result = ValType::I64 },
+    { .name = "endo_i64_pow", .params = detail::I64x2, .result = ValType::I64 },
+    // float math
+    { .name = "endo_f64_rem", .params = detail::F64x2, .result = ValType::F64 },
+    { .name = "endo_f64_pow", .params = detail::F64x2, .result = ValType::F64 },
+    // strings
+    { .name = "endo_str_concat", .params = detail::I64x2, .result = ValType::I64 },
+    { .name = "endo_str_substr", .params = detail::I64x3, .result = ValType::I64 },
+    { .name = "endo_str_len", .params = detail::I64x1, .result = ValType::I64 },
+    { .name = "endo_str_eq", .params = detail::I64x2, .result = ValType::I64 },
+    { .name = "endo_str_cmp", .params = detail::I64x2, .result = ValType::I64 },
+    { .name = "endo_str_starts_with", .params = detail::I64x2, .result = ValType::I64 },
+    { .name = "endo_str_ends_with", .params = detail::I64x2, .result = ValType::I64 },
+    { .name = "endo_str_contains", .params = detail::I64x2, .result = ValType::I64 },
+    // number <-> string conversion
+    { .name = "endo_i64_to_str", .params = detail::I64x1, .result = ValType::I64 },
+    { .name = "endo_f64_to_str_g", .params = detail::F64x1, .result = ValType::I64 },
+    { .name = "endo_f64_to_str_fixed", .params = detail::F64x1, .result = ValType::I64 },
+    { .name = "endo_str_to_i64", .params = detail::I64x1, .result = ValType::I64 },
+    { .name = "endo_str_to_f64", .params = detail::I64x1, .result = ValType::F64 },
+    // objects
+    { .name = "endo_obj_alloc", .params = detail::I64x2, .result = ValType::I64 },
+    // value formatting (composite display)
+    { .name = "endo_object_to_string", .params = detail::I64x1, .result = ValType::I64 },
+    { .name = "endo_list_to_string", .params = detail::I64x1, .result = ValType::I64 },
+    { .name = "endo_value_to_str", .params = detail::I64x1, .result = ValType::I64 },
+    // I/O
+    { .name = "endo_print", .params = detail::I64x1, .result = std::nullopt },
+    { .name = "endo_println", .params = detail::I64x1, .result = std::nullopt },
+    { .name = "endo_panic", .params = detail::I64x1, .result = std::nullopt, .noReturn = true },
+});
+
+/// Looks up a runtime helper by name.
+/// @return the descriptor, or nullptr if no such helper exists.
+[[nodiscard]] inline RuntimeHelperDef const* findRuntimeHelper(std::string_view name)
+{
+    for (auto const& helper: RuntimeHelpers)
+        if (helper.name == name)
+            return &helper;
+    return nullptr;
+}
+
+/// Builds the BinaryenType tuple for a helper's parameter list.
+[[nodiscard]] inline BinaryenType binaryenParamsType(RuntimeHelperDef const& def)
+{
+    auto types = std::array<BinaryenType, 8> {};
+    auto count = size_t { 0 };
+    for (auto const param: def.params)
+        types.at(count++) = toBinaryenType(param);
+    return BinaryenTypeCreate(types.data(), static_cast<BinaryenIndex>(count));
+}
+
+/// Builds the BinaryenType for a helper's result.
+[[nodiscard]] inline BinaryenType binaryenResultType(RuntimeHelperDef const& def)
+{
+    return def.result ? toBinaryenType(*def.result) : BinaryenTypeNone();
+}
+
+/// Dependency-injection seam between the code generator and the WASM-side
+/// runtime: the generator lowers user code and records which runtime helpers
+/// it referenced; the provider then materializes those helpers into the module.
+class WasmRuntimeProvider
+{
+  public:
+    virtual ~WasmRuntimeProvider() = default;
+
+    /// Materializes all used runtime helpers into the module.
+    ///
+    /// Called once per module, after all user code has been lowered and
+    /// before validation.
+    ///
+    /// @param module      the module under construction
+    /// @param usedHelpers helpers referenced by the generated code
+    virtual void provide(BinaryenModuleRef module, std::set<RuntimeHelperDef const*> const& usedHelpers) = 0;
+};
+
+/// Declares every used helper as a function import from module "endo".
+///
+/// The resulting module validates and its WAT is inspectable, but it cannot
+/// run standalone (no host provides the "endo" imports). Used by unit tests
+/// and early development milestones.
+class ImportOnlyRuntimeProvider final: public WasmRuntimeProvider
+{
+  public:
+    void provide(BinaryenModuleRef module, std::set<RuntimeHelperDef const*> const& usedHelpers) override
+    {
+        for (auto const* helper: usedHelpers)
+        {
+            auto const name = std::string(helper->name);
+            BinaryenAddFunctionImport(module,
+                                      name.c_str(),
+                                      "endo",
+                                      name.c_str(),
+                                      binaryenParamsType(*helper),
+                                      binaryenResultType(*helper));
+        }
+    }
+};
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmStringTable.cpp
+++ b/src/CoreVM/wasm/WasmStringTable.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <CoreVM/wasm/WasmStringTable.hpp>
+
+namespace CoreVM::wasm
+{
+
+uint32_t WasmStringTable::intern(std::string_view text)
+{
+    if (auto const it = _offsets.find(std::string(text)); it != _offsets.end())
+        return it->second;
+
+    auto const pointer = dataEnd();
+
+    // Unified cell header: kind, tag, typeId (u16 LE), byte length (u32 LE).
+    _blob.push_back(layout::KindString);
+    _blob.push_back(0); // tag
+    _blob.push_back(0); // typeId lo
+    _blob.push_back(0); // typeId hi
+    auto const length = static_cast<uint32_t>(text.size());
+    for (auto const shift: { 0U, 8U, 16U, 24U })
+        _blob.push_back(static_cast<uint8_t>(length >> shift));
+
+    _blob.insert(_blob.end(), text.begin(), text.end());
+    while (_blob.size() % 8 != 0)
+        _blob.push_back(0);
+
+    _offsets.emplace(std::string(text), pointer);
+    return pointer;
+}
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmStringTable.cpp
+++ b/src/CoreVM/wasm/WasmStringTable.cpp
@@ -6,7 +6,7 @@ namespace CoreVM::wasm
 
 uint32_t WasmStringTable::intern(std::string_view text)
 {
-    if (auto const it = _offsets.find(std::string(text)); it != _offsets.end())
+    if (auto const it = _offsets.find(text); it != _offsets.end())
         return it->second;
 
     auto const pointer = dataEnd();

--- a/src/CoreVM/wasm/WasmStringTable.hpp
+++ b/src/CoreVM/wasm/WasmStringTable.hpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <CoreVM/wasm/WasmRuntimeABI.hpp>
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace CoreVM::wasm
+{
+
+/// Interns string constants into the module's data segment.
+///
+/// Each string is stored with the unified 8-byte cell header (kind, tag,
+/// typeId, byte length) followed by its UTF-8 bytes, 8-byte aligned, starting
+/// at layout::DataBase. Interning is content-deduplicating, so equal literals
+/// share one cell. Both the code generator (user string literals) and the
+/// runtime provider (diagnostic messages) intern through the same table.
+class WasmStringTable
+{
+  public:
+    /// Interns @p text and returns its pointer (address of the header base).
+    uint32_t intern(std::string_view text);
+
+    /// First address past the interned data (>= layout::DataBase).
+    [[nodiscard]] uint32_t dataEnd() const noexcept
+    {
+        return layout::DataBase + static_cast<uint32_t>(_blob.size());
+    }
+
+    /// The raw data-segment contents, to be placed at layout::DataBase.
+    [[nodiscard]] std::span<uint8_t const> blob() const noexcept { return _blob; }
+
+    [[nodiscard]] bool empty() const noexcept { return _blob.empty(); }
+
+  private:
+    std::vector<uint8_t> _blob;
+    std::unordered_map<std::string, uint32_t> _offsets;
+};
+
+} // namespace CoreVM::wasm

--- a/src/CoreVM/wasm/WasmStringTable.hpp
+++ b/src/CoreVM/wasm/WasmStringTable.hpp
@@ -38,8 +38,19 @@ class WasmStringTable
     [[nodiscard]] bool empty() const noexcept { return _blob.empty(); }
 
   private:
+    /// Transparent hashing so lookups take string_views without allocating.
+    struct StringHash
+    {
+        using is_transparent = void;
+
+        [[nodiscard]] size_t operator()(std::string_view text) const noexcept
+        {
+            return std::hash<std::string_view> {}(text);
+        }
+    };
+
     std::vector<uint8_t> _blob;
-    std::unordered_map<std::string, uint32_t> _offsets;
+    std::unordered_map<std::string, uint32_t, StringHash, std::equal_to<>> _offsets;
 };
 
 } // namespace CoreVM::wasm

--- a/src/endo-language/CMakeLists.txt
+++ b/src/endo-language/CMakeLists.txt
@@ -103,6 +103,10 @@ add_library(endo STATIC
     format/SourceFormatter.hpp
     format/SourceFormatter.cpp
 
+    # One-shot compilation driver (parse + IR generation, no execution)
+    CompileToIR.hpp
+    CompileToIR.cpp
+
     # Logging (used by parser tracing)
     LogCategories.hpp
     LogCategories.cpp

--- a/src/endo-language/CompileToIR.cpp
+++ b/src/endo-language/CompileToIR.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <endo-language/CompileToIR.hpp>
+#include <endo-language/lexer/Lexer.hpp>
+#include <endo-language/parser/Parser.hpp>
+
+#include <CoreVM/types/TypeRegistry.hpp>
+
+namespace endo
+{
+
+FSharpPersistentState makeDefaultPersistentState()
+{
+    FSharpPersistentState state;
+    CoreVM::TypeRegistry registry;
+    for (auto const& type: registry.allTypes())
+    {
+        if (!type->producingCommand.empty())
+        {
+            state.structuredCommands[type->producingCommand] = {
+                .builtinCallbackName = "structured_" + type->producingCommand,
+                .recordTypeId = type->id,
+                .recordTypeName = type->name,
+            };
+        }
+    }
+    if (auto it = state.structuredCommands.find("ls"); it != state.structuredCommands.end())
+        it->second.defaultStringArg = ".";
+    return state;
+}
+
+std::unique_ptr<CoreVM::IRProgram> compileToIR(std::string source,
+                                               CoreVM::Runtime& runtime,
+                                               CoreVM::diagnostics::Report& report,
+                                               std::string_view sourceName,
+                                               bool unusedValueDetection)
+{
+    Parser parser(runtime, report, std::make_unique<StringSource>(std::move(source), sourceName));
+    auto rootNode = parser.parse();
+    if (!rootNode || report.containsFailures())
+        return nullptr;
+
+    auto persistentState = makeDefaultPersistentState();
+    auto irProgram =
+        IRGenerator::generate(*rootNode, report, runtime, &persistentState, unusedValueDetection);
+    if (!irProgram || report.containsFailures())
+        return nullptr;
+
+    return irProgram;
+}
+
+} // namespace endo

--- a/src/endo-language/CompileToIR.hpp
+++ b/src/endo-language/CompileToIR.hpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <endo-language/codegen/IRGenerator.hpp>
+
+#include <CoreVM/CoreVM.hpp>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace endo
+{
+
+/// Creates a minimal FSharpPersistentState with the builtin structured
+/// commands registered (ls, ps, ... producing record types).
+[[nodiscard]] FSharpPersistentState makeDefaultPersistentState();
+
+/// Compiles endo source text to CoreVM IR without executing it.
+///
+/// This is the shared one-shot compilation driver used by non-executing
+/// consumers (the `endo -o` WASM compile path, endo-test's ir-only mode, unit
+/// tests). It runs Parser and IRGenerator only — no Shell, no
+/// TargetCodeGenerator, no Runner.
+///
+/// @param source               the script source (shebang already stripped)
+/// @param runtime              a runtime with builtin signatures registered
+///                             (a stub runtime is sufficient; see StubRuntime.hpp)
+/// @param report               receives parse and IR-generation diagnostics
+/// @param sourceName           name used in diagnostics (e.g. the file path)
+/// @param unusedValueDetection enable unused-value analysis
+/// @return the IR program, or nullptr if parsing or IR generation failed
+///         (details in @p report)
+[[nodiscard]] std::unique_ptr<CoreVM::IRProgram> compileToIR(std::string source,
+                                                             CoreVM::Runtime& runtime,
+                                                             CoreVM::diagnostics::Report& report,
+                                                             std::string_view sourceName = {},
+                                                             bool unusedValueDetection = false);
+
+} // namespace endo

--- a/src/endo-language/CompileToWasm.hpp
+++ b/src/endo-language/CompileToWasm.hpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <endo-language/CompileToIR.hpp>
+#include <endo-language/builtins/StubRuntime.hpp>
+
+#include <CoreVM/wasm/WasmCodeGenerator.hpp>
+#include <CoreVM/wasm/WasmRuntime.hpp>
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+// NOTE: This header requires the WASM backend (ENDO_HAS_WASM); include it
+// only from translation units gated on that feature.
+
+namespace endo
+{
+
+/// Compiles endo source text to a WebAssembly module.
+///
+/// This is the single source-to-wasm pipeline shared by `endo -o`
+/// (CompileCommand) and endo-test's `# mode: wasm`, so the tests always
+/// exercise exactly what the CLI ships.
+///
+/// The CoreVM IR-level optimization passes (PassManager) are deliberately
+/// not run here: they verify() the IR after each change, and the frontend
+/// routinely emits blocks that fail verification (e.g. unterminated match
+/// merge blocks after fully-returning arms) yet execute fine. Optimization
+/// happens at the WASM module level via binaryen (WasmOptions::optimize).
+///
+/// @param source     the script source (shebang already stripped)
+/// @param sourceName name used in diagnostics (e.g. the file path)
+/// @param options    WASM backend options
+/// @param report     receives parse, IR and WASM-lowering diagnostics
+/// @return the compiled module, or std::nullopt on any failure (see @p report)
+[[nodiscard]] inline std::optional<CoreVM::wasm::WasmOutput> compileSourceToWasm(
+    std::string source,
+    std::string_view sourceName,
+    CoreVM::wasm::WasmOptions const& options,
+    CoreVM::diagnostics::Report& report)
+{
+    // IR generation only needs builtin signatures, not executable callbacks.
+    auto runtime = CoreVM::Runtime {};
+    registerStubRuntime(runtime);
+
+    auto irProgram = compileToIR(std::move(source), runtime, report, sourceName);
+    if (!irProgram)
+        return std::nullopt;
+
+    auto provider = CoreVM::wasm::WasmRuntime {};
+    return CoreVM::wasm::WasmCodeGenerator(provider, options).generate(irProgram.get(), report);
+}
+
+} // namespace endo

--- a/src/endo-language/TestHelper.cpp
+++ b/src/endo-language/TestHelper.cpp
@@ -5,6 +5,7 @@
 #include <endo-language/ast/ASTPrinter.hpp>
 #include <endo-language/builtins/BuiltinImpls.hpp>
 #include <endo-language/builtins/BuiltinSignatures.hpp>
+#include <endo-language/CompileToIR.hpp>
 #include <endo-language/builtins/TypeFormatters.hpp>
 #include <endo-language/codegen/IRGenerator.hpp>
 #include <endo-language/lexer/Lexer.hpp>
@@ -763,43 +764,12 @@ std::unique_ptr<ast::Statement> parse(std::string const& source)
     return result;
 }
 
-/// Creates a minimal FSharpPersistentState with builtin structured commands registered.
-FSharpPersistentState createDefaultPersistentState()
-{
-    FSharpPersistentState state;
-    CoreVM::TypeRegistry registry;
-    for (auto const& type: registry.allTypes())
-    {
-        if (!type->producingCommand.empty())
-        {
-            state.structuredCommands[type->producingCommand] = {
-                .builtinCallbackName = "structured_" + type->producingCommand,
-                .recordTypeId = type->id,
-                .recordTypeName = type->name,
-            };
-        }
-    }
-    if (auto it = state.structuredCommands.find("ls"); it != state.structuredCommands.end())
-        it->second.defaultStringArg = ".";
-    return state;
-}
-
 std::unique_ptr<CoreVM::IRProgram> generateIR(std::string const& source, bool unusedValueDetection)
 {
     auto& testRuntime = TestRuntime::instance();
     testRuntime.clearErrors();
 
-    Parser parser(testRuntime.runtime, testRuntime.report, std::make_unique<StringSource>(source));
-    auto ast = parser.parse();
-
-    if (!ast || testRuntime.hasErrors())
-    {
-        return nullptr;
-    }
-
-    auto defaultState = createDefaultPersistentState();
-    auto ir = IRGenerator::generate(
-        *ast, testRuntime.report, testRuntime.runtime, &defaultState, unusedValueDetection);
+    auto ir = compileToIR(source, testRuntime.runtime, testRuntime.report, {}, unusedValueDetection);
 
     if (!ir || testRuntime.hasErrors())
     {

--- a/src/endo-test/CMakeLists.txt
+++ b/src/endo-test/CMakeLists.txt
@@ -16,6 +16,11 @@ if(ENDO_TESTING)
         ${CMAKE_CURRENT_SOURCE_DIR}/../endo-language/TestHelper.cpp
     )
     target_link_libraries(endo-test PRIVATE endo endo-platform endo-shell CoreVM crispy::core)
+    if(ENDO_HAS_WASM)
+        # Brings in the ENDO_HAS_WASM=1 compile definition (INTERFACE) and the
+        # WASM backend used by `# mode: wasm` tests.
+        target_link_libraries(endo-test PRIVATE CoreVM-wasm)
+    endif()
     target_include_directories(endo-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
     target_compile_definitions(endo-test PRIVATE
         ENDO_TEST_DIR="${CMAKE_SOURCE_DIR}/tests"

--- a/src/endo-test/TestExecutor.cpp
+++ b/src/endo-test/TestExecutor.cpp
@@ -16,11 +16,7 @@
 #include <platform/testing/TestEnvironmentProvider.hpp>
 
 #if defined(ENDO_HAS_WASM) && !defined(_WIN32)
-    #include <endo-language/CompileToIR.hpp>
-    #include <endo-language/builtins/StubRuntime.hpp>
-
-    #include <CoreVM/wasm/WasmCodeGenerator.hpp>
-    #include <CoreVM/wasm/WasmRuntime.hpp>
+    #include <endo-language/CompileToWasm.hpp>
 
     #include <algorithm>
     #include <array>
@@ -84,7 +80,8 @@ namespace
                 if (!dir.empty())
                     if (auto candidate = std::filesystem::path(dir) / "wasmtime"; executable(candidate))
                         return candidate;
-                remaining = colon == std::string_view::npos ? std::string_view {} : remaining.substr(colon + 1);
+                remaining =
+                    colon == std::string_view::npos ? std::string_view {} : remaining.substr(colon + 1);
             }
         }
 
@@ -441,36 +438,25 @@ TestResult TestExecutor::run(TestFile const& testFile)
             result.failureMessage = "built without the WebAssembly backend";
             return result;
 #else
-            auto runtime = CoreVM::Runtime {};
-            registerStubRuntime(runtime);
-            auto report = CoreVM::diagnostics::BufferedReport {};
-
             auto const finish = [&](TestOutcome outcome, std::string message = {}) {
                 auto const endTime = std::chrono::steady_clock::now();
-                result.duration =
-                    std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
+                result.duration = std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
                 result.outcome = outcome;
                 if (!message.empty())
                     result.failureMessage = std::move(message);
                 return result;
             };
 
-            auto irProgram = compileToIR(testFile.source, runtime, report, testFile.relativePath);
-            if (!irProgram)
-                return finish(TestOutcome::Fail,
-                              std::format("IR generation failed: {}",
-                                          report.size() > 0 ? report[0].text : "unknown error"));
-
-            auto provider = CoreVM::wasm::WasmRuntime {};
-            auto generator = CoreVM::wasm::WasmCodeGenerator(provider, CoreVM::wasm::WasmOptions {});
-            auto const wasmOutput = generator.generate(irProgram.get(), report);
+            // The shared source-to-wasm pipeline — identical to `endo -o`.
+            auto report = CoreVM::diagnostics::BufferedReport {};
+            auto const wasmOutput = compileSourceToWasm(
+                testFile.source, testFile.relativePath, CoreVM::wasm::WasmOptions {}, report);
 
             // Error tests: expect WASM compilation failure with matching diagnostics
             if (!testFile.expectedErrors.empty())
             {
                 if (wasmOutput.has_value())
-                    return finish(TestOutcome::Fail,
-                                  "Expected WASM compilation failure but it succeeded");
+                    return finish(TestOutcome::Fail, "Expected WASM compilation failure but it succeeded");
                 for (auto const& expectedError: testFile.expectedErrors)
                 {
                     if (expectedError.empty())
@@ -505,8 +491,7 @@ TestResult TestExecutor::run(TestFile const& testFile)
                     return finish(TestOutcome::Fail, "failed to write the .wasm module");
             }
 
-            auto const run =
-                runCapture(std::format("'{}' '{}'", wasmtime->string(), wasmPath.string()));
+            auto const run = runCapture(std::format("'{}' '{}'", wasmtime->string(), wasmPath.string()));
             if (!run.has_value())
                 return finish(TestOutcome::Fail, "failed to launch wasmtime");
 

--- a/src/endo-test/TestExecutor.cpp
+++ b/src/endo-test/TestExecutor.cpp
@@ -15,6 +15,23 @@
 #include <platform/testing/InMemoryFileSystem.hpp>
 #include <platform/testing/TestEnvironmentProvider.hpp>
 
+#if defined(ENDO_HAS_WASM) && !defined(_WIN32)
+    #include <endo-language/CompileToIR.hpp>
+    #include <endo-language/builtins/StubRuntime.hpp>
+
+    #include <CoreVM/wasm/WasmCodeGenerator.hpp>
+    #include <CoreVM/wasm/WasmRuntime.hpp>
+
+    #include <algorithm>
+    #include <array>
+    #include <cstdio>
+    #include <cstdlib>
+    #include <optional>
+    #include <utility>
+
+    #include <sys/wait.h>
+#endif
+
 namespace endo::test
 {
 
@@ -39,6 +56,64 @@ namespace
         TempTestDir(TempTestDir const&) = delete;
         TempTestDir& operator=(TempTestDir const&) = delete;
     };
+
+#if defined(ENDO_HAS_WASM) && !defined(_WIN32)
+    /// Locates the wasmtime binary: $ENDO_WASMTIME overrides, then PATH,
+    /// then ~/.cargo/bin/wasmtime.
+    [[nodiscard]] std::optional<std::filesystem::path> findWasmtimeBinary()
+    {
+        auto const executable = [](std::filesystem::path const& path) {
+            auto ec = std::error_code {};
+            return std::filesystem::is_regular_file(path, ec);
+        };
+
+        if (auto const* env = std::getenv("ENDO_WASMTIME"); env != nullptr && *env != '\0')
+        {
+            if (auto candidate = std::filesystem::path(env); executable(candidate))
+                return candidate;
+            return std::nullopt; // explicit but unusable override: skip rather than fail
+        }
+
+        if (auto const* path = std::getenv("PATH"); path != nullptr)
+        {
+            auto remaining = std::string_view(path);
+            while (!remaining.empty())
+            {
+                auto const colon = remaining.find(':');
+                auto const dir = remaining.substr(0, colon);
+                if (!dir.empty())
+                    if (auto candidate = std::filesystem::path(dir) / "wasmtime"; executable(candidate))
+                        return candidate;
+                remaining = colon == std::string_view::npos ? std::string_view {} : remaining.substr(colon + 1);
+            }
+        }
+
+        if (auto const* home = std::getenv("HOME"); home != nullptr)
+            if (auto candidate = std::filesystem::path(home) / ".cargo" / "bin" / "wasmtime";
+                executable(candidate))
+                return candidate;
+
+        return std::nullopt;
+    }
+
+    /// Runs a command via popen, capturing stdout (stderr is discarded).
+    /// @return captured output and process exit code, or nullopt if spawning failed
+    [[nodiscard]] std::optional<std::pair<std::string, int>> runCapture(std::string const& command)
+    {
+        auto* pipe = ::popen((command + " 2>/dev/null").c_str(), "r");
+        if (pipe == nullptr)
+            return std::nullopt;
+
+        auto output = std::string {};
+        auto buffer = std::array<char, 4096> {};
+        while (auto const n = ::fread(buffer.data(), 1, buffer.size(), pipe))
+            output.append(buffer.data(), n);
+
+        auto const status = ::pclose(pipe);
+        auto const exitCode = WIFEXITED(status) ? WEXITSTATUS(status) : 128;
+        return std::pair { std::move(output), exitCode };
+    }
+#endif
 
     /// Joins expected output lines with newlines as separator (not terminator).
     /// Trailing newlines are normalized during comparison, so a trailing empty
@@ -358,6 +433,108 @@ TestResult TestExecutor::run(TestFile const& testFile)
                     result.failureMessage = "IR generation failed";
             }
             return result;
+        }
+
+        case TestMode::Wasm: {
+#if !defined(ENDO_HAS_WASM) || defined(_WIN32)
+            result.outcome = TestOutcome::Skip;
+            result.failureMessage = "built without the WebAssembly backend";
+            return result;
+#else
+            auto runtime = CoreVM::Runtime {};
+            registerStubRuntime(runtime);
+            auto report = CoreVM::diagnostics::BufferedReport {};
+
+            auto const finish = [&](TestOutcome outcome, std::string message = {}) {
+                auto const endTime = std::chrono::steady_clock::now();
+                result.duration =
+                    std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
+                result.outcome = outcome;
+                if (!message.empty())
+                    result.failureMessage = std::move(message);
+                return result;
+            };
+
+            auto irProgram = compileToIR(testFile.source, runtime, report, testFile.relativePath);
+            if (!irProgram)
+                return finish(TestOutcome::Fail,
+                              std::format("IR generation failed: {}",
+                                          report.size() > 0 ? report[0].text : "unknown error"));
+
+            auto provider = CoreVM::wasm::WasmRuntime {};
+            auto generator = CoreVM::wasm::WasmCodeGenerator(provider, CoreVM::wasm::WasmOptions {});
+            auto const wasmOutput = generator.generate(irProgram.get(), report);
+
+            // Error tests: expect WASM compilation failure with matching diagnostics
+            if (!testFile.expectedErrors.empty())
+            {
+                if (wasmOutput.has_value())
+                    return finish(TestOutcome::Fail,
+                                  "Expected WASM compilation failure but it succeeded");
+                for (auto const& expectedError: testFile.expectedErrors)
+                {
+                    if (expectedError.empty())
+                        continue; // wildcard: any failure suffices
+                    auto const found = std::ranges::any_of(report, [&](auto const& message) {
+                        return message.text.find(expectedError) != std::string::npos;
+                    });
+                    if (!found)
+                        return finish(
+                            TestOutcome::Fail,
+                            std::format("Expected error containing \"{}\" not found", expectedError));
+                }
+                return finish(TestOutcome::Pass);
+            }
+
+            if (!wasmOutput.has_value())
+                return finish(TestOutcome::Fail,
+                              std::format("WASM compilation failed: {}",
+                                          report.size() > 0 ? report[0].text : "unknown error"));
+
+            static auto const wasmtime = findWasmtimeBinary();
+            if (!wasmtime.has_value())
+                return finish(TestOutcome::Skip, "wasmtime not found (set ENDO_WASMTIME or install it)");
+
+            TempTestDir tempDir;
+            auto const wasmPath = tempDir.dir / "test.wasm";
+            {
+                auto stream = std::ofstream(wasmPath, std::ios::binary | std::ios::trunc);
+                stream.write(reinterpret_cast<char const*>(wasmOutput->binary.data()),
+                             static_cast<std::streamsize>(wasmOutput->binary.size()));
+                if (!stream.good())
+                    return finish(TestOutcome::Fail, "failed to write the .wasm module");
+            }
+
+            auto const run =
+                runCapture(std::format("'{}' '{}'", wasmtime->string(), wasmPath.string()));
+            if (!run.has_value())
+                return finish(TestOutcome::Fail, "failed to launch wasmtime");
+
+            result.actualOutput = run->first;
+            result.actualExitCode = run->second;
+
+            if (result.actualExitCode != testFile.expectedExitCode)
+                return finish(TestOutcome::Fail,
+                              std::format("Exit code mismatch: expected {}, got {}",
+                                          testFile.expectedExitCode,
+                                          result.actualExitCode));
+
+            if (testFile.expectNonEmptyOutput && result.actualOutput.empty())
+                return finish(TestOutcome::Fail, "Expected non-empty output, but output was empty");
+
+            if (!testFile.expectedOutput.empty())
+            {
+                auto const expected = joinExpectedOutput(testFile.expectedOutput);
+                if (rtrimNewlines(result.actualOutput) != rtrimNewlines(expected))
+                    return finish(
+                        TestOutcome::Fail,
+                        std::format("Output mismatch:\n        Expected: \"{}\"\n        Actual:   \"{}\"",
+                                    escapeForDisplay(rtrimNewlines(expected)),
+                                    escapeForDisplay(rtrimNewlines(result.actualOutput))));
+            }
+
+            return finish(TestOutcome::Pass);
+#endif
         }
 
         case TestMode::Structured: {

--- a/src/endo-test/TestFileParser.cpp
+++ b/src/endo-test/TestFileParser.cpp
@@ -163,6 +163,8 @@ std::optional<TestFile> TestFileParser::parse(std::filesystem::path const& fileP
                     result.mode = TestMode::Structured;
                 else if (modeStr == "shell")
                     result.mode = TestMode::Shell;
+                else if (modeStr == "wasm")
+                    result.mode = TestMode::Wasm;
                 else
                     result.mode = TestMode::Execute;
                 continue;

--- a/src/endo-test/TestFileParser.hpp
+++ b/src/endo-test/TestFileParser.hpp
@@ -19,6 +19,7 @@ enum class TestMode : std::uint8_t
     ParseOnly,  ///< Parse only, no IR generation
     Structured, ///< Execute with pre-populated structured command state
     Shell,      ///< Execute through a real Shell instance (for script/module e2e tests)
+    Wasm,       ///< Compile to WebAssembly and execute under wasmtime
 };
 
 /// Parsed metadata and source from an .endo test file.

--- a/src/endo-test/main.cpp
+++ b/src/endo-test/main.cpp
@@ -57,7 +57,7 @@ Test File Format:
     # expect: <line>             Expected output line (repeatable, joined with \n)
     # expect-exit: <code>        Expected exit code (default: 0)
     # expect-error: <substring>  Expected compilation error (repeatable, empty = any error)
-    # mode: <mode>               execute (default), ir-only, parse-only, structured, shell
+    # mode: <mode>               execute (default), ir-only, parse-only, structured, shell, wasm
     # skip: <reason>             Skip this test
     # session-separator: <sep>   Split source into REPL prompts at "# <sep>" lines
     # mock-env: KEY=VALUE        Set mock environment variable

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -167,6 +167,10 @@ add_library(endo-shell STATIC
     FormatCommand.hpp
     FormatCommand.cpp
 
+    # Compile-to-WebAssembly (self-gated on ENDO_HAS_WASM)
+    CompileCommand.hpp
+    CompileCommand.cpp
+
     # Help
     HelpPrinter.hpp
     HelpPrinter.cpp
@@ -233,6 +237,10 @@ else()
 endif()
 
 target_link_libraries(endo-shell PUBLIC endo-platform net yaml-cpp::yaml-cpp nlohmann_json::nlohmann_json endo-http)
+if(ENDO_HAS_WASM)
+    # Brings in the ENDO_HAS_WASM=1 compile definition (INTERFACE) and binaryen.
+    target_link_libraries(endo-shell PUBLIC CoreVM-wasm)
+endif()
 if(ENDO_ENABLE_AGENT)
     target_sources(endo-shell PRIVATE AgentModeSession.cpp)
     target_link_libraries(endo-shell PUBLIC endo-agent)

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -364,6 +364,15 @@ if(ENDO_TESTING)
 endif()
 
 # Installation
+
+# Installing discards the build-tree RPATH, so libraries that live outside the
+# dynamic loader's search path must be re-declared here or the installed shell
+# fails to start.  Binaryen is the only such dependency; FindBinaryen.cmake
+# leaves Binaryen_INSTALL_RPATH empty when the loader finds it unaided.
+if(ENDO_HAS_WASM AND Binaryen_INSTALL_RPATH)
+    set_property(TARGET endo-bin APPEND PROPERTY INSTALL_RPATH "${Binaryen_INSTALL_RPATH}")
+endif()
+
 install(TARGETS endo-bin RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install runtime DLL dependencies alongside the executable (Windows/vcpkg).
@@ -377,6 +386,20 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/data/completers/
         DESTINATION ${CMAKE_INSTALL_DATADIR}/endo/completers)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/data/stdlib/
         DESTINATION ${CMAKE_INSTALL_DATADIR}/endo/stdlib)
+
+# Guards the RPATH above: the build-tree binary resolves its libraries even when
+# the installed one cannot, so only an installed binary can prove the install is
+# usable. Unix-only, where RPATH is the mechanism being tested.
+if(ENDO_TESTING AND UNIX AND NOT EMSCRIPTEN)
+    add_test(
+        NAME installed-binary
+        COMMAND ${CMAKE_COMMAND}
+            -DBUILD_DIR=${CMAKE_BINARY_DIR}
+            -DCONFIG=$<CONFIG>
+            -P ${CMAKE_SOURCE_DIR}/cmake/tests/TestInstalledBinary.cmake
+    )
+    set_tests_properties(installed-binary PROPERTIES TIMEOUT 120)
+endif()
 
 # Enable sanitizers and clang-tidy for all targets
 enable_sanitizers(endo-shell)

--- a/src/shell/CompileCommand.cpp
+++ b/src/shell/CompileCommand.cpp
@@ -2,49 +2,47 @@
 #include "CompileCommand.hpp"
 
 #include <cstdlib>
+#include <cstring>
+#include <format>
+#include <fstream>
 #include <print>
+#include <sstream>
+
+namespace endo::compile
+{
+
+std::expected<std::string, std::string> readScriptSource(std::string_view scriptPath)
+{
+    auto const path = std::string(scriptPath);
+    std::ifstream file(path);
+    if (!file)
+        return std::unexpected(std::format("{}: {}", scriptPath, strerror(errno)));
+
+    std::ostringstream ss;
+    ss << file.rdbuf();
+    std::string content = ss.str();
+
+    if (content.starts_with("#!"))
+    {
+        auto const pos = content.find('\n');
+        content = pos != std::string::npos ? content.substr(pos + 1) : std::string {};
+    }
+    return content;
+}
+
+} // namespace endo::compile
 
 #if defined(ENDO_HAS_WASM)
 
-    #include <endo-language/CompileToIR.hpp>
-    #include <endo-language/builtins/StubRuntime.hpp>
+    #include <endo-language/CompileToWasm.hpp>
 
-    #include <CoreVM/CoreVM.hpp>
-    #include <CoreVM/transform/Passes.hpp>
-    #include <CoreVM/wasm/WasmCodeGenerator.hpp>
-    #include <CoreVM/wasm/WasmRuntime.hpp>
-
-    #include <expected>
     #include <filesystem>
-    #include <fstream>
-    #include <sstream>
-    #include <string>
 
 namespace endo::compile
 {
 
 namespace
 {
-
-    /// Reads a script file and strips a leading shebang line.
-    std::expected<std::string, std::string> readScriptSource(std::string_view scriptPath)
-    {
-        auto const path = std::string(scriptPath);
-        std::ifstream file(path);
-        if (!file)
-            return std::unexpected(std::format("{}: {}", scriptPath, strerror(errno)));
-
-        std::ostringstream ss;
-        ss << file.rdbuf();
-        std::string content = ss.str();
-
-        if (content.starts_with("#!"))
-        {
-            auto const pos = content.find('\n');
-            content = pos != std::string::npos ? content.substr(pos + 1) : std::string {};
-        }
-        return content;
-    }
 
     /// Writes the compiled module to the output file (binary or text).
     bool writeOutput(std::string_view outputFile, CoreVM::wasm::WasmOutput const& output, bool asText)
@@ -84,28 +82,15 @@ int runCompileCommand(CompileOptions const& options)
         return EXIT_FAILURE;
     }
 
-    // IR generation only needs builtin signatures, not executable callbacks.
-    auto runtime = CoreVM::Runtime {};
-    registerStubRuntime(runtime);
-
     auto report = CoreVM::diagnostics::ConsoleReport {};
-    // NOTE: The CoreVM IR-level optimization passes (PassManager) are not run
-    // here: they verify() the IR after each change, and the frontend routinely
-    // emits blocks that fail verification (e.g. unterminated match merge
-    // blocks after fully-returning arms) yet execute fine. -O optimization
-    // happens at the WASM module level via binaryen instead.
-    auto irProgram = compileToIR(std::move(*source), runtime, report, options.scriptFile);
-    if (!irProgram)
-        return EXIT_FAILURE;
-
-    auto provider = CoreVM::wasm::WasmRuntime {};
-    auto generator = CoreVM::wasm::WasmCodeGenerator(provider,
-                                                     CoreVM::wasm::WasmOptions {
-                                                         .optimize = options.optimize,
-                                                         .tailCalls = options.tailCalls,
-                                                         .emitWat = emitWat,
-                                                     });
-    auto const output = generator.generate(irProgram.get(), report);
+    auto const output = compileSourceToWasm(std::move(*source),
+                                            options.scriptFile,
+                                            CoreVM::wasm::WasmOptions {
+                                                .optimize = options.optimize,
+                                                .tailCalls = options.tailCalls,
+                                                .emitWat = emitWat,
+                                            },
+                                            report);
     if (!output)
         return EXIT_FAILURE;
 

--- a/src/shell/CompileCommand.cpp
+++ b/src/shell/CompileCommand.cpp
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "CompileCommand.hpp"
+
+#include <cstdlib>
+#include <print>
+
+#if defined(ENDO_HAS_WASM)
+
+    #include <endo-language/CompileToIR.hpp>
+    #include <endo-language/builtins/StubRuntime.hpp>
+
+    #include <CoreVM/CoreVM.hpp>
+    #include <CoreVM/transform/Passes.hpp>
+    #include <CoreVM/wasm/WasmCodeGenerator.hpp>
+    #include <CoreVM/wasm/WasmRuntimeABI.hpp>
+
+    #include <expected>
+    #include <filesystem>
+    #include <fstream>
+    #include <sstream>
+    #include <string>
+
+namespace endo::compile
+{
+
+namespace
+{
+
+    /// Reads a script file and strips a leading shebang line.
+    std::expected<std::string, std::string> readScriptSource(std::string_view scriptPath)
+    {
+        auto const path = std::string(scriptPath);
+        std::ifstream file(path);
+        if (!file)
+            return std::unexpected(std::format("{}: {}", scriptPath, strerror(errno)));
+
+        std::ostringstream ss;
+        ss << file.rdbuf();
+        std::string content = ss.str();
+
+        if (content.starts_with("#!"))
+        {
+            auto const pos = content.find('\n');
+            content = pos != std::string::npos ? content.substr(pos + 1) : std::string {};
+        }
+        return content;
+    }
+
+    /// Runs the same semantics-preserving IR cleanup passes as Shell::execute.
+    /// The WASM path always runs them: cross-block value materialization
+    /// benefits from empty-block and unused-instruction elimination.
+    void optimizeIR(CoreVM::IRProgram& program)
+    {
+        CoreVM::PassManager pm;
+
+        // clang-format off
+        pm.registerPass("eliminate-empty-blocks", &CoreVM::transform::emptyBlockElimination);
+        pm.registerPass("eliminate-linear-br", &CoreVM::transform::eliminateLinearBr);
+        pm.registerPass("eliminate-unused-blocks", &CoreVM::transform::eliminateUnusedBlocks);
+        pm.registerPass("eliminate-unused-instr", &CoreVM::transform::eliminateUnusedInstr);
+        pm.registerPass("fold-constant-condbr", &CoreVM::transform::foldConstantCondBr);
+        pm.registerPass("rewrite-br-to-exit", &CoreVM::transform::rewriteBrToExit);
+        pm.registerPass("rewrite-cond-br-to-same-branches", &CoreVM::transform::rewriteCondBrToSameBranches);
+        // clang-format on
+
+        pm.run(&program);
+    }
+
+    /// Writes the compiled module to the output file (binary or text).
+    bool writeOutput(std::string_view outputFile, CoreVM::wasm::WasmOutput const& output, bool asText)
+    {
+        auto stream = std::ofstream(std::string(outputFile), std::ios::binary | std::ios::trunc);
+        if (!stream)
+        {
+            std::print(stderr, "endo: cannot write {}: {}\n", outputFile, strerror(errno));
+            return false;
+        }
+        if (asText)
+            stream.write(output.wat.data(), static_cast<std::streamsize>(output.wat.size()));
+        else
+            stream.write(reinterpret_cast<char const*>(output.binary.data()),
+                         static_cast<std::streamsize>(output.binary.size()));
+        return stream.good();
+    }
+
+} // namespace
+
+int runCompileCommand(CompileOptions const& options)
+{
+    auto const extension = std::filesystem::path(options.outputFile).extension().string();
+    bool const emitWat = extension == ".wat";
+    if (!emitWat && extension != ".wasm")
+    {
+        std::print(stderr,
+                   "endo: unsupported output format '{}' (supported: .wasm, .wat)\n",
+                   extension.empty() ? std::string(options.outputFile) : extension);
+        return EXIT_FAILURE;
+    }
+
+    auto source = readScriptSource(options.scriptFile);
+    if (!source)
+    {
+        std::print(stderr, "endo: {}\n", source.error());
+        return EXIT_FAILURE;
+    }
+
+    // IR generation only needs builtin signatures, not executable callbacks.
+    auto runtime = CoreVM::Runtime {};
+    registerStubRuntime(runtime);
+
+    auto report = CoreVM::diagnostics::ConsoleReport {};
+    auto irProgram = compileToIR(std::move(*source), runtime, report, options.scriptFile);
+    if (!irProgram)
+        return EXIT_FAILURE;
+
+    optimizeIR(*irProgram);
+
+    auto provider = CoreVM::wasm::ImportOnlyRuntimeProvider {};
+    auto generator = CoreVM::wasm::WasmCodeGenerator(provider,
+                                                     CoreVM::wasm::WasmOptions {
+                                                         .optimize = options.optimize,
+                                                         .tailCalls = options.tailCalls,
+                                                         .emitWat = emitWat,
+                                                     });
+    auto const output = generator.generate(irProgram.get(), report);
+    if (!output)
+        return EXIT_FAILURE;
+
+    return writeOutput(options.outputFile, *output, emitWat) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+} // namespace endo::compile
+
+#else
+
+namespace endo::compile
+{
+
+int runCompileCommand(CompileOptions const& options)
+{
+    (void) options;
+    std::print(stderr,
+               "endo: this build does not include the WebAssembly backend "
+               "(binaryen was not found at configure time)\n");
+    return EXIT_FAILURE;
+}
+
+} // namespace endo::compile
+
+#endif

--- a/src/shell/CompileCommand.cpp
+++ b/src/shell/CompileCommand.cpp
@@ -46,26 +46,6 @@ namespace
         return content;
     }
 
-    /// Runs the same semantics-preserving IR cleanup passes as Shell::execute.
-    /// The WASM path always runs them: cross-block value materialization
-    /// benefits from empty-block and unused-instruction elimination.
-    void optimizeIR(CoreVM::IRProgram& program)
-    {
-        CoreVM::PassManager pm;
-
-        // clang-format off
-        pm.registerPass("eliminate-empty-blocks", &CoreVM::transform::emptyBlockElimination);
-        pm.registerPass("eliminate-linear-br", &CoreVM::transform::eliminateLinearBr);
-        pm.registerPass("eliminate-unused-blocks", &CoreVM::transform::eliminateUnusedBlocks);
-        pm.registerPass("eliminate-unused-instr", &CoreVM::transform::eliminateUnusedInstr);
-        pm.registerPass("fold-constant-condbr", &CoreVM::transform::foldConstantCondBr);
-        pm.registerPass("rewrite-br-to-exit", &CoreVM::transform::rewriteBrToExit);
-        pm.registerPass("rewrite-cond-br-to-same-branches", &CoreVM::transform::rewriteCondBrToSameBranches);
-        // clang-format on
-
-        pm.run(&program);
-    }
-
     /// Writes the compiled module to the output file (binary or text).
     bool writeOutput(std::string_view outputFile, CoreVM::wasm::WasmOutput const& output, bool asText)
     {
@@ -109,11 +89,14 @@ int runCompileCommand(CompileOptions const& options)
     registerStubRuntime(runtime);
 
     auto report = CoreVM::diagnostics::ConsoleReport {};
+    // NOTE: The CoreVM IR-level optimization passes (PassManager) are not run
+    // here: they verify() the IR after each change, and the frontend routinely
+    // emits blocks that fail verification (e.g. unterminated match merge
+    // blocks after fully-returning arms) yet execute fine. -O optimization
+    // happens at the WASM module level via binaryen instead.
     auto irProgram = compileToIR(std::move(*source), runtime, report, options.scriptFile);
     if (!irProgram)
         return EXIT_FAILURE;
-
-    optimizeIR(*irProgram);
 
     auto provider = CoreVM::wasm::WasmRuntime {};
     auto generator = CoreVM::wasm::WasmCodeGenerator(provider,

--- a/src/shell/CompileCommand.cpp
+++ b/src/shell/CompileCommand.cpp
@@ -12,7 +12,7 @@
     #include <CoreVM/CoreVM.hpp>
     #include <CoreVM/transform/Passes.hpp>
     #include <CoreVM/wasm/WasmCodeGenerator.hpp>
-    #include <CoreVM/wasm/WasmRuntimeABI.hpp>
+    #include <CoreVM/wasm/WasmRuntime.hpp>
 
     #include <expected>
     #include <filesystem>
@@ -115,7 +115,7 @@ int runCompileCommand(CompileOptions const& options)
 
     optimizeIR(*irProgram);
 
-    auto provider = CoreVM::wasm::ImportOnlyRuntimeProvider {};
+    auto provider = CoreVM::wasm::WasmRuntime {};
     auto generator = CoreVM::wasm::WasmCodeGenerator(provider,
                                                      CoreVM::wasm::WasmOptions {
                                                          .optimize = options.optimize,

--- a/src/shell/CompileCommand.hpp
+++ b/src/shell/CompileCommand.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <string_view>
+
+namespace endo::compile
+{
+
+/// Options for the `endo -o <output> <script>` compile mode.
+struct CompileOptions
+{
+    std::string_view scriptFile; ///< The .endo script to compile.
+    std::string_view outputFile; ///< Output path; format is derived from the extension (.wasm, .wat).
+    bool optimize = false;       ///< -O: run binaryen optimizations over the module.
+    bool tailCalls = true;       ///< Emit return_call (disable via --wasm-no-tail-call).
+};
+
+/// Compiles a script to WebAssembly instead of executing it.
+///
+/// Reads the script, compiles it to CoreVM IR (no Shell, no execution), runs
+/// the standard IR cleanup passes, and emits a WASI command module via the
+/// WASM backend. Prints diagnostics to stderr.
+///
+/// @return the process exit code (EXIT_SUCCESS on success)
+[[nodiscard]] int runCompileCommand(CompileOptions const& options);
+
+} // namespace endo::compile

--- a/src/shell/CompileCommand.hpp
+++ b/src/shell/CompileCommand.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <expected>
+#include <string>
 #include <string_view>
 
 namespace endo::compile
@@ -15,11 +17,16 @@ struct CompileOptions
     bool tailCalls = true;       ///< Emit return_call (disable via --wasm-no-tail-call).
 };
 
+/// Reads a script file and strips a leading shebang line.
+/// Shared by the compile mode and script execution.
+/// @return the script source, or an error message ("<path>: <reason>")
+[[nodiscard]] std::expected<std::string, std::string> readScriptSource(std::string_view scriptPath);
+
 /// Compiles a script to WebAssembly instead of executing it.
 ///
-/// Reads the script, compiles it to CoreVM IR (no Shell, no execution), runs
-/// the standard IR cleanup passes, and emits a WASI command module via the
-/// WASM backend. Prints diagnostics to stderr.
+/// Reads the script, compiles it through the shared source-to-wasm pipeline
+/// (no Shell, no execution; see endo-language/CompileToWasm.hpp), and writes
+/// a WASI command module. Prints diagnostics to stderr.
 ///
 /// @return the process exit code (EXIT_SUCCESS on success)
 [[nodiscard]] int runCompileCommand(CompileOptions const& options);

--- a/src/shell/HelpPrinter.cpp
+++ b/src/shell/HelpPrinter.cpp
@@ -296,6 +296,9 @@ void printHelp()
     h.option("-h, --help", "Show this help message and exit");
     h.option("-v, --version", "Show version information and exit");
     h.option("-c COMMAND", "Execute COMMAND and exit");
+    h.option("-o, --output FILE", "Compile SCRIPT to WebAssembly (.wasm) or text format (.wat)");
+    h.option("-O", "Optimize the compiled WebAssembly output");
+    h.option("--wasm-no-tail-call", "Compile tail calls as plain calls (older WASM runtimes)");
     h.option("--check", "Compile without executing (syntax and semantic check)");
     h.option("--unused-detection", "Enable unused-value detection for F# bindings");
     h.option("--lsp", "Launch Language Server Protocol server");
@@ -346,6 +349,9 @@ void printHelp()
     h.example("Sort and filter a list:", "endo -c '[3; 1; 4; 1; 5] |> sort |> filter (_ > 2) |> println'");
     h.blank();
     h.example("Execute a script with arguments:", "endo script.endo arg1 arg2");
+    h.blank();
+    h.example("Compile a script to WebAssembly and run it:",
+              "endo -o script.wasm script.endo && wasmtime script.wasm");
 
     // Learn More
     h.header("LEARN MORE");

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -28,6 +28,7 @@
 #endif
 #include <shell/EndoVersion.hpp>
 
+#include "CompileCommand.hpp"
 #include "FormatCommand.hpp"
 #include "HelpPrinter.hpp"
 #include "Shell.hpp"
@@ -78,6 +79,9 @@ struct ParsedArgs
     std::optional<std::string> logFile;        ///< Log file path for protocol messages (DAP, etc.).
     std::vector<std::string_view> modulePaths; ///< Additional module search paths (--module-path).
     bool noProfile = false;                    ///< Skip loading init.endo profile.
+    std::string_view outputFile;               ///< -o/--output: compile to .wasm/.wat instead of executing.
+    bool optimizeOutput = false;               ///< -O: optimize the compiled output module.
+    bool wasmNoTailCall = false;               ///< Lower tail calls as plain calls (older WASM runtimes).
 };
 
 /// Tries to extract the value for a long option.
@@ -170,6 +174,22 @@ ParsedArgs parseArguments(std::span<char const* const> args)
         else if (auto val = consumeOptionValue(arg, "--module-path", i, args))
         {
             result.modulePaths.emplace_back(*val);
+        }
+        else if (auto val = consumeOptionValue(arg, "-o", i, args))
+        {
+            result.outputFile = *val;
+        }
+        else if (auto val = consumeOptionValue(arg, "--output", i, args))
+        {
+            result.outputFile = *val;
+        }
+        else if (arg == "-O")
+        {
+            result.optimizeOutput = true;
+        }
+        else if (arg == "--wasm-no-tail-call")
+        {
+            result.wasmNoTailCall = true;
         }
         else if (arg == "-c" && i + 1 < args.size())
         {
@@ -388,6 +408,22 @@ int main(int argc, char const* argv[])
     {
         std::print(stderr, "endo: --check requires -c <command> or a script file\n");
         return EXIT_FAILURE;
+    }
+
+    // Handle -o FILE: compile the script to WebAssembly instead of executing it
+    if (!parsed.outputFile.empty())
+    {
+        if (parsed.scriptFile.empty())
+        {
+            std::print(stderr, "endo: -o requires a script file to compile\n");
+            return EXIT_FAILURE;
+        }
+        return endo::compile::runCompileCommand({
+            .scriptFile = parsed.scriptFile,
+            .outputFile = parsed.outputFile,
+            .optimize = parsed.optimizeOutput,
+            .tailCalls = !parsed.wasmNoTailCall,
+        });
     }
 
     auto shell = endo::Shell {};

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -6,14 +6,11 @@
 
 #include <crispy/LogStore.hpp>
 
-#include <cerrno>
 #include <clocale>
 #include <cstdlib>
 #include <cstring>
-#include <fstream>
 #include <print>
 #include <span>
-#include <sstream>
 #include <string>
 #include <string_view>
 
@@ -230,34 +227,19 @@ int executeScript(endo::Shell& shell,
                   std::span<std::string_view const> scriptArgs,
                   std::string_view programName)
 {
-    // 1. Open and read file
-    auto const scriptPathStr = std::string(scriptPath);
-    std::ifstream file(scriptPathStr);
-    if (!file)
+    // 1. Read the file, stripping a leading shebang line
+    auto content = endo::compile::readScriptSource(scriptPath);
+    if (!content)
     {
-        std::print(stderr, "endo: {}: {}\n", scriptPath, strerror(errno));
+        std::print(stderr, "endo: {}\n", content.error());
         return EXIT_FAILURE;
-    }
-
-    std::ostringstream ss;
-    ss << file.rdbuf();
-    std::string content = ss.str();
-
-    // 2. Strip shebang line if present
-    if (content.starts_with("#!"))
-    {
-        auto const pos = content.find('\n');
-        if (pos != std::string::npos)
-            content = content.substr(pos + 1);
-        else
-            content.clear(); // Script is only a shebang
     }
 
     // 3. Set up non-interactive mode
     shell.setInteractive(false);
 
     // 4. Set source file path for relative module resolution
-    shell.setSourceFile(std::filesystem::canonical(scriptPathStr));
+    shell.setSourceFile(std::filesystem::canonical(std::string(scriptPath)));
 
     // 5. Set positional parameters ($0 = script, $1... = args)
     std::vector<std::string> params;
@@ -267,7 +249,7 @@ int executeScript(endo::Shell& shell,
     shell.setPositionalParameters(std::move(params));
 
     // 6. Execute (parser validates entire script before execution)
-    return shell.execute(content);
+    return shell.execute(*content);
 }
 
 #if defined(_WIN32)

--- a/tests/wasm/division_by_zero.endo
+++ b/tests/wasm/division_by_zero.endo
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Division by zero is a runtime error with exit code 1
+# mode: wasm
+# expect-exit: 1
+
+let a = 10
+
+let b = 0
+
+let c = a / b
+
+print c

--- a/tests/wasm/exit_code.endo
+++ b/tests/wasm/exit_code.endo
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Explicit exit code propagates through proc_exit
+# mode: wasm
+# expect-exit: 42
+
+let x = 40
+
+let y = 2
+
+let z = x + y
+
+exit z

--- a/tests/wasm/exit_status_false.endo
+++ b/tests/wasm/exit_status_false.endo
@@ -1,0 +1,6 @@
+false
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Bare false sets the shell exit status
+# mode: wasm
+# expect-exit: 1

--- a/tests/wasm/fizzbuzz.endo
+++ b/tests/wasm/fizzbuzz.endo
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: FizzBuzz produces VM-identical output under wasmtime
+# mode: wasm
+# expect: 1
+# expect: 2
+# expect: Fizz
+# expect: 4
+# expect: Buzz
+# expect: Fizz
+# expect: 7
+# expect: 8
+# expect: Fizz
+# expect: Buzz
+# expect: 11
+# expect: Fizz
+# expect: 13
+# expect: 14
+# expect: FizzBuzz
+
+let word (n: int): string =
+    if n % 15 == 0 then
+        "FizzBuzz"
+    elif n % 3 == 0 then
+        "Fizz"
+    elif n % 5 == 0 then "Buzz"
+    else $"{n}"
+
+let rec fizz (n: int) (stop: int): int =
+    if n > stop then
+        0
+    else
+        println (word n)
+        fizz (n + 1) stop
+
+fizz 1 15

--- a/tests/wasm/floats.endo
+++ b/tests/wasm/floats.endo
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Float arithmetic and %g-style formatting
+# mode: wasm
+# expect: 3.14
+# expect: 6.28
+# expect: 2.5
+# expect: 0.001
+# expect: 123457
+
+let a = 3.14
+
+print a
+println ""
+print (a * 2.0)
+println ""
+print (10.0 / 4.0)
+println ""
+print 0.001
+println ""
+print 123456.7
+println ""

--- a/tests/wasm/functions.endo
+++ b/tests/wasm/functions.endo
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Typed functions compile to WASM calls; deep recursion uses return_call
+# mode: wasm
+# expect: 42
+# expect: 0
+
+let add (a: int) (b: int) = a + b
+
+print (add 40 2)
+println ""
+
+let rec deep (n: int): int =
+    if n == 0 then 0
+    else deep (n - 1)
+
+print (deep 100000)
+println ""

--- a/tests/wasm/hello.endo
+++ b/tests/wasm/hello.endo
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Hello world compiled to WASM runs under wasmtime
+# mode: wasm
+# expect: hello, world
+
+println "hello, world"

--- a/tests/wasm/if_else.endo
+++ b/tests/wasm/if_else.endo
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: If/else branching decides the exit code
+# mode: wasm
+# expect-exit: 2
+
+let x = 3
+
+let code =
+    if x > 5 then 1
+    else 2
+
+exit code

--- a/tests/wasm/list_builtins.endo
+++ b/tests/wasm/list_builtins.endo
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Native list builtins (length, head, tail, nth, concat)
+# mode: wasm
+# expect: 3
+# expect: Some 1
+# expect: [2; 3]
+# expect: Some 2
+# expect: [1; 2; 3; 4; 5]
+# expect: empty
+
+let xs = [1; 2; 3]
+
+print (xs |> length)
+println ""
+print (head xs)
+println ""
+print (tail xs)
+println ""
+print (nth 1 xs)
+println ""
+print (xs @ [4; 5])
+println ""
+
+let msg =
+    if isEmpty [] then "empty"
+    else "nonempty"
+
+println msg

--- a/tests/wasm/lists_hof.endo
+++ b/tests/wasm/lists_hof.endo
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: List literals, HOF pipelines and display formatting
+# mode: wasm
+# expect: [1; 2; 3; 4; 5]
+# expect: [2; 4; 6; 8; 10]
+# expect: [2; 4]
+# expect: 15
+# expect: ["x"; "y"]
+
+let xs = [1; 2; 3; 4; 5]
+
+print xs
+println ""
+print (xs |> map (_ * 2))
+println ""
+print (xs |> filter (_ % 2 == 0))
+println ""
+print (xs |> fold 0 (fun acc v -> acc + v))
+println ""
+print ["x"; "y"]
+println ""

--- a/tests/wasm/match_string.endo
+++ b/tests/wasm/match_string.endo
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Match on string values compares by content
+# mode: wasm
+# expect: h
+
+let s = "hello"
+
+match s with
+| "world" -> println "w"
+| "hello" -> println "h"
+| _ -> println "other"

--- a/tests/wasm/option_result.endo
+++ b/tests/wasm/option_result.endo
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Option/Result construction, display and pattern matching
+# mode: wasm
+# expect: Some 42
+# expect: 42
+# expect: Ok 7
+# expect: boom
+
+let o = Some 42
+
+print o
+println ""
+
+let x =
+    match o with
+    | Some v -> v
+    | None -> 0
+
+print x
+println ""
+print (Ok 7)
+println ""
+
+let r = Error "boom"
+
+match r with
+| Ok v -> println "ok"
+| Error e -> println e

--- a/tests/wasm/print_values.endo
+++ b/tests/wasm/print_values.endo
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Printing numbers, strings and negative values
+# mode: wasm
+# expect: 42
+# expect: hello
+# expect: -7
+
+print 42
+println ""
+println "hello"
+
+let n = 0 - 7
+
+print n
+println ""

--- a/tests/wasm/recursion.endo
+++ b/tests/wasm/recursion.endo
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: let-rec with match compiles via the dispatch loop
+# mode: wasm
+# expect: 3628800
+
+let rec factorial n acc =
+    match n with
+    | 0 -> acc
+    | _ -> factorial (n - 1) (n * acc)
+
+print (factorial 10 1)
+println ""

--- a/tests/wasm/strings.endo
+++ b/tests/wasm/strings.endo
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: String concatenation, comparison and interpolation
+# mode: wasm
+# expect: hello world
+# expect: eq-ok
+# expect: lt-ok
+# expect: n is 42
+
+let a = "hello"
+
+let b = "world"
+
+println (a + " " + b)
+if a == "hello" then println "eq-ok"
+else println "eq-bad"
+if a < b then println "lt-ok"
+else println "lt-bad"
+
+let n = 42
+
+println $"n is {n}"

--- a/tests/wasm/tuples.endo
+++ b/tests/wasm/tuples.endo
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Tuple construction and mixed-type display
+# mode: wasm
+# expect: (1, 2)
+# expect: ("a", 5, true)
+
+print (1, 2)
+println ""
+print ("a", 5, true)
+println ""

--- a/tests/wasm/unsupported_lazy.endo
+++ b/tests/wasm/unsupported_lazy.endo
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Lazy evaluation cannot compile to WASM yet
+# mode: wasm
+# expect-error: not supported
+
+let x = lazy 42
+
+println (force x)

--- a/tests/wasm/unsupported_shell_exec.endo
+++ b/tests/wasm/unsupported_shell_exec.endo
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# description: Shell command execution cannot compile to WASM
+# mode: wasm
+# expect-error: cannot compile to WebAssembly
+
+ls -l


### PR DESCRIPTION
Implements the first iteration of ROADMAP-WASM.md: `endo -o hello.wasm hello.endo` compiles a script to a self-contained WASI command module (also `.wat` for inspection) that runs in the terminal under wasmtime — with output and exit codes byte-identical to the interpreter for the supported subset. The backend consumes the same SSA-form `IRProgram` as the bytecode `TargetCodeGenerator` and emits WASM through the system binaryen C API.

## Changes

- **Backend** (`src/CoreVM/wasm/`, new `CoreVM-wasm` library): `WasmCodeGenerator` + `WasmFunctionLowerer` (an `InstructionVisitor` mirroring `TargetCodeGenerator`) with a uniform-i64 value representation matching the VM's stack slots, binaryen's relooper for control flow, and data-driven lowering tables (operators, casts, builtins) per the project's descriptor-table convention.
- **In-module runtime** (`WasmRuntime`): lazily emitted helper functions — bump allocator over linear memory, string operations, INT64_MIN-safe integer formatting, printf-`%g`-style float formatting, division/remainder/power with VM semantics, and recursive display formatters producing the interpreter's exact output (`[1; 2; 3]`, `Some 42`, quoted strings in containers). I/O goes through WASI `fd_write`/`proc_exit`; shell exit-status semantics live in a single `endo_exit` helper.
- **Language coverage**: integers, floats, booleans, strings and interpolation, if/else, pattern matching (literals, constructors, cons, string matches), user functions with `return_call` tail calls (1M-deep recursion verified), Option/Result/tuples/lists, the IR-inlined HOF pipelines (map/filter/fold/...), and the list builtins (`length`, `head`, `tail`, `nth`, `isEmpty`, `@`). Unsupported constructs (shell execution, file I/O, regex, closures, lazy) fail with located compile-time errors, all collected in one run.
- **CLI**: `-o/--output`, `-O` (binaryen optimizer), `--wasm-no-tail-call`; compilation runs without constructing a `Shell` via the new shared `endo::compileToIR()` / `compileSourceToWasm()` drivers (TestHelper now reuses the former).
- **Build**: new `cmake/FindBinaryen.cmake`; the backend is gated on `ENDO_HAS_WASM` and auto-disabled when binaryen is absent, under Emscripten, or for static builds — endo builds unchanged without it.
- **Tests**: Catch2 unit tests in `test-corevm` plus a new `# mode: wasm` in endo-test running `tests/wasm/` (18 differential E2E tests) under wasmtime, skipping cleanly when wasmtime is not installed.
- **Docs**: `docs/shell/wasm-compilation.md` (usage, supported features, documented deviations from the interpreter), roadmap status updates.