### PR TITLE
Fix flaky test-endo-shell by making TestPTY output capture deterministic

### DIFF
--- a/src/shell/DirectoryConfig_test.cpp
+++ b/src/shell/DirectoryConfig_test.cpp
@@ -44,7 +44,7 @@ struct TestShell
 
     endo::Shell shell { pty, env };
 
-    std::string_view output() const noexcept { return pty.output(); }
+    std::string output() const { return pty.output(); }
 
     TestShell()
     {

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -46,7 +46,7 @@ struct TestShell
 
     endo::Shell shell { pty, env };
 
-    std::string_view output() const noexcept { return pty.output(); }
+    std::string output() const { return pty.output(); }
 
     TestShell()
     {

--- a/src/shell/TTY.cpp
+++ b/src/shell/TTY.cpp
@@ -11,6 +11,7 @@
 #if !defined(_WIN32)
     #include <sys/ioctl.h>
 
+    #include <fcntl.h>
     #include <poll.h>
     #include <unistd.h>
     #if defined(__APPLE__)
@@ -183,15 +184,26 @@ TestPTY::TestPTY(): _windowSize { .ws_row = 25, .ws_col = 80, .ws_xpixel = 0, .w
     if (openpty(&_ptyMaster, &_ptySlave, name, &_baseTermios, &_windowSize) == -1)
         throw std::runtime_error("openpty: " + std::string(strerror(errno)));
 
+    // The reader polls for readability before every read, so a read should never block --
+    // O_NONBLOCK makes that a property of the descriptor rather than an assumption about
+    // what poll() reported a moment earlier.
+    if (auto const flags = fcntl(_ptyMaster, F_GETFL, 0); flags != -1)
+        (void) fcntl(_ptyMaster, F_SETFL, flags | O_NONBLOCK);
+
     _updateThread = std::thread { std::bind(&TestPTY::outputUpdateLoop, this) };
 }
 
 TestPTY::~TestPTY()
 {
     _closed = true;
-    pthread_cancel(_updateThread.native_handle());
-    _updateThread.join();
+
+    // Closing the slave makes the reader's poll() report POLLHUP, so it leaves its loop on
+    // its own within one 50ms timeout at worst. pthread_cancel() was doing this before, but
+    // it can fire while the reader holds _outputMutex, leaving it locked forever, and
+    // unwinding a C++ thread through cancellation is not something the standard promises.
     safeClose(&_ptySlave);
+    if (_updateThread.joinable())
+        _updateThread.join();
     safeClose(&_ptyMaster);
 }
 
@@ -295,10 +307,39 @@ void TestPTY::setSize(uint16_t rows, uint16_t cols)
     ioctl(_ptySlave, TIOCSWINSZ, &_windowSize);
 }
 
-std::string_view TestPTY::output() const noexcept
+namespace
 {
-    // Give the output thread time to read remaining data from the PTY
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    /// @brief Reports whether @p fd has data ready to read, without consuming it.
+    [[nodiscard]] bool hasPendingInput(NativeHandle fd) noexcept
+    {
+        auto descriptor = pollfd { .fd = fd, .events = POLLIN, .revents = 0 };
+        return poll(&descriptor, 1, 0) > 0 && (descriptor.revents & POLLIN) != 0;
+    }
+} // namespace
+
+std::string TestPTY::output() const
+{
+    // The caller has just finished a command, so everything it produced is already in the
+    // PTY and nothing new can arrive. Every byte is therefore in exactly one of three
+    // states, and this waits out the first two:
+    //
+    //   pending in the PTY          -- hasPendingInput() sees it
+    //   taken but not yet appended  -- _transferring covers read()..append()
+    //   appended to _output         -- done
+    //
+    // Checking only the PTY would miss the middle state, which is what made captures come
+    // back empty. The deadline is a safety net for a wedged reader, not the mechanism.
+    auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+
+    while (hasPendingInput(_ptyMaster) || _transferring.load(std::memory_order_acquire))
+    {
+        if (!_readerRunning.load(std::memory_order_acquire) || _closed.load(std::memory_order_acquire)
+            || std::chrono::steady_clock::now() >= deadline)
+            break;
+
+        std::this_thread::yield();
+    }
+
     auto _ = std::scoped_lock { _outputMutex };
     return _output;
 }
@@ -307,26 +348,47 @@ void TestPTY::outputUpdateLoop()
 {
     while (!_closed)
     {
-        char buffer[1024] {};
-        ssize_t const writeResult = read(_ptyMaster, buffer, sizeof(buffer));
-        if (writeResult == 0)
+        // Wait for readability rather than blocking in read(), so that _transferring can be
+        // raised before the PTY is drained. The timeout only bounds how long shutdown waits.
+        auto descriptor = pollfd { .fd = _ptyMaster, .events = POLLIN, .revents = 0 };
+        int const ready = poll(&descriptor, 1, 50);
+
+        if (ready == 0)
+            continue; // Timed out; re-check _closed.
+        if (ready < 0)
         {
+            if (errno == EINTR)
+                continue;
             break;
         }
-        else if (writeResult > 0)
+        if ((descriptor.revents & POLLIN) == 0)
+            break; // POLLHUP/POLLERR: the slave is gone, so no more output can arrive.
+
+        // Raised before the read and cleared after the append, so the bytes are never
+        // invisible: while this is set, output() keeps waiting even though the PTY is empty.
+        _transferring.store(true, std::memory_order_release);
+
+        char buffer[1024] {};
+        ssize_t const readResult = read(_ptyMaster, buffer, sizeof(buffer));
+        if (readResult > 0)
         {
             auto _ = std::scoped_lock { _outputMutex };
-            _output.append(buffer, writeResult);
+            _output.append(buffer, static_cast<size_t>(readResult));
         }
-        else if (errno == EINTR || errno == EAGAIN)
-        {
+        _transferring.store(false, std::memory_order_release);
+
+        if (readResult > 0)
             continue;
-        }
-        else
-        {
-            throw std::runtime_error("read: " + std::string(strerror(errno)));
-        }
+        if (readResult < 0 && (errno == EINTR || errno == EAGAIN))
+            continue;
+
+        // EOF, or EIO once the slave closed -- ordinary shutdown. Throwing here would cross
+        // a thread boundary with nobody to catch it and abort the process, so just stop.
+        break;
     }
+
+    _transferring.store(false, std::memory_order_release);
+    _readerRunning.store(false, std::memory_order_release);
 }
 
 #endif // !_WIN32

--- a/src/shell/TTY.hpp
+++ b/src/shell/TTY.hpp
@@ -163,8 +163,14 @@ class WindowsTestPTY final: public TTY
     [[nodiscard]] bool isStderrTerminal() const noexcept override;
     void writeToStdin(std::string_view str) const override;
 
-    /// Returns the output that was written to the TTY.
-    [[nodiscard]] std::string_view output() const noexcept;
+    /// @brief Returns everything written to the TTY so far.
+    ///
+    /// Blocks until the capture thread has drained the pipe, so a caller that has just
+    /// finished a command observes all of its output.
+    ///
+    /// @return A copy of the captured output. By value deliberately: the capture thread
+    ///         keeps appending to the buffer, so a view into it would race with reallocation.
+    [[nodiscard]] std::string output() const;
 
     /// Sets the terminal size for testing resize behavior.
     void setSize(uint16_t rows, uint16_t cols);
@@ -185,6 +191,14 @@ class WindowsTestPTY final: public TTY
     std::thread _captureThread;
     mutable std::mutex _outputMutex;
     std::atomic<bool> _closed = false;
+
+    /// Set while the capture thread is between taking bytes out of the pipe and appending
+    /// them to _output. During that window the pipe looks empty although the capture is
+    /// incomplete, so output() must keep waiting rather than conclude it has everything.
+    std::atomic<bool> _transferring = false;
+
+    /// Cleared once the capture loop exits, so a wait cannot spin forever.
+    std::atomic<bool> _readerRunning = true;
 
     // Terminal size (fixed for tests)
     TerminalSize _terminalSize { .rows = 25, .cols = 80 };
@@ -251,8 +265,15 @@ class TestPTY final: public TTY
     [[nodiscard]] bool isStderrTerminal() const noexcept override;
     void writeToStdin(std::string_view str) const override;
 
-    // Returns the output that was written to the TTY.
-    [[nodiscard]] std::string_view output() const noexcept;
+    /// @brief Returns everything written to the TTY so far.
+    ///
+    /// Blocks until the reader thread has drained the PTY, so a caller that has just
+    /// finished a command observes all of its output rather than whatever happened to be
+    /// captured by then.
+    ///
+    /// @return A copy of the captured output. By value deliberately: the reader thread
+    ///         keeps appending to the buffer, so a view into it would race with reallocation.
+    [[nodiscard]] std::string output() const;
 
     /// Sets the terminal size for testing resize behavior.
     void setSize(uint16_t rows, uint16_t cols);
@@ -263,6 +284,15 @@ class TestPTY final: public TTY
     std::string _output;
     std::thread _updateThread;
     mutable std::mutex _outputMutex;
+
+    /// Set while the reader is between taking bytes out of the PTY and appending them to
+    /// _output. During that window the PTY looks empty although the capture is incomplete,
+    /// so output() must keep waiting rather than conclude it has everything.
+    std::atomic<bool> _transferring = false;
+
+    /// Cleared once the reader loop exits, so a wait cannot spin forever on a thread that
+    /// will never consume anything again.
+    std::atomic<bool> _readerRunning = true;
 
     NativeHandle _ptyMaster = InvalidHandle;
     NativeHandle _ptySlave = InvalidHandle;

--- a/src/shell/platform/WindowsTestPTY.cpp
+++ b/src/shell/platform/WindowsTestPTY.cpp
@@ -203,23 +203,26 @@ void WindowsTestPTY::setSize(uint16_t rows, uint16_t cols)
     _terminalSize = TerminalSize { .rows = rows, .cols = cols };
 }
 
-std::string_view WindowsTestPTY::output() const noexcept
+std::string WindowsTestPTY::output() const
 {
-    // Wait until the capture thread has drained all data from the pipe.
-    // After shell.execute() returns, all writes to the pipe are done.
-    // PeekNamedPipe reports 0 bytes once the capture thread has read everything.
+    // After shell.execute() returns, every write to the pipe is done, so "pipe empty and
+    // capture thread parked" is a stable end state. Both halves are needed: an empty pipe
+    // alone leaves the window where the thread has read the bytes but not yet appended
+    // them, which a fixed grace period could only paper over.
     auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-    while (std::chrono::steady_clock::now() < deadline)
+    while (_readerRunning.load(std::memory_order_acquire) && !_closed.load(std::memory_order_acquire))
     {
         DWORD bytesAvailable = 0;
         if (!PeekNamedPipe(_readOutputHandle, nullptr, 0, nullptr, &bytesAvailable, nullptr))
             break; // Pipe error (broken/closed)
-        if (bytesAvailable == 0)
-            break; // All data consumed by capture thread
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (bytesAvailable == 0 && !_transferring.load(std::memory_order_acquire))
+            break;
+
+        if (std::chrono::steady_clock::now() >= deadline)
+            break; // Safety net only; the condition above is what normally ends this loop.
+        std::this_thread::yield();
     }
-    // Small grace period for the capture thread to finish appending under mutex
-    std::this_thread::sleep_for(std::chrono::milliseconds(2));
     auto _ = std::scoped_lock { _outputMutex };
     return _output;
 }
@@ -246,16 +249,27 @@ void WindowsTestPTY::outputCaptureLoop()
             continue;
         }
 
+        // Raised before the read and cleared after the append, so the bytes are never
+        // invisible: while this is set, output() keeps waiting even though the pipe is empty.
+        _transferring.store(true, std::memory_order_release);
+
         DWORD bytesRead = 0;
         BOOL const success =
             ReadFile(_readOutputHandle, buffer, std::min(BufferSize, bytesAvailable), &bytesRead, nullptr);
 
+        if (success && bytesRead > 0)
+        {
+            auto _ = std::lock_guard<std::mutex> { _outputMutex };
+            _output.append(buffer, bytesRead);
+        }
+        _transferring.store(false, std::memory_order_release);
+
         if (!success || bytesRead == 0)
             break; // EOF or error
-
-        auto _ = std::lock_guard<std::mutex> { _outputMutex };
-        _output.append(buffer, bytesRead);
     }
+
+    _transferring.store(false, std::memory_order_release);
+    _readerRunning.store(false, std::memory_order_release);
 }
 
 #endif // _WIN32


### PR DESCRIPTION
`test-endo-shell` failed roughly one run in five on an unchanged tree, always on empty captured output, with a different test losing each time:

```
Shell_test.cpp:2139: FAILED:
  CHECK( escape(shell("echo hello | grep --color=never $PATTERN").output()) == escape("hello\n") )
with expansion:
  "" == "hello\n"
```

A fixed `--rng-seed` does not reproduce it, so this was never test-order dependence. `TestPTY::output()` waited for the reader thread by sleeping one millisecond and hoping:

```cpp
std::string_view TestPTY::output() const noexcept
{
    // Give the output thread time to read remaining data from the PTY
    std::this_thread::sleep_for(std::chrono::milliseconds(1));
    auto _ = std::scoped_lock { _outputMutex };
    return _output;
}
```

Under load the reader had not appended yet, so the test read an empty buffer.

## Approach

A sleep cannot be tightened into correctness, so this replaces it with an invariant. Every byte the shell wrote is in exactly one of three states:

1. still pending in the PTY,
2. taken by the reader but not yet appended,
3. already in `_output`.

`output()` now waits out the first two — `poll()` covers (1), and a `_transferring` flag raised *before* the read and cleared *after* the append covers the invisible (2). Once neither holds, the capture is provably complete rather than probably complete.

State (2) is what makes this subtle, and it is worth being explicit about: an earlier attempt at this fix flagged the reader as idle *before* `read()` and cleared it afterwards, which left the window between `read()` returning and the append uncovered. That is the same bug with a smaller window — and across a few thousand assertions it fired on *every* run rather than one in five. The flag has to bracket the whole transfer, not just the wait.

To allow the flag to be raised before the PTY is drained, the reader now waits in `poll()` rather than blocking in `read()`. Two consequences worth having fall out:

- The destructor no longer needs `pthread_cancel()`, which could fire while the reader held `_outputMutex` and leave it locked forever, and which unwinds a C++ thread in a way the standard does not promise. Closing the slave makes `poll()` report `POLLHUP` and the loop exits on its own.
- A read error no longer `throw`s from inside the reader thread, where nothing could catch it and the process would abort. It ends the capture instead.

`output()` also returns `std::string` instead of a `string_view` into a buffer the reader keeps appending to — the view outlived the lock meant to protect it, so a caller could observe a reallocation mid-read.

The same read-then-append window exists on Windows, where `output()` polled the pipe correctly but then slept 2 ms hoping the append had landed. It now uses the same flag.

## Result

Measured on one machine, unloaded, same binary and conditions:

| | failures |
|---|---|
| before | 3 in 20 runs, all empty output |
| after | 0 in 65 runs |

If the failure rate were unchanged, seeing zero in 65 runs has probability around 10⁻⁵.

## Noted but not addressed

Running several copies of `test-endo-shell` concurrently fails for an unrelated reason: a number of tests use hardcoded fixture paths such as `/tmp/endo_test_procsubst.txt` and `/tmp/endo_mv_test_dir`, so parallel instances clobber each other. `ctest` runs one instance, so this does not affect CI today, and it is out of scope here.

Fixes #178