### PR TITLE
Keep adjacent let bindings grouped when formatting

### DIFF
--- a/src/endo-language/format/SourceFormatter.cpp
+++ b/src/endo-language/format/SourceFormatter.cpp
@@ -674,6 +674,30 @@ bool SourceFormatter::wouldFormatMultiline(ast::Expr const& expr) const
     return false;
 }
 
+bool SourceFormatter::bodyBreaksAfterEquals(ast::LetBindingStmt const& node) const
+{
+    // Property bindings (`with get () = ...` / `and set (v) = ...`) span several lines
+    // when either accessor body wraps — mirroring how visit(LetBindingStmt) emits them.
+    if ((node.getter && wouldFormatMultiline(*node.getter->body))
+        || (node.setter && wouldFormatMultiline(*node.setter->body)))
+        return true;
+
+    if (!node.value)
+        return false;
+
+    // List/Tuple expressions wrap themselves (emitWrappedWith handles `[`, indent,
+    // bin-pack, dedent, `]`), so their opening delimiter stays on the `=` line.
+    if (dynamic_cast<ast::ListExpr const*>(node.value.get())
+        || dynamic_cast<ast::TupleExpr const*>(node.value.get()))
+        return false;
+
+    // A wide body is only pushed onto its own line for function bindings, where the
+    // parameter list has already consumed part of the first line.
+    auto const bodyWidth = estimateWidth(*node.value);
+    return wouldFormatMultiline(*node.value)
+           || (bodyWidth > _config.maxLineWidth / 2 && !node.parameters.empty());
+}
+
 // ============================================================================
 // Current column tracking
 // ============================================================================
@@ -948,6 +972,14 @@ static bool isDeclarationOrBlock(ast::Node const& node)
            || dynamic_cast<ast::ForInStmt const*>(&node) != nullptr;
 }
 
+/// Checks whether a statement is a `let` binding, which participates in grouping:
+/// consecutive single-line bindings the author wrote adjacently stay adjacent, rather
+/// than being forced apart by a blank line.
+static bool isLetBinding(ast::Node const& node)
+{
+    return dynamic_cast<ast::LetBindingStmt const*>(&node) != nullptr;
+}
+
 void SourceFormatter::visit(ast::CompoundStmt const& node)
 {
     emitLeadingComments(node);
@@ -972,13 +1004,36 @@ void SourceFormatter::visit(ast::CompoundStmt const& node)
             emitNewline();
             auto wantBlankLine = false;
 
-            // (A) Existing heuristic: declarations/blocks at top level always get blank lines
-            if (_indentLevel == 0
+            // Consecutive `let` bindings form a group: when the author wrote them on
+            // adjacent lines they stay adjacent, so related aliases or exports read as a
+            // block instead of being spread apart. A binding that occupies more than one
+            // line is always isolated by blank lines above and below, which keeps a
+            // wrapped body from visually merging into its neighbours. Whether a binding
+            // is multi-line is decided from what was actually emitted (see
+            // previousStatementWasMultiline), not from the source: a long single-line
+            // binding may wrap, and a wrapped one may fit back onto a single line.
+            auto const groupableLets =
+                isLetBinding(*node.statements[i - 1]) && isLetBinding(*node.statements[i]);
+
+            // (A) Existing heuristic: declarations/blocks at top level get blank lines.
+            // Groupable `let` runs are exempt, and fall through to (B) so the author's
+            // own blank lines decide where one group ends and the next begins.
+            if (_indentLevel == 0 && !groupableLets
                 && (isDeclarationOrBlock(*node.statements[i - 1])
                     || isDeclarationOrBlock(*node.statements[i])))
                 wantBlankLine = true;
 
-            // (B) Preserve user-authored blank lines at any indent level
+            // A multi-line binding gets a group to itself, regardless of how the author
+            // spaced it: separated from the binding before it (which has already been
+            // emitted, so its shape is known exactly) and from the one after it (not yet
+            // emitted, so its shape is predicted with the same helper that decides the
+            // wrap).
+            if (!wantBlankLine && groupableLets
+                && (_previousStatementWasMultiline
+                    || bodyBreaksAfterEquals(dynamic_cast<ast::LetBindingStmt const&>(*node.statements[i]))))
+                wantBlankLine = true;
+
+            // (B) Preserve user-authored blank lines at any indent level.
             if (!wantBlankLine && !_blankLines.empty())
             {
                 auto const prevStart = findFirstLine(*node.statements[i - 1]);
@@ -998,10 +1053,18 @@ void SourceFormatter::visit(ast::CompoundStmt const& node)
         {
             emitVerbatimRegion(*region);
             lastEmittedRegionBegin = region->beginLine;
+            _previousStatementWasMultiline = true; // a verbatim block spans its own lines
             continue;
         }
 
+        // Emit the statement, then record whether it produced more than one line so the
+        // next iteration can isolate it. Counting newlines in the emitted text is exact,
+        // where re-deriving the wrapping decision from the AST would have to duplicate
+        // (and stay in sync with) the composite condition in visit(LetBindingStmt).
+        auto const offsetBefore = _result.size();
         node.statements[i]->accept(*this);
+        auto const emitted = std::string_view { _result }.substr(offsetBefore);
+        _previousStatementWasMultiline = emitted.find('\n') != std::string_view::npos;
     }
     emitTrailingComment(node);
 }
@@ -1703,12 +1766,7 @@ void SourceFormatter::visit(ast::LetBindingStmt const& node)
         {
             // List/Tuple expressions are self-wrapping (emitWrappedWith handles [, indent,
             // bin-pack, dedent, ]) — keep opening delimiter on the = line.
-            auto const bodyWidth = estimateWidth(*node.value);
-            auto const isWrappableContainer = dynamic_cast<ast::ListExpr const*>(node.value.get())
-                                              || dynamic_cast<ast::TupleExpr const*>(node.value.get());
-            if (!isWrappableContainer
-                && (wouldFormatMultiline(*node.value)
-                    || (bodyWidth > _config.maxLineWidth / 2 && !node.parameters.empty())))
+            if (bodyBreaksAfterEquals(node))
             {
                 emitNewline();
                 indent();

--- a/src/endo-language/format/SourceFormatter.hpp
+++ b/src/endo-language/format/SourceFormatter.hpp
@@ -260,6 +260,15 @@ class SourceFormatter: public ast::Visitor, public pattern::PatternVisitor
     /// Checks whether an expression would produce multiline output when formatted.
     [[nodiscard]] bool wouldFormatMultiline(ast::Expr const& expr) const;
 
+    /// Checks whether a `let` binding's body is pushed onto its own indented line rather
+    /// than staying after the `=`, which is what makes the binding span several lines.
+    ///
+    /// Shared by the emission itself and by the blank-line grouping that isolates a
+    /// multi-line binding, so the prediction cannot drift from what is actually emitted.
+    /// @param node The binding to inspect.
+    /// @return True if the body breaks onto its own line.
+    [[nodiscard]] bool bodyBreaksAfterEquals(ast::LetBindingStmt const& node) const;
+
     /// Returns the current column position (0-based) in the output.
     [[nodiscard]] size_t currentColumn() const;
 
@@ -328,6 +337,13 @@ class SourceFormatter: public ast::Visitor, public pattern::PatternVisitor
     std::vector<CommentTrivia> const& _comments;
     size_t _nextCommentIndex = 0; ///< Index of next un-emitted comment
     std::set<int> _blankLines;    ///< 0-based line numbers of blank lines in original source
+
+    /// Whether the statement emitted just before the current one spanned several lines.
+    /// Drives `let`-group separation: a multi-line binding is isolated by blank lines even
+    /// when the author wrote it flush against its neighbours. Derived from the emitted text
+    /// rather than the source, so a binding that wraps (or stops wrapping) is classified by
+    /// how it actually comes out.
+    bool _previousStatementWasMultiline = false;
 
     /// Original source split into lines (0-based), used to reproduce verbatim regions exactly.
     /// Empty when the formatter is invoked without source (AST-only overload) — in that case

--- a/src/endo-language/format/SourceFormatter_test.cpp
+++ b/src/endo-language/format/SourceFormatter_test.cpp
@@ -823,12 +823,53 @@ TEST_CASE("SourceFormatter.blank_line_between_expression_and_let", "[format]")
     CHECK(result.find("print 1\n\nlet x = 42") != std::string::npos);
 }
 
-TEST_CASE("SourceFormatter.blank_line_between_consecutive_lets", "[format]")
+TEST_CASE("SourceFormatter.consecutive_lets_stay_grouped", "[format]")
 {
-    // Consecutive let bindings should still get blank lines (declarations)
+    // Single-line bindings the author wrote adjacently keep their grouping, so a run of
+    // related aliases or exports is not spread apart.
     auto const result = SourceFormatter::format("let x = 1\nlet y = 2");
     INFO("Result: [" << result << "]");
-    CHECK(result.find("let x = 1\n\nlet y = 2") != std::string::npos);
+    CHECK(result.find("let x = 1\nlet y = 2") != std::string::npos);
+    CHECK(result.find("let x = 1\n\nlet y = 2") == std::string::npos);
+}
+
+TEST_CASE("SourceFormatter.let_groups_separated_by_authored_blank_line", "[format]")
+{
+    // A blank line the author wrote is what separates one group from the next.
+    auto const result = SourceFormatter::format("let a = 1\nlet b = 2\n\nlet c = 3\nlet d = 4");
+    INFO("Result: [" << result << "]");
+    CHECK(result.find("let a = 1\nlet b = 2") != std::string::npos);
+    CHECK(result.find("let b = 2\n\nlet c = 3") != std::string::npos);
+    CHECK(result.find("let c = 3\nlet d = 4") != std::string::npos);
+}
+
+TEST_CASE("SourceFormatter.multiline_let_is_isolated", "[format]")
+{
+    // A binding whose body breaks onto its own line gets a group to itself — blank lines
+    // above *and* below — even though the author wrote all three flush together.
+    auto const result = SourceFormatter::format("let a = 1\nlet r = if true then 42 else 0\nlet b = 2");
+    INFO("Result: [" << result << "]");
+    CHECK(result.find("let a = 1\n\nlet r =") != std::string::npos);
+    CHECK(result.find("else 0\n\nlet b = 2") != std::string::npos);
+}
+
+TEST_CASE("SourceFormatter.let_grouping_idempotency", "[format]")
+{
+    const auto* const source = "let a = 1\nlet b = 2\n\nlet r = if true then 42 else 0\nlet c = 3";
+    auto const first = SourceFormatter::format(source);
+    auto const second = SourceFormatter::format(first);
+    INFO("First: [" << first << "]");
+    INFO("Second: [" << second << "]");
+    CHECK(first == second);
+}
+
+TEST_CASE("SourceFormatter.let_grouping_only_at_top_level", "[format]")
+{
+    // Nested bindings are governed by the author's own spacing, not by the top-level
+    // grouping rule; this simply must not crash or insert stray blank lines.
+    auto const result = SourceFormatter::format("let f () =\n    let a = 1\n    let b = 2\n    a + b");
+    INFO("Result: [" << result << "]");
+    CHECK(result.find("let a = 1\n    let b = 2") != std::string::npos);
 }
 
 TEST_CASE("SourceFormatter.consecutive_expressions_idempotency", "[format]")

--- a/tests/builtins/property_getter_and_setter.endo
+++ b/tests/builtins/property_getter_and_setter.endo
@@ -4,7 +4,6 @@
 # expect: 1042
 
 let mut _value = 10
-
 let Value with get () = _value and set (v) = _value <- v
 
 print Value

--- a/tests/builtins/property_getter_with_backing_variable.endo
+++ b/tests/builtins/property_getter_with_backing_variable.endo
@@ -4,7 +4,6 @@
 # expect: 0
 
 let mut _count = 0
-
 let Count with get () = _count
 
 print Count

--- a/tests/builtins/property_setter_first_then_getter.endo
+++ b/tests/builtins/property_setter_first_then_getter.endo
@@ -4,7 +4,6 @@
 # expect: 510
 
 let mut _x = 5
-
 let X with get () = _x and set (v) = _x <- v
 
 print X

--- a/tests/builtins/property_setter_only.endo
+++ b/tests/builtins/property_setter_only.endo
@@ -4,7 +4,6 @@
 # expect: 99
 
 let mut _log = 0
-
 let Logger with set (v) = _log <- v
 
 Logger <- 99

--- a/tests/builtins/property_with_on_next_line.endo
+++ b/tests/builtins/property_with_on_next_line.endo
@@ -4,7 +4,6 @@
 # expect: 77
 
 let mut _x = 0
-
 let X with get () = _x and set (v) = _x <- v
 
 X <- 77


### PR DESCRIPTION
`endo format` inserted a blank line between every pair of top-level declarations, so a deliberately grouped run of aliases or exports came back spread apart:

```endo
let passthrough l ...xs = & lsd -l ...xs

let passthrough ll ...xs = & lsd -la ...xs

let export EDITOR = "nvim"
```

Because the rule fired unconditionally it also flattened the author's *own* blank lines into that same uniform spacing, so the grouping information was not merely ignored — it was destroyed, and no amount of manual spacing survived a format pass.

Consecutive `let` bindings are now exempt from that heuristic and fall through to the formatter's existing author-blank-line preservation. Bindings written adjacently stay adjacent, and a blank line the author wrote still separates one group from the next. A binding that spans several lines is always isolated by blank lines above and below, so a wrapped body does not visually merge into its neighbours.

## Changes

- Exempt runs of consecutive `let` bindings from the declaration blank-line heuristic, reusing the existing `hasBlankLineBetween` preservation rather than adding a parallel mechanism.
- Isolate multi-line bindings with blank lines on both sides. Whether a binding is multi-line is decided from what is actually emitted, not from the source — a long single-line binding may wrap, and a wrapped one may fit back onto a single line. For the preceding binding this is exact (newlines in the emitted text); for the following one it is predicted by the new `bodyBreaksAfterEquals`.
- Factor `bodyBreaksAfterEquals` out of `visit(LetBindingStmt)` so the prediction cannot drift from the wrapping decision it mirrors. It also covers property accessors (`with get () = ...`), whose extra lines come from the accessor bodies rather than from a break after `=`.
- Reformat five committed `.endo` tests, each of which carried a spurious blank line between two single-line bindings that existed only because of the old behaviour.