### PR TITLE
Use fastcache-cc automatically when a fastcached daemon is running

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -179,11 +179,13 @@ launcher. It picks the first of these that is installed and usable:
 
 1. `fastcache-cc` — picked whenever a fastcached daemon actually answers. The address defaults to
    fastcached's own port, `127.0.0.1:6674`, so an installed daemon needs no configuration;
-   `FASTCACHE_ADDR=host:port` (environment or `-DFASTCACHE_ADDR=`) points it elsewhere, and an
-   empty value opts out. Configure verifies the cache end to end by compiling one tiny file
-   through the launcher (~0.1 s), and falls through to the next launcher when nothing answers —
-   `fastcache-cc` never fails a build, it just stops caching, so being told is the point. Its
-   cache entries are portable across checkout paths, so CI and local builds share hits.
+   `FASTCACHE_ADDR=host:port` in the environment points it at any other daemon, local or remote,
+   and `-DFASTCACHE_ADDR=host:port` overrides even that (an empty value opts out). Configure
+   verifies the cache end to end by compiling one tiny file through the launcher — ~0.1 s when a
+   daemon answers, capped at 10 s when none does — and falls through to the next launcher when
+   nothing answers, naming the address it tried. `fastcache-cc` never fails a build, it just stops
+   caching, so being told is the point. Its cache entries are portable across checkout paths, so
+   CI and local builds share hits.
 2. `sccache`
 3. `ccache`
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -180,7 +180,9 @@ launcher. It picks the first of these that is installed and usable:
 1. `fastcache-cc` — picked whenever a fastcached daemon actually answers. The address defaults to
    fastcached's own port, `127.0.0.1:6674`, so an installed daemon needs no configuration;
    `FASTCACHE_ADDR=host:port` in the environment points it at any other daemon, local or remote,
-   and `-DFASTCACHE_ADDR=host:port` overrides even that (an empty value opts out). Configure
+   and takes effect on the next configure of an existing build tree too, rather than being frozen
+   at what the first one saw; `-DFASTCACHE_ADDR=host:port` overrides even that for the run it is
+   passed on, and an empty value opts out. Configure
    verifies the cache end to end by compiling one tiny file through the launcher — ~0.1 s when a
    daemon answers, capped at 10 s when none does — and falls through to the next launcher when
    nothing answers, naming the address it tried. `fastcache-cc` never fails a build, it just stops

--- a/AGENT.md
+++ b/AGENT.md
@@ -177,7 +177,12 @@ cmake --build --preset clang-release
 `USE_COMPILER_CACHE` (default ON, `cmake/CompileCache.cmake`) fronts the compiler with a caching
 launcher. It picks the first of these that is installed and usable:
 
-1. `fastcache-cc` — only when `FASTCACHE_ADDR=host:port` names a running fastcached daemon. Its
+1. `fastcache-cc` — picked whenever a fastcached daemon actually answers. The address defaults to
+   fastcached's own port, `127.0.0.1:6674`, so an installed daemon needs no configuration;
+   `FASTCACHE_ADDR=host:port` (environment or `-DFASTCACHE_ADDR=`) points it elsewhere, and an
+   empty value opts out. Configure verifies the cache end to end by compiling one tiny file
+   through the launcher (~0.1 s), and falls through to the next launcher when nothing answers —
+   `fastcache-cc` never fails a build, it just stops caching, so being told is the point. Its
    cache entries are portable across checkout paths, so CI and local builds share hits.
 2. `sccache`
 3. `ccache`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,8 +136,9 @@ endif()
 
 # Set up the compiler-cache launcher before EndoThirdParties, so the sources CPM
 # and FetchContent pull in get cached too. CompileCache.cmake prefers fastcache-cc
-# when FASTCACHE_ADDR points at a daemon, else sccache, else ccache, and silently
-# no-ops when none is usable or USE_COMPILER_CACHE=OFF.
+# when a fastcached daemon answers (127.0.0.1:6674 unless FASTCACHE_ADDR says
+# otherwise), else sccache, else ccache, and silently no-ops when none is usable
+# or USE_COMPILER_CACHE=OFF.
 include(CompileCache)
 include(StaticLinking)
 include(EndoThirdParties)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1382,6 +1382,10 @@ and — as the flagship language consumer — a builtin HTTP server.
   - [x] CPM-built dependencies when static: yaml-cpp, libunicode, CURL with mbedTLS backend
   - [x] Guard `-rdynamic` when static (incompatible with `-static`)
   - [x] CI workflow for static build artifact (`static-build.yml`)
+- [x] Compiler-cache launcher selection (`USE_COMPILER_CACHE`, `cmake/CompileCache.cmake`)
+  - [x] Prefer `fastcache-cc`, then `sccache`, then `ccache`; respect a launcher set externally
+  - [x] Select `fastcache-cc` only when a fastcached daemon answers — `127.0.0.1:6674` unless `FASTCACHE_ADDR` says otherwise — verified at configure time by compiling one file through it
+  - [x] Disable precompiled headers and C++20 module scanning, and force MSVC `/Z7`, while a launcher is active
 - [x] Add Windows CMake preset (4 presets: cl-debug, cl-release, clangcl-debug, clangcl-release)
 - [x] Configure MSVC and Clang-cl support (`PedanticCompiler.cmake` handles both)
 - [x] Set up Windows CI pipeline (`build.yml` has `windows-clangcl` job)

--- a/cmake/CompileCache.cmake
+++ b/cmake/CompileCache.cmake
@@ -92,6 +92,15 @@ function(_fc_probe_fastcache_cc outVar reasonVar)
         set(_args -c "${_src}" -o "${_dir}/probe.o")
     endif()
 
+    # A probe that answers takes ~0.1s locally and little more over a LAN, so ten
+    # seconds is generous for a working daemon and a bounded wait for a broken
+    # one. The cap has to live here: FASTCACHE_TIMEOUT_MS bounds the launcher's
+    # send/recv but not its connect(), so an address that drops packets rather
+    # than refusing them — a firewall, a downed VPN, a host that is simply gone —
+    # stalls on the TCP connect timeout instead (measured: 2m30s), and every
+    # configure would pay it.
+    set(_timeoutSeconds 10)
+
     # NO_STATS keeps the probe out of `fastcache-cc --show-stats`, where it would
     # read as a build that never hits. TIMEOUT_MS bounds a daemon that accepts
     # the connection and then stalls; builds keep the launcher's own default.
@@ -103,11 +112,14 @@ function(_fc_probe_fastcache_cc outVar reasonVar)
                 "FASTCACHE_TIMEOUT_MS=2000"
                 "${FASTCACHE_CC}" "${CMAKE_CXX_COMPILER}" ${_args}
         WORKING_DIRECTORY "${_dir}"
+        TIMEOUT ${_timeoutSeconds}
         RESULT_VARIABLE _rc
         OUTPUT_QUIET
         ERROR_VARIABLE _err)
 
-    if(NOT _rc EQUAL 0)
+    if(_rc MATCHES "[Tt]imeout")
+        set(${reasonVar} "no answer within ${_timeoutSeconds}s" PARENT_SCOPE)
+    elseif(NOT _rc EQUAL 0)
         set(${reasonVar} "probe compile failed (${_rc})" PARENT_SCOPE)
     elseif(_err MATCHES "fastcache-cc: (HIT|MISS) key=")
         set(${outVar} TRUE PARENT_SCOPE)
@@ -131,6 +143,19 @@ endfunction()
 #   _fc_cache_<id>_detail    extra words for the status message (empty for none)
 # Supporting a fourth launcher is adding an id here plus its six variables.
 set(_fc_cache_candidates fastcache_cc sccache ccache)
+
+# Render "<label>[ <detail>]" for a row, so a launcher and where it points are
+# named the same way whether it won or was passed over. Diagnosing a daemon that
+# did not answer starts with knowing which address was tried.
+# @param id Row id from _fc_cache_candidates.
+# @param outVar Receives the rendered text.
+function(_fc_cache_describe id outVar)
+    set(_text "${_fc_cache_${id}_label}")
+    if(_fc_cache_${id}_detail)
+        string(APPEND _text " ${_fc_cache_${id}_detail}")
+    endif()
+    set(${outVar} "${_text}" PARENT_SCOPE)
+endfunction()
 
 set(_fc_cache_fastcache_cc_label "fastcache-cc")
 set(_fc_cache_fastcache_cc_program "${FASTCACHE_CC}")
@@ -165,7 +190,8 @@ if(USE_COMPILER_CACHE)
             if(NOT _fc_cache_usable)
                 # Remember why, so a fall-through to a slower launcher explains
                 # itself rather than looking like the faster one was never there.
-                list(APPEND _fc_cache_rejected "${_fc_cache_${_id}_label}: ${_fc_cache_why_not}")
+                _fc_cache_describe("${_id}" _fc_cache_desc)
+                list(APPEND _fc_cache_rejected "${_fc_cache_desc}: ${_fc_cache_why_not}")
                 continue()
             endif()
         endif()
@@ -181,7 +207,6 @@ foreach(_rejection IN LISTS _fc_cache_rejected)
 endforeach()
 
 if(_fc_cache_chosen)
-    set(_fc_cache_label "${_fc_cache_${_fc_cache_chosen}_label}")
     set(_fc_cache_program "${_fc_cache_${_fc_cache_chosen}_program}")
 
     # `cmake -E env NAME=VALUE ... <program>` is the only way to attach
@@ -196,12 +221,8 @@ if(_fc_cache_chosen)
         set(_fc_cache_launcher "${_fc_cache_program}")
     endif()
 
-    set(_fc_cache_detail "${_fc_cache_${_fc_cache_chosen}_detail}")
-    if(_fc_cache_detail)
-        string(PREPEND _fc_cache_detail " ")
-    endif()
-    message(STATUS "[cache] Enabling ${_fc_cache_label} (${_fc_cache_program})${_fc_cache_detail} "
-                   "for C/C++ compilation")
+    _fc_cache_describe("${_fc_cache_chosen}" _fc_cache_desc)
+    message(STATUS "[cache] Enabling ${_fc_cache_desc} (${_fc_cache_program}) for C/C++ compilation")
     set(CMAKE_C_COMPILER_LAUNCHER ${_fc_cache_launcher})
     set(CMAKE_CXX_COMPILER_LAUNCHER ${_fc_cache_launcher})
 

--- a/cmake/CompileCache.cmake
+++ b/cmake/CompileCache.cmake
@@ -7,9 +7,10 @@
 #      from different directories share cache hits. It must already be installed
 #      and on PATH. It is configured purely through the environment and caches
 #      nothing unless FASTCACHE_ADDR / FASTCACHE_SRCROOT / FASTCACHE_BUILDTREE
-#      are all set, so it is only selected once a daemon address is known; the
-#      two roots are injected here via `cmake -E env` because CMake already
-#      knows them.
+#      are all set; the address defaults to fastcached's own port,
+#      127.0.0.1:6674, and the two roots are injected here via `cmake -E env`,
+#      because CMake already knows them. Selecting it is conditional on a daemon
+#      actually answering there — see the probe below.
 #   2. sccache — the usual third-party launcher, used when fastcache-cc is
 #      unavailable or unconfigured. Supports shared (Redis/S3/...) caches.
 #   3. ccache — the classic local cache, used when neither of the above applies.
@@ -21,7 +22,7 @@
 # To disable entirely: -DUSE_COMPILER_CACHE=OFF.
 
 option(USE_COMPILER_CACHE
-       "Use a compiler-cache launcher when one is available (fastcache-cc when configured, else sccache, else ccache) [default: ON]"
+       "Use a compiler-cache launcher when one is available (fastcache-cc when a daemon answers, else sccache, else ccache) [default: ON]"
        ON)
 
 # Respect a launcher provided externally (command line, preset, toolchain).
@@ -30,51 +31,154 @@ option(USE_COMPILER_CACHE
 if(DEFINED CMAKE_CXX_COMPILER_LAUNCHER OR DEFINED CMAKE_C_COMPILER_LAUNCHER)
     message(STATUS "[cache] Compiler launcher already set externally "
                    "(C='${CMAKE_C_COMPILER_LAUNCHER}', CXX='${CMAKE_CXX_COMPILER_LAUNCHER}'); leaving it untouched.")
+    # A build tree configured before this module existed carries the launcher of
+    # the day in its cache, and would keep it forever without a word about why
+    # the selection below never runs.
+    if(DEFINED CACHE{CMAKE_CXX_COMPILER_LAUNCHER} OR DEFINED CACHE{CMAKE_C_COMPILER_LAUNCHER})
+        message(STATUS "[cache] That value comes from the CMake cache (a -D, a preset, or an older configure); "
+                       "reconfigure with --fresh to let this module choose instead.")
+    endif()
     return()
 endif()
 
-find_program(FASTCACHE_CC fastcache-cc DOC "fastcache-cc tool path; needs FASTCACHE_ADDR to be used")
+find_program(FASTCACHE_CC fastcache-cc DOC "fastcache-cc tool path; needs a fastcached daemon to be used")
 find_program(SCCACHE sccache DOC "sccache tool path")
 find_program(CCACHE ccache DOC "ccache tool path")
 
-set(FASTCACHE_ADDR "$ENV{FASTCACHE_ADDR}" CACHE STRING
-    "host:port of the fastcached compile-cache daemon (enables the fastcache-cc launcher)")
+# An address in the environment wins; otherwise fastcached's own port, which a
+# stock daemon (and the service the installers register) listens on. An empty
+# -DFASTCACHE_ADDR= opts out of fastcache-cc entirely.
+set(_fc_addr_initial "$ENV{FASTCACHE_ADDR}")
+if(_fc_addr_initial STREQUAL "")
+    set(_fc_addr_initial "127.0.0.1:6674")
+endif()
+set(FASTCACHE_ADDR "${_fc_addr_initial}" CACHE STRING
+    "host:port of the fastcached compile-cache daemon, 127.0.0.1:6674 by default (empty disables the fastcache-cc launcher)")
+
+# How fastcache-cc is configured, in one place: the probe below must test the
+# very environment the build will use, or it would vouch for a configuration
+# nothing else runs.
+set(_fc_fastcache_env
+    "FASTCACHE_ADDR=${FASTCACHE_ADDR}"
+    "FASTCACHE_SRCROOT=${CMAKE_SOURCE_DIR}"
+    "FASTCACHE_BUILDTREE=${CMAKE_BINARY_DIR}")
+
+# Ask fastcache-cc itself whether the cache works, by compiling one tiny
+# translation unit through it with FASTCACHE_VERBOSE=1 and requiring a reported
+# cache outcome. A launcher that cannot reach its daemon still compiles fine —
+# it just runs the real compiler — so nothing but an end-to-end exchange tells
+# "the cache works" apart from "every TU will silently pay a failed connect,
+# with precompiled headers disabled for nothing and ccache passed over".
+#
+# The match is positive (HIT/MISS only): should the launcher's diagnostics ever
+# be reworded, this reports unusable and the build falls back to the next
+# launcher, which is the harmless direction to be wrong in.
+#
+# @param outVar Set to TRUE when the cache served the probe, FALSE otherwise.
+# @param reasonVar Set to a short diagnostic when outVar is FALSE.
+function(_fc_probe_fastcache_cc outVar reasonVar)
+    set(${outVar} FALSE PARENT_SCOPE)
+
+    set(_dir "${CMAKE_BINARY_DIR}/CMakeFiles/fastcache-probe")
+    set(_src "${_dir}/probe.cpp")
+    # Both the file and its content are fixed, so the probe itself is a cache
+    # hit from the second configure onwards — which exercises FETCH rather than
+    # just STORE, and costs less than the first run.
+    file(WRITE "${_src}" "int fastcacheProbe() { return 0; }\n")
+
+    if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+        set(_args /nologo /c "${_src}" "/Fo${_dir}/probe.obj")
+    else()
+        set(_args -c "${_src}" -o "${_dir}/probe.o")
+    endif()
+
+    # NO_STATS keeps the probe out of `fastcache-cc --show-stats`, where it would
+    # read as a build that never hits. TIMEOUT_MS bounds a daemon that accepts
+    # the connection and then stalls; builds keep the launcher's own default.
+    execute_process(
+        COMMAND "${CMAKE_COMMAND}" -E env
+                ${_fc_fastcache_env}
+                "FASTCACHE_VERBOSE=1"
+                "FASTCACHE_NO_STATS=1"
+                "FASTCACHE_TIMEOUT_MS=2000"
+                "${FASTCACHE_CC}" "${CMAKE_CXX_COMPILER}" ${_args}
+        WORKING_DIRECTORY "${_dir}"
+        RESULT_VARIABLE _rc
+        OUTPUT_QUIET
+        ERROR_VARIABLE _err)
+
+    if(NOT _rc EQUAL 0)
+        set(${reasonVar} "probe compile failed (${_rc})" PARENT_SCOPE)
+    elseif(_err MATCHES "fastcache-cc: (HIT|MISS) key=")
+        set(${outVar} TRUE PARENT_SCOPE)
+        set(${reasonVar} "" PARENT_SCOPE)
+    elseif(_err MATCHES "fastcache-cc: cache unavailable \\(([^)]*)\\)")
+        set(${reasonVar} "${CMAKE_MATCH_1}" PARENT_SCOPE)
+    else()
+        set(${reasonVar} "no cache outcome reported" PARENT_SCOPE)
+    endif()
+endfunction()
 
 # Candidate table, most-preferred first. Each row <id> is described by:
 #   _fc_cache_<id>_label     human-readable name for the status message
 #   _fc_cache_<id>_program   the found program (empty when not installed)
 #   _fc_cache_<id>_requires  extra condition; the row is skipped when falsy
 #   _fc_cache_<id>_env       NAME=VALUE pairs to inject around the invocation
-# Supporting a fourth launcher is adding an id here plus its four variables.
+#   _fc_cache_<id>_check     function deciding usability at configure time
+#                            (empty when being installed is enough); called as
+#                            <fn>(<outVar> <reasonVar>) and only for a row that
+#                            already passed program and requires
+#   _fc_cache_<id>_detail    extra words for the status message (empty for none)
+# Supporting a fourth launcher is adding an id here plus its six variables.
 set(_fc_cache_candidates fastcache_cc sccache ccache)
 
 set(_fc_cache_fastcache_cc_label "fastcache-cc")
 set(_fc_cache_fastcache_cc_program "${FASTCACHE_CC}")
 set(_fc_cache_fastcache_cc_requires "${FASTCACHE_ADDR}")
-set(_fc_cache_fastcache_cc_env
-    "FASTCACHE_ADDR=${FASTCACHE_ADDR}"
-    "FASTCACHE_SRCROOT=${CMAKE_SOURCE_DIR}"
-    "FASTCACHE_BUILDTREE=${CMAKE_BINARY_DIR}")
+set(_fc_cache_fastcache_cc_env ${_fc_fastcache_env})
+set(_fc_cache_fastcache_cc_check _fc_probe_fastcache_cc)
+set(_fc_cache_fastcache_cc_detail "at ${FASTCACHE_ADDR}")
 
 set(_fc_cache_sccache_label "sccache")
 set(_fc_cache_sccache_program "${SCCACHE}")
 set(_fc_cache_sccache_requires ON)
 set(_fc_cache_sccache_env "")
+set(_fc_cache_sccache_check "")
+set(_fc_cache_sccache_detail "")
 
 set(_fc_cache_ccache_label "ccache")
 set(_fc_cache_ccache_program "${CCACHE}")
 set(_fc_cache_ccache_requires ON)
 set(_fc_cache_ccache_env "")
+set(_fc_cache_ccache_check "")
+set(_fc_cache_ccache_detail "")
 
 set(_fc_cache_chosen "")
+set(_fc_cache_rejected "")
 if(USE_COMPILER_CACHE)
     foreach(_id IN LISTS _fc_cache_candidates)
-        if(_fc_cache_${_id}_program AND _fc_cache_${_id}_requires)
-            set(_fc_cache_chosen "${_id}")
-            break()
+        if(NOT _fc_cache_${_id}_program OR NOT _fc_cache_${_id}_requires)
+            continue()
         endif()
+        if(_fc_cache_${_id}_check)
+            cmake_language(CALL ${_fc_cache_${_id}_check} _fc_cache_usable _fc_cache_why_not)
+            if(NOT _fc_cache_usable)
+                # Remember why, so a fall-through to a slower launcher explains
+                # itself rather than looking like the faster one was never there.
+                list(APPEND _fc_cache_rejected "${_fc_cache_${_id}_label}: ${_fc_cache_why_not}")
+                continue()
+            endif()
+        endif()
+        set(_fc_cache_chosen "${_id}")
+        break()
     endforeach()
 endif()
+
+# Say why a preferred launcher was passed over, whatever the outcome: falling
+# through in silence looks exactly like it never being installed.
+foreach(_rejection IN LISTS _fc_cache_rejected)
+    message(STATUS "[cache] Not using ${_rejection}")
+endforeach()
 
 if(_fc_cache_chosen)
     set(_fc_cache_label "${_fc_cache_${_fc_cache_chosen}_label}")
@@ -92,7 +196,12 @@ if(_fc_cache_chosen)
         set(_fc_cache_launcher "${_fc_cache_program}")
     endif()
 
-    message(STATUS "[cache] Enabling ${_fc_cache_label} (${_fc_cache_program}) for C/C++ compilation")
+    set(_fc_cache_detail "${_fc_cache_${_fc_cache_chosen}_detail}")
+    if(_fc_cache_detail)
+        string(PREPEND _fc_cache_detail " ")
+    endif()
+    message(STATUS "[cache] Enabling ${_fc_cache_label} (${_fc_cache_program})${_fc_cache_detail} "
+                   "for C/C++ compilation")
     set(CMAKE_C_COMPILER_LAUNCHER ${_fc_cache_launcher})
     set(CMAKE_CXX_COMPILER_LAUNCHER ${_fc_cache_launcher})
 
@@ -135,9 +244,9 @@ else()
 
     if(NOT USE_COMPILER_CACHE)
         message(STATUS "[cache] Compiler caching disabled by USE_COMPILER_CACHE=OFF")
-    elseif(FASTCACHE_CC AND NOT FASTCACHE_ADDR)
-        message(STATUS "[cache] fastcache-cc found but FASTCACHE_ADDR is unset, and neither sccache nor "
-                       "ccache was found; caching disabled (set FASTCACHE_ADDR=host:port to use fastcache-cc)")
+    elseif(_fc_cache_rejected)
+        message(STATUS "[cache] No other compiler-cache launcher found (sccache, ccache); caching disabled "
+                       "(start a daemon with `fastcached` to cache through fastcache-cc)")
     else()
         message(STATUS "[cache] No compiler-cache launcher found (fastcache-cc, sccache, ccache); caching disabled")
     endif()

--- a/cmake/CompileCache.cmake
+++ b/cmake/CompileCache.cmake
@@ -45,15 +45,41 @@ find_program(FASTCACHE_CC fastcache-cc DOC "fastcache-cc tool path; needs a fast
 find_program(SCCACHE sccache DOC "sccache tool path")
 find_program(CCACHE ccache DOC "ccache tool path")
 
-# An address in the environment wins; otherwise fastcached's own port, which a
-# stock daemon (and the service the installers register) listens on. An empty
-# -DFASTCACHE_ADDR= opts out of fastcache-cc entirely.
-set(_fc_addr_initial "$ENV{FASTCACHE_ADDR}")
-if(_fc_addr_initial STREQUAL "")
-    set(_fc_addr_initial "127.0.0.1:6674")
+# Where the daemon is: FASTCACHE_ADDR from the environment, else fastcached's
+# own port, which a stock daemon (and the service the installers register)
+# listens on. An empty -DFASTCACHE_ADDR= opts out of fastcache-cc entirely.
+set(_fc_addr_env "$ENV{FASTCACHE_ADDR}")
+if(_fc_addr_env STREQUAL "")
+    set(_fc_addr_wanted "127.0.0.1:6674")
+else()
+    set(_fc_addr_wanted "${_fc_addr_env}")
 endif()
-set(FASTCACHE_ADDR "${_fc_addr_initial}" CACHE STRING
-    "host:port of the fastcached compile-cache daemon, 127.0.0.1:6674 by default (empty disables the fastcache-cc launcher)")
+
+# Ordinary cache semantics would freeze the address at whatever the first
+# configure saw, so exporting FASTCACHE_ADDR to reach a remote daemon would do
+# nothing until the build tree was wiped. Track the environment across
+# configures instead and let a *change* to it retarget the cache entry — while
+# leaving a -D from this very run alone, which is the one instruction more
+# deliberate than the environment. The two are told apart by whether the cache
+# still holds what this module last put there, which is also why the retarget
+# needs a previous configure to compare against: on a first configure there is
+# no bookkeeping yet, both tests hold vacuously, and a -DFASTCACHE_ADDR= meant
+# to opt out would be overwritten by an address merely left in the environment.
+if(NOT DEFINED CACHE{FASTCACHE_ADDR})
+    set(FASTCACHE_ADDR "${_fc_addr_wanted}" CACHE STRING
+        "host:port of the fastcached compile-cache daemon, 127.0.0.1:6674 by default (empty disables the fastcache-cc launcher)")
+elseif(DEFINED CACHE{_FASTCACHE_ADDR_APPLIED}
+       AND NOT _fc_addr_env STREQUAL "${_FASTCACHE_ADDR_ENV_SEEN}"
+       AND FASTCACHE_ADDR STREQUAL "${_FASTCACHE_ADDR_APPLIED}")
+    message(STATUS "[cache] FASTCACHE_ADDR changed in the environment; retargeting to ${_fc_addr_wanted}")
+    set(FASTCACHE_ADDR "${_fc_addr_wanted}" CACHE STRING
+        "host:port of the fastcached compile-cache daemon, 127.0.0.1:6674 by default (empty disables the fastcache-cc launcher)"
+        FORCE)
+endif()
+set(_FASTCACHE_ADDR_ENV_SEEN "${_fc_addr_env}" CACHE INTERNAL
+    "FASTCACHE_ADDR as the environment last presented it, to notice a change on reconfigure")
+set(_FASTCACHE_ADDR_APPLIED "${FASTCACHE_ADDR}" CACHE INTERNAL
+    "the address this module last applied, to tell its own value from one set externally")
 
 # How fastcache-cc is configured, in one place: the probe below must test the
 # very environment the build will use, or it would vouch for a configuration

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,8 +47,6 @@ if(_need_fetch)
     endif()
 endif()
 
-add_subdirectory(coro)
-set_target_properties(coro PROPERTIES SYSTEM TRUE)
 add_subdirectory(CoreVM)
 add_subdirectory(crispy)
 set_target_properties(crispy-core PROPERTIES SYSTEM TRUE)
@@ -59,6 +57,12 @@ if(NOT EMSCRIPTEN)
     add_subdirectory(vtparser)
     set_target_properties(vtparser PROPERTIES SYSTEM TRUE)
     add_subdirectory(platform)
+    # Only net and tui link coro, and both are native-only. Configuring it under
+    # Emscripten would buy nothing and cost the build: coro fails configure
+    # outright when the standard library has no <stop_token>, which is exactly
+    # what Emscripten's libc++ reports.
+    add_subdirectory(coro)
+    set_target_properties(coro PROPERTIES SYSTEM TRUE)
     # net sits below tui now: it drives its own net::EventLoop reactor rather than
     # borrowing the TUI runtime's, so it depends on coro alone.
     add_subdirectory(net)


### PR DESCRIPTION
`cmake/CompileCache.cmake` gated its most-preferred launcher, `fastcache-cc`, on `FASTCACHE_ADDR` being present in the environment — so out of the box it was never selected and every build quietly fell through to `ccache`. fastcached 0.1.0 now listens on its own port, `127.0.0.1:6674`, and its installers register a service that starts it at login, so that address no longer needs saying.

The launcher is now picked whenever a daemon actually answers there. "Actually answers" is checked rather than assumed: `fastcache-cc` never fails a build — pointed at a dead daemon it just runs the real compiler — so an unchecked launcher would leave every translation unit paying a failed connect, with precompiled headers disabled for nothing and `ccache` passed over, and nothing on screen to say so.

## Changes

- `FASTCACHE_ADDR` defaults to `127.0.0.1:6674` when the environment names no address. A non-empty environment value still wins, `-DFASTCACHE_ADDR=host:port` retargets it, and an empty value opts out.
- Configure probes the cache end to end: one tiny translation unit compiled through the launcher with `FASTCACHE_VERBOSE=1`, accepted only on a reported `HIT`/`MISS`. Measured at ~0.1 s, and it runs every configure so that starting the daemon and reconfiguring is enough.
- `connect failed`, a wrong service on the port, a version mismatch, or a probe that cannot drive the compiler all fall through to `sccache`/`ccache`, with the reason printed instead of a silent downgrade. The match is positive, so a future rewording of the launcher's diagnostics costs a fallback rather than a broken build.
- The candidate table gains `_check` (runtime usability hook) and `_detail` (extra status words) columns, keeping the probe and the address in the status line data rows rather than branches; the environment `fastcache-cc` is configured with is defined once, so the probe cannot vouch for a configuration the build does not use.
- A launcher already sitting in the CMake cache now says so and points at `--fresh` — an existing build tree carrying an older `ccache` entry otherwise never reaches the selection logic, with no hint why.