### PR TITLE
Isolate the shell test suites from each other's fixtures

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -78,12 +78,21 @@ jobs:
           echo "WASM backend disabled at configure time; skipping src/CoreVM/wasm in clang-tidy"
           WASM_EXCLUDES=(':!src/CoreVM/wasm/*' ':!src/endo-language/CompileToWasm.hpp')
         fi
+        # CrashHandler_test.cpp is only compiled when the built-in crash dumper is
+        # disabled (src/shell/CMakeLists.txt), so with the default ON it is absent
+        # from the compile database and would be analyzed without its include paths.
+        CRASH_EXCLUDES=()
+        if ! grep -sq "shell/CrashHandler_test.cpp" build/compile_commands.json; then
+          echo "CrashHandler_test.cpp not in compile database; skipping it in clang-tidy"
+          CRASH_EXCLUDES=(':!src/shell/CrashHandler_test.cpp')
+        fi
         git diff -U0 origin/${{ github.base_ref }}...HEAD \
             -- 'src/*.cpp' 'src/*.hpp' 'src/*.h' \
             ':!src/crispy/*' ':!src/vtparser/*' ':!src/coro/*' ':!src/net/*' \
             ':!src/shell/platform/Windows*' \
             ':!src/endo-language/wasm_bridge.cpp' \
             "${WASM_EXCLUDES[@]}" \
+            "${CRASH_EXCLUDES[@]}" \
           | python3 "$CLANG_TIDY_DIFF" \
               -p1 \
               -path build \

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -272,6 +272,9 @@
             "configurePreset": "clang-debug",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -279,6 +282,9 @@
             "configurePreset": "clang-release",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -286,6 +292,9 @@
             "configurePreset": "clang-release-native",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -293,6 +302,9 @@
             "configurePreset": "clang-release-static",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -300,6 +312,9 @@
             "configurePreset": "clang-coverage",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -307,6 +322,9 @@
             "configurePreset": "clang-tsan",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -314,6 +332,9 @@
             "configurePreset": "gcc-debug",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -321,6 +342,9 @@
             "configurePreset": "clang-pgo-instrument",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -328,6 +352,9 @@
             "configurePreset": "clang-pgo-optimize",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -335,6 +362,9 @@
             "configurePreset": "cl-debug",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -342,6 +372,9 @@
             "configurePreset": "cl-release",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -349,6 +382,9 @@
             "configurePreset": "clangcl-debug",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         },
         {
@@ -356,6 +392,9 @@
             "configurePreset": "clangcl-release",
             "output": {
                 "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 4
             }
         }
     ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,8 +24,16 @@
             "condition": {
                 "type": "anyOf",
                 "conditions": [
-                    { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux" },
-                    { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Darwin" }
+                    {
+                        "type": "equals",
+                        "lhs": "${hostSystemName}",
+                        "rhs": "Linux"
+                    },
+                    {
+                        "type": "equals",
+                        "lhs": "${hostSystemName}",
+                        "rhs": "Darwin"
+                    }
                 ]
             }
         },
@@ -268,134 +276,79 @@
     ],
     "testPresets": [
         {
-            "name": "clang-debug",
-            "configurePreset": "clang-debug",
+            "name": "default-test",
+            "hidden": true,
             "output": {
                 "outputOnFailure": true
             },
             "execution": {
                 "jobs": 4
             }
+        },
+        {
+            "name": "clang-debug",
+            "configurePreset": "clang-debug",
+            "inherits": "default-test"
         },
         {
             "name": "clang-release",
             "configurePreset": "clang-release",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         },
         {
             "name": "clang-release-native",
             "configurePreset": "clang-release-native",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         },
         {
             "name": "clang-release-static",
             "configurePreset": "clang-release-static",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         },
         {
             "name": "clang-coverage",
             "configurePreset": "clang-coverage",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         },
         {
             "name": "clang-tsan",
             "configurePreset": "clang-tsan",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         },
         {
             "name": "gcc-debug",
             "configurePreset": "gcc-debug",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         },
         {
             "name": "clang-pgo-instrument",
             "configurePreset": "clang-pgo-instrument",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         },
         {
             "name": "clang-pgo-optimize",
             "configurePreset": "clang-pgo-optimize",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         },
         {
             "name": "cl-debug",
             "configurePreset": "cl-debug",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         },
         {
             "name": "cl-release",
             "configurePreset": "cl-release",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         },
         {
             "name": "clangcl-debug",
             "configurePreset": "clangcl-debug",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         },
         {
             "name": "clangcl-release",
             "configurePreset": "clangcl-release",
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "jobs": 4
-            }
+            "inherits": "default-test"
         }
     ],
     "packagePresets": [
@@ -423,7 +376,9 @@
             "name": "clang-deb",
             "configurePreset": "clang-deb",
             "displayName": "Debian Package (.deb + .ddeb)",
-            "generators": ["DEB"]
+            "generators": [
+                "DEB"
+            ]
         }
     ]
 }

--- a/scripts/check-test-isolation.py
+++ b/scripts/check-test-isolation.py
@@ -21,8 +21,10 @@ from pathlib import Path
 SEARCH_ROOTS = ["src/shell"]
 
 # temp_directory_path() joined with a literal, or a hardcoded /tmp path.
+TEMP_DIR_CALL = re.compile(r"temp_directory_path\s*\(\s*\)")
+
 PATTERNS = [
-    (re.compile(r"temp_directory_path\s*\(\s*\)"), "temp_directory_path()"),
+    (TEMP_DIR_CALL, "temp_directory_path()"),
     (re.compile(r"/tmp/"), "a hardcoded /tmp path"),
 ]
 
@@ -53,7 +55,12 @@ def main() -> int:
     for search_root in SEARCH_ROOTS:
         for path in sorted((root / search_root).rglob("*_test.cpp")):
             for number, line in enumerate(path.read_text().splitlines(), start=1):
-                if ALLOW.search(line):
+                # The allowance is matched against the whole line, so a broad alternative
+                # could otherwise exempt a genuine violation sharing that line.
+                # temp_directory_path() is always a real filesystem call and never a literal
+                # value, so nothing exempts it -- which is what keeps
+                # `dirs.push_back(fs::temp_directory_path() / "x")` caught.
+                if ALLOW.search(line) and not TEMP_DIR_CALL.search(line):
                     continue
                 for pattern, what in PATTERNS:
                     if pattern.search(line):

--- a/scripts/check-test-isolation.py
+++ b/scripts/check-test-isolation.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Fail if a test builds fixtures at a fixed filesystem path.
+
+`std::filesystem::temp_directory_path() / "endo_cp_test"` resolves to the same directory for
+every process on the machine, so two runs of one test binary -- `ctest -j`, a developer
+alongside CI, a sanitizer build alongside a normal one -- share it. Several tests also wipe
+the directory before creating it, which makes a collision destructive rather than flaky.
+
+Use an injected `InMemoryFileSystem` where the code under test accepts one, and
+`endo::testing::ScopedTempDir` where a real filesystem is unavoidable.
+
+Scoped to the directories already converted; widen SEARCH_ROOTS as others follow.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SEARCH_ROOTS = ["src/shell"]
+
+# temp_directory_path() joined with a literal, or a hardcoded /tmp path.
+PATTERNS = [
+    (re.compile(r"temp_directory_path\s*\(\s*\)"), "temp_directory_path()"),
+    (re.compile(r"/tmp/"), "a hardcoded /tmp path"),
+]
+
+# Paths used purely as string *values* passed to pure functions never touch disk.
+#
+# Every alternative here is deliberately anchored to the call or field it exempts. A bare
+# identifier such as `argv` or `push_back` would exempt any line that merely happens to
+# mention it -- including `dirs.push_back(fs::temp_directory_path() / "endo_x")`, exactly
+# the defect this lint exists to catch.
+ALLOW = re.compile(
+    # Pure functions taking a path as a value.
+    r"canonicalizeForHistory\(|expandForLookup\(|addValidPath\(|renderSegment\("
+    r"|makeGitContext\("
+    # Fixture/context struct fields and environment lookups asserted on.
+    r"|\.cwd\s*=|get\(\"PWD\"\)|get\(\"OLDPWD\"\)|\.path\s*=\s*\"|\.target\s*=\s*\""
+    r"|\.cellArea\b"
+    # Literal argument vectors handed to argument parsers.
+    r"|std::vector<std::string>\s*\{|argv\.push_back\(\"|CHECK\(paths\["
+    # Rendered URIs and OSC 8 escape sequences.
+    r"|file://|\\033\]8"
+)
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    findings: list[str] = []
+
+    for search_root in SEARCH_ROOTS:
+        for path in sorted((root / search_root).rglob("*_test.cpp")):
+            for number, line in enumerate(path.read_text().splitlines(), start=1):
+                if ALLOW.search(line):
+                    continue
+                for pattern, what in PATTERNS:
+                    if pattern.search(line):
+                        rel = path.relative_to(root)
+                        findings.append(f"{rel}:{number}: {what}\n    {line.strip()}")
+                        break
+
+    if not findings:
+        print(f"test isolation: no fixed fixture paths under {', '.join(SEARCH_ROOTS)}")
+        return 0
+
+    print("Tests must not build fixtures at a fixed filesystem path.\n")
+    print("Use an injected InMemoryFileSystem, or endo::testing::ScopedTempDir when a real")
+    print("filesystem is unavoidable (src/testing/ScopedTempDir.hpp).\n")
+    for finding in findings:
+        print(finding)
+    print(f"\n{len(findings)} finding(s).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -113,6 +113,7 @@ if(ENDO_TESTING)
         Clock_test.cpp
         SystemPipe_test.cpp
         FileSystem_test.cpp
+        ../testing/ScopedTempDir_test.cpp
         Generator_test.cpp
         InterruptThrottle_test.cpp
         PlatformError_test.cpp

--- a/src/platform/FileSystem.hpp
+++ b/src/platform/FileSystem.hpp
@@ -55,10 +55,32 @@ class FileSystem
                                                                      std::string_view content) const = 0;
     [[nodiscard]] virtual std::expected<void, std::string> appendFile(std::filesystem::path const& path,
                                                                       std::string_view content) const = 0;
-    [[nodiscard]] virtual std::unique_ptr<std::istream> openRead(std::filesystem::path const& path) const = 0;
-    [[nodiscard]] virtual std::unique_ptr<std::ostream> openWrite(std::filesystem::path const& path,
-                                                                  bool append = false) const = 0;
-    [[nodiscard]] virtual std::unique_ptr<std::iostream> openReadWrite(
+    /// @brief Opens a file for reading.
+    ///
+    /// The error is the reason alone -- "No such file or directory", "Permission denied",
+    /// "Is a directory" -- so a caller prefixes it with its own command name and the path
+    /// rather than reformatting it. Without this a caller can only observe *that* the open
+    /// failed, and reporting an unreadable file as a missing one is a real diagnosis error.
+    ///
+    /// A directory is rejected here rather than left to the first read: opening one succeeds
+    /// on POSIX and would otherwise surface as an empty file.
+    ///
+    /// @param path The file to open.
+    /// @return The stream, or why it could not be opened.
+    [[nodiscard]] virtual std::expected<std::unique_ptr<std::istream>, std::string> openRead(
+        std::filesystem::path const& path) const = 0;
+
+    /// @brief Opens a file for writing, creating it if absent.
+    /// @param path The file to open.
+    /// @param append Append to the existing content rather than truncating it.
+    /// @return The stream, or why it could not be opened. See openRead() on the error's form.
+    [[nodiscard]] virtual std::expected<std::unique_ptr<std::ostream>, std::string> openWrite(
+        std::filesystem::path const& path, bool append = false) const = 0;
+
+    /// @brief Opens a file for reading and writing.
+    /// @param path The file to open.
+    /// @return The stream, or why it could not be opened. See openRead() on the error's form.
+    [[nodiscard]] virtual std::expected<std::unique_ptr<std::iostream>, std::string> openReadWrite(
         std::filesystem::path const& path) const = 0;
 
     // Directory ops

--- a/src/platform/FileSystem_test.cpp
+++ b/src/platform/FileSystem_test.cpp
@@ -5,6 +5,7 @@
 #include <cerrno>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <string>
 #include <system_error>
 #include <vector>
@@ -149,7 +150,7 @@ TEST_CASE("isExecutableFile agrees with the real filesystem on the execute bit",
                 .has_value());
     CHECK(fs.isExecutableFile(*path));
 
-    CHECK(fs.remove(*path).has_value());
+    // No removal here: that is the guard's job, exactly as its comment says.
 }
 #endif
 
@@ -217,4 +218,34 @@ TEST_CASE("openRead reports the operating system's own reason", "[FileSystem]")
     auto const missing = fs.openRead(dir / "absent.txt");
     REQUIRE_FALSE(missing.has_value());
     CHECK(missing.error() == std::error_code(ENOENT, std::generic_category()).message());
+}
+
+TEST_CASE("the in-memory model classifies a symlink by its target", "[FileSystem]")
+{
+    // std::filesystem follows symlinks for is_regular_file()/is_directory() and only reports
+    // the link itself through is_symlink(); the model has to agree or a consumer written
+    // against the real filesystem behaves differently under injection.
+    auto fs = InMemoryFileSystem {};
+    fs.addFile("/root/target.txt", "content");
+    fs.addDirectory("/root/dir");
+    fs.addSymlink("/root/to-file", "/root/target.txt");
+    fs.addSymlink("/root/to-dir", "/root/dir");
+    fs.addSymlink("/root/dangling", "/root/absent");
+
+    CHECK(fs.isRegularFile("/root/to-file"));
+    CHECK(fs.isDirectory("/root/to-dir"));
+    CHECK_FALSE(fs.isRegularFile("/root/dangling"));
+
+    // is_symlink() does not follow: the link is still a link.
+    CHECK(fs.isSymlink("/root/to-file"));
+    CHECK_FALSE(fs.isSymlink("/root/target.txt"));
+
+    auto const opened = fs.openRead("/root/to-file");
+    REQUIRE(opened.has_value());
+    CHECK(std::string(std::istreambuf_iterator<char>(**opened), {}) == "content");
+
+    // A cycle terminates rather than hanging.
+    fs.addSymlink("/root/loop-a", "/root/loop-b");
+    fs.addSymlink("/root/loop-b", "/root/loop-a");
+    CHECK_FALSE(fs.isRegularFile("/root/loop-a"));
 }

--- a/src/platform/FileSystem_test.cpp
+++ b/src/platform/FileSystem_test.cpp
@@ -2,10 +2,12 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <filesystem>
 #include <string>
 #include <system_error>
 #include <vector>
 
+#include <platform/NativeFileSystem.hpp>
 #include <platform/testing/InMemoryFileSystem.hpp>
 
 using endo::platform::FileSystem;
@@ -113,6 +115,40 @@ TEST_CASE("isExecutableFile rejects a regular file without an execute bit", "[Fi
 
     CHECK_FALSE(fs.isExecutableFile("/usr/bin/data"));
 }
+
+#if !defined(_WIN32)
+TEST_CASE("isExecutableFile agrees with the real filesystem on the execute bit", "[FileSystem]")
+{
+    // The tests above pin InMemoryFileSystem's behaviour, which on its own only proves the
+    // model is self-consistent. This one anchors it to the real thing: shell PATH resolution
+    // (CommandResolver) is tested entirely against the model, so if the two ever disagree
+    // about the execute bit, every one of those tests would agree with each other and be
+    // wrong together.
+    auto const& fs = endo::platform::NativeFileSystem::instance();
+
+    auto const path = fs.createTempFile("endo_execbit_test");
+    REQUIRE(path.has_value());
+
+    // A failing REQUIRE below throws out of the test case, so removal cannot be a trailing
+    // statement -- it would leave the file behind in the system temp directory.
+    struct Remover
+    {
+        FileSystem const& fs;
+        std::filesystem::path path;
+
+        ~Remover() { [[maybe_unused]] auto const removed = fs.remove(path); }
+    } const remover { .fs = fs, .path = *path };
+
+    REQUIRE(fs.setPermissions(*path, std::filesystem::perms::owner_read).has_value());
+    CHECK_FALSE(fs.isExecutableFile(*path));
+
+    REQUIRE(fs.setPermissions(*path, std::filesystem::perms::owner_read | std::filesystem::perms::owner_exec)
+                .has_value());
+    CHECK(fs.isExecutableFile(*path));
+
+    CHECK(fs.remove(*path).has_value());
+}
+#endif
 
 TEST_CASE("isExecutableFile rejects directories and missing paths", "[FileSystem]")
 {

--- a/src/platform/FileSystem_test.cpp
+++ b/src/platform/FileSystem_test.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <fstream>
 #include <string>
 #include <system_error>
 #include <vector>

--- a/src/platform/FileSystem_test.cpp
+++ b/src/platform/FileSystem_test.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <cerrno>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -10,6 +11,7 @@
 
 #include <platform/NativeFileSystem.hpp>
 #include <platform/testing/InMemoryFileSystem.hpp>
+#include <testing/ScopedTempDir.hpp>
 
 using endo::platform::FileSystem;
 using endo::platform::testing::InMemoryFileSystem;
@@ -169,4 +171,50 @@ TEST_CASE("isExecutableFile follows the execute bit of a symlink entry", "[FileS
                 .has_value());
 
     CHECK(fs.isExecutableFile("/usr/bin/link"));
+}
+
+// ============================================================================
+// openRead error reporting
+// ============================================================================
+
+TEST_CASE("openRead names the reason it failed", "[FileSystem]")
+{
+    // Every backend distinguishes the same three cases, so a caller can report what the
+    // filesystem said instead of inferring it from a follow-up probe.
+    auto fs = InMemoryFileSystem {};
+    fs.addDirectory("/root/dir");
+    fs.addFile("/root/readable.txt", "content");
+    fs.addFile("/root/locked.txt", "secret");
+    fs.denyAccess("/root/locked.txt");
+
+    CHECK(fs.openRead("/root/readable.txt").has_value());
+
+    auto const missing = fs.openRead("/root/absent.txt");
+    REQUIRE_FALSE(missing.has_value());
+    CHECK(missing.error() == "No such file or directory");
+
+    auto const directory = fs.openRead("/root/dir");
+    REQUIRE_FALSE(directory.has_value());
+    CHECK(directory.error() == "Is a directory");
+
+    auto const denied = fs.openRead("/root/locked.txt");
+    REQUIRE_FALSE(denied.has_value());
+    CHECK(denied.error() == "Permission denied");
+}
+
+TEST_CASE("openRead reports the operating system's own reason", "[FileSystem]")
+{
+    auto const& fs = endo::platform::NativeFileSystem::instance();
+    auto const dir = endo::testing::ScopedTempDir { "endo_openread" };
+
+    // A directory opens successfully on POSIX and fails only on the first read, so it has to
+    // be refused explicitly rather than surfacing as an empty file.
+    auto const directory = fs.openRead(dir.path());
+    REQUIRE_FALSE(directory.has_value());
+    CHECK(directory.error() == "Is a directory");
+
+    // errno's text, not a guess: distinct from the directory case above and from success.
+    auto const missing = fs.openRead(dir / "absent.txt");
+    REQUIRE_FALSE(missing.has_value());
+    CHECK(missing.error() == std::error_code(ENOENT, std::generic_category()).message());
 }

--- a/src/platform/NativeFileSystem.cpp
+++ b/src/platform/NativeFileSystem.cpp
@@ -281,6 +281,31 @@ std::expected<void, std::string> NativeFileSystem::rename(fs::path const& from, 
         std::format("Cannot rename '{}' to '{}': {}", from.string(), to.string(), ec.message()));
 }
 
+namespace
+{
+    /// @brief Describes one directory entry without ever throwing.
+    ///
+    /// The throwing status accessors escape as filesystem_error whenever an entry cannot be
+    /// stat'ed -- EACCES on a readable-but-not-searchable directory, or a filesystem that
+    /// reports DT_UNKNOWN -- which would abort enumerating an otherwise perfectly readable
+    /// directory. An entry whose type cannot be determined is reported as neither.
+    ///
+    /// @param entry The entry to describe.
+    /// @param depth Walk-root-relative depth; 0 for a flat listing.
+    /// @return The described entry.
+    [[nodiscard]] FileSystem::DirectoryEntry describeEntry(fs::directory_entry const& entry, int depth = 0)
+    {
+        std::error_code ec;
+        return FileSystem::DirectoryEntry {
+            .path = entry.path(),
+            .isDirectory = entry.is_directory(ec),
+            .isRegularFile = entry.is_regular_file(ec),
+            .isSymlink = entry.is_symlink(ec),
+            .depth = depth,
+        };
+    }
+} // namespace
+
 std::expected<std::vector<FileSystem::DirectoryEntry>, std::string> NativeFileSystem::listDirectory(
     fs::path const& path) const
 {
@@ -288,24 +313,11 @@ std::expected<std::vector<FileSystem::DirectoryEntry>, std::string> NativeFileSy
     auto entries = std::vector<DirectoryEntry> {};
     auto it = fs::directory_iterator(path, ec);
     auto const end = fs::directory_iterator {};
-    // C-style loop is intentional here, as in walkDirectoryRecursive(): a range-based for
-    // would advance through the throwing operator++, so a mid-walk readdir failure would
-    // escape this std::expected-returning function as a filesystem_error.
+    // Advanced through increment(ec) rather than a range-based for, whose operator++ throws:
+    // a mid-walk readdir failure would otherwise escape this std::expected-returning function
+    // as a filesystem_error.
     for (; !ec && it != end; it.increment(ec))
-    {
-        auto const& entry = *it;
-        // error_code overloads: the throwing ones escape as filesystem_error whenever an
-        // entry cannot be stat'ed (EACCES on a readable-but-not-searchable directory, or a
-        // filesystem that reports DT_UNKNOWN), which would abort listing an otherwise
-        // perfectly readable directory. An unknown entry is reported as neither.
-        std::error_code entryEc;
-        entries.push_back(DirectoryEntry {
-            .path = entry.path(),
-            .isDirectory = entry.is_directory(entryEc),
-            .isRegularFile = entry.is_regular_file(entryEc),
-            .isSymlink = entry.is_symlink(entryEc),
-        });
-    }
+        entries.push_back(describeEntry(*it));
     if (ec)
         return std::unexpected(std::format("Cannot list directory '{}': {}", path.string(), ec.message()));
     return entries;
@@ -323,25 +335,12 @@ Generator<FileSystem::DirectoryEntry> NativeFileSystem::walkDirectoryRecursive(
     std::error_code ec;
     auto it = fs::recursive_directory_iterator(path, fs::directory_options::skip_permission_denied, ec);
     auto const end = fs::recursive_directory_iterator {};
-    // C-style loop is intentional here: a range-based for would use the throwing operator++,
-    // whereas we must thread an error_code through the non-throwing increment(ec) overload.
+    // Advanced through increment(ec) rather than a range-based for, whose operator++ throws:
+    // the error must be threaded out rather than escaping the coroutine.
     for (; !ec && it != end; it.increment(ec))
-    {
-        auto const& entry = *it;
-        // error_code overloads, so an unstattable entry is reported as neither a directory
-        // nor a regular file instead of throwing filesystem_error out of the coroutine.
-        // `entryEc` is deliberately separate from `ec`, which drives the loop.
-        std::error_code entryEc;
-        co_yield DirectoryEntry {
-            .path = entry.path(),
-            .isDirectory = entry.is_directory(entryEc),
-            .isRegularFile = entry.is_regular_file(entryEc),
-            .isSymlink = entry.is_symlink(entryEc),
-            // recursive_directory_iterator::depth() is 0 for a direct child; +1 to match the
-            // walk-root-relative convention (direct child = depth 1) consumers expect.
-            .depth = it.depth() + 1,
-        };
-    }
+        // recursive_directory_iterator::depth() is 0 for a direct child; +1 to match the
+        // walk-root-relative convention (direct child = depth 1) consumers expect.
+        co_yield describeEntry(*it, it.depth() + 1);
     if (ec && outError != nullptr)
         *outError = ec;
 }

--- a/src/platform/NativeFileSystem.cpp
+++ b/src/platform/NativeFileSystem.cpp
@@ -286,8 +286,14 @@ std::expected<std::vector<FileSystem::DirectoryEntry>, std::string> NativeFileSy
 {
     std::error_code ec;
     auto entries = std::vector<DirectoryEntry> {};
-    for (auto const& entry: fs::directory_iterator(path, ec))
+    auto it = fs::directory_iterator(path, ec);
+    auto const end = fs::directory_iterator {};
+    // C-style loop is intentional here, as in walkDirectoryRecursive(): a range-based for
+    // would advance through the throwing operator++, so a mid-walk readdir failure would
+    // escape this std::expected-returning function as a filesystem_error.
+    for (; !ec && it != end; it.increment(ec))
     {
+        auto const& entry = *it;
         // error_code overloads: the throwing ones escape as filesystem_error whenever an
         // entry cannot be stat'ed (EACCES on a readable-but-not-searchable directory, or a
         // filesystem that reports DT_UNKNOWN), which would abort listing an otherwise

--- a/src/platform/NativeFileSystem.cpp
+++ b/src/platform/NativeFileSystem.cpp
@@ -288,11 +288,16 @@ std::expected<std::vector<FileSystem::DirectoryEntry>, std::string> NativeFileSy
     auto entries = std::vector<DirectoryEntry> {};
     for (auto const& entry: fs::directory_iterator(path, ec))
     {
+        // error_code overloads: the throwing ones escape as filesystem_error whenever an
+        // entry cannot be stat'ed (EACCES on a readable-but-not-searchable directory, or a
+        // filesystem that reports DT_UNKNOWN), which would abort listing an otherwise
+        // perfectly readable directory. An unknown entry is reported as neither.
+        std::error_code entryEc;
         entries.push_back(DirectoryEntry {
             .path = entry.path(),
-            .isDirectory = entry.is_directory(),
-            .isRegularFile = entry.is_regular_file(),
-            .isSymlink = entry.is_symlink(),
+            .isDirectory = entry.is_directory(entryEc),
+            .isRegularFile = entry.is_regular_file(entryEc),
+            .isSymlink = entry.is_symlink(entryEc),
         });
     }
     if (ec)
@@ -317,11 +322,15 @@ Generator<FileSystem::DirectoryEntry> NativeFileSystem::walkDirectoryRecursive(
     for (; !ec && it != end; it.increment(ec))
     {
         auto const& entry = *it;
+        // error_code overloads, so an unstattable entry is reported as neither a directory
+        // nor a regular file instead of throwing filesystem_error out of the coroutine.
+        // `entryEc` is deliberately separate from `ec`, which drives the loop.
+        std::error_code entryEc;
         co_yield DirectoryEntry {
             .path = entry.path(),
-            .isDirectory = entry.is_directory(),
-            .isRegularFile = entry.is_regular_file(),
-            .isSymlink = entry.is_symlink(),
+            .isDirectory = entry.is_directory(entryEc),
+            .isRegularFile = entry.is_regular_file(entryEc),
+            .isSymlink = entry.is_symlink(entryEc),
             // recursive_directory_iterator::depth() is 0 for a direct child; +1 to match the
             // walk-root-relative convention (direct child = depth 1) consumers expect.
             .depth = it.depth() + 1,

--- a/src/platform/NativeFileSystem.cpp
+++ b/src/platform/NativeFileSystem.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <optional>
 #include <ranges>
 #include <sstream>
 #include <string>
@@ -133,29 +134,78 @@ std::expected<void, std::string> NativeFileSystem::appendFile(fs::path const& pa
     return {};
 }
 
-std::unique_ptr<std::istream> NativeFileSystem::openRead(fs::path const& path) const
+namespace
 {
-    auto stream = std::make_unique<std::ifstream>(path, std::ios::binary);
-    if (!*stream)
-        return nullptr;
-    return stream;
+    /// @brief Explains a failed stream open in the operating system's own words.
+    ///
+    /// The stream classes report only *that* the open failed, so the reason comes from errno,
+    /// which the open() underlying every standard library this project targets sets. Callers
+    /// previously inferred the reason from a follow-up exists() probe, which both misreported
+    /// every cause other than the two it guessed between and raced with the open.
+    ///
+    /// @param errorNumber The value of errno immediately after the failed open.
+    /// @return The reason, or a generic message when errno says nothing useful.
+    [[nodiscard]] std::string describeOpenFailure(int errorNumber)
+    {
+        if (errorNumber == 0)
+            return "Cannot open file";
+        return std::error_code(errorNumber, std::generic_category()).message();
+    }
+
+    /// @brief Rejects a directory before it is opened as a file.
+    ///
+    /// Opening a directory succeeds on POSIX and fails only on the first read, which would
+    /// otherwise be indistinguishable from an empty file.
+    ///
+    /// @param path The path about to be opened.
+    /// @return The reason to refuse, or nullopt to proceed.
+    [[nodiscard]] std::optional<std::string> refuseDirectory(fs::path const& path)
+    {
+        std::error_code ec;
+        if (fs::is_directory(path, ec))
+            return "Is a directory";
+        return std::nullopt;
+    }
+
+    /// @brief Opens a stream, reporting why rather than merely that it failed.
+    ///
+    /// @tparam StreamT The concrete stream to construct.
+    /// @tparam BaseT   The interface type to hand back.
+    /// @param path The file to open.
+    /// @param mode The open mode.
+    /// @return The stream, or the reason it could not be opened.
+    template <typename StreamT, typename BaseT>
+    [[nodiscard]] std::expected<std::unique_ptr<BaseT>, std::string> openStream(fs::path const& path,
+                                                                                std::ios::openmode mode)
+    {
+        if (auto refusal = refuseDirectory(path))
+            return std::unexpected(std::move(*refusal));
+
+        errno = 0;
+        auto stream = std::make_unique<StreamT>(path, mode);
+        if (!*stream)
+            return std::unexpected(describeOpenFailure(errno));
+        return stream;
+    }
+} // namespace
+
+std::expected<std::unique_ptr<std::istream>, std::string> NativeFileSystem::openRead(
+    fs::path const& path) const
+{
+    return openStream<std::ifstream, std::istream>(path, std::ios::binary);
 }
 
-std::unique_ptr<std::ostream> NativeFileSystem::openWrite(fs::path const& path, bool append) const
+std::expected<std::unique_ptr<std::ostream>, std::string> NativeFileSystem::openWrite(fs::path const& path,
+                                                                                      bool append) const
 {
-    auto const mode = std::ios::binary | (append ? std::ios::app : std::ios::trunc);
-    auto stream = std::make_unique<std::ofstream>(path, mode);
-    if (!*stream)
-        return nullptr;
-    return stream;
+    return openStream<std::ofstream, std::ostream>(
+        path, std::ios::binary | (append ? std::ios::app : std::ios::trunc));
 }
 
-std::unique_ptr<std::iostream> NativeFileSystem::openReadWrite(fs::path const& path) const
+std::expected<std::unique_ptr<std::iostream>, std::string> NativeFileSystem::openReadWrite(
+    fs::path const& path) const
 {
-    auto stream = std::make_unique<std::fstream>(path, std::ios::binary | std::ios::in | std::ios::out);
-    if (!*stream)
-        return nullptr;
-    return stream;
+    return openStream<std::fstream, std::iostream>(path, std::ios::binary | std::ios::in | std::ios::out);
 }
 
 std::expected<void, std::string> NativeFileSystem::createDirectory(fs::path const& path) const

--- a/src/platform/NativeFileSystem.hpp
+++ b/src/platform/NativeFileSystem.hpp
@@ -26,10 +26,11 @@ class NativeFileSystem final: public FileSystem
                                                              std::string_view content) const override;
     [[nodiscard]] std::expected<void, std::string> appendFile(std::filesystem::path const& path,
                                                               std::string_view content) const override;
-    [[nodiscard]] std::unique_ptr<std::istream> openRead(std::filesystem::path const& path) const override;
-    [[nodiscard]] std::unique_ptr<std::ostream> openWrite(std::filesystem::path const& path,
-                                                          bool append = false) const override;
-    [[nodiscard]] std::unique_ptr<std::iostream> openReadWrite(
+    [[nodiscard]] std::expected<std::unique_ptr<std::istream>, std::string> openRead(
+        std::filesystem::path const& path) const override;
+    [[nodiscard]] std::expected<std::unique_ptr<std::ostream>, std::string> openWrite(
+        std::filesystem::path const& path, bool append = false) const override;
+    [[nodiscard]] std::expected<std::unique_ptr<std::iostream>, std::string> openReadWrite(
         std::filesystem::path const& path) const override;
 
     [[nodiscard]] std::expected<void, std::string> createDirectory(

--- a/src/platform/PathUtils.cpp
+++ b/src/platform/PathUtils.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+#include <algorithm>
 #include <string>
 
 #include <platform/PathUtils.hpp>
@@ -15,19 +16,24 @@
 namespace endo::platform
 {
 
+std::string stripTrailingSeparator(std::filesystem::path const& path)
+{
+    auto text = path.lexically_normal().generic_string();
+    // Never strip into the root itself: "/" stays "/" and, on Windows, "C:/" stays "C:/"
+    // (reducing it to "C:" would name the drive's current directory, not its root).
+    auto const rootLength = std::max<std::size_t>(
+        std::filesystem::path(text).root_path().generic_string().size(), std::size_t { 1 });
+    while (text.size() > rootLength && text.back() == '/')
+        text.pop_back();
+    return text;
+}
+
 bool isCaseOnlyRename(std::filesystem::path const& from, std::filesystem::path const& to)
 {
     // Reduce both paths to their canonical lexical spelling and drop any trailing
     // separator so that `foo/` and `foo` are treated identically.
-    auto const stripTrailingSeparator = [](std::filesystem::path const& p) {
-        auto text = p.lexically_normal().generic_string();
-        while (text.size() > 1 && text.back() == '/')
-            text.pop_back();
-        return std::filesystem::path(text);
-    };
-
-    auto const source = stripTrailingSeparator(from);
-    auto const dest = stripTrailingSeparator(to);
+    auto const source = std::filesystem::path(stripTrailingSeparator(from));
+    auto const dest = std::filesystem::path(stripTrailingSeparator(to));
 
     auto const sourceName = source.filename().generic_string();
     auto const destName = dest.filename().generic_string();

--- a/src/platform/PathUtils.hpp
+++ b/src/platform/PathUtils.hpp
@@ -143,6 +143,22 @@ inline constexpr bool FilesystemCaseInsensitive =
 /// @return The path with on-disk capitalization and forward slashes.
 [[nodiscard]] auto canonicalCasePath(std::filesystem::path const& p) -> std::string;
 
+/// @brief Reduces a path to its canonical lexical spelling without a trailing separator.
+///
+/// `lexically_normal()` keeps a trailing separator whenever the final component was `.`
+/// or `..`, so `foo/.` normalizes to `foo/` rather than `foo`. That distinction is never
+/// meaningful for identity — `foo/` and `foo` name the same entry — but it does break any
+/// comparison or map lookup keyed on the normalized spelling. This applies the
+/// normalization and drops the separator, leaving the root itself intact (`/` on POSIX,
+/// and `C:/` on Windows — `C:` would name the drive's current directory, not its root).
+///
+/// The result is spelled with forward slashes on every platform. The check is purely
+/// lexical and touches no filesystem.
+///
+/// @param path The path to reduce.
+/// @return The normalized path without a trailing separator.
+[[nodiscard]] std::string stripTrailingSeparator(std::filesystem::path const& path);
+
 /// @brief Tests whether two paths name the same directory entry differing only in
 /// the lettercase of their final component.
 ///

--- a/src/platform/Wakeup_test.cpp
+++ b/src/platform/Wakeup_test.cpp
@@ -78,8 +78,10 @@ TEST_CASE("Wakeup.cross_thread_signal", "[platform][wakeup]")
 
     auto worker = std::jthread([&](const std::stop_token&) {
         std::this_thread::sleep_for(std::chrono::milliseconds(20));
-        wakeup.signal();
+        // Store before signalling: poll() returns as soon as signal() lands, so the reader
+        // can observe the wakeup and check the flag before a later store became visible.
         signaled.store(true);
+        wakeup.signal();
     });
 
 #if !defined(_WIN32)

--- a/src/platform/WindowsPlatform_test.cpp
+++ b/src/platform/WindowsPlatform_test.cpp
@@ -273,6 +273,39 @@ TEST_CASE("platformRead.returns_zero_on_closed_pipe_eof", "[platform]")
 }
 
 // ============================================================================
+// stripTrailingSeparator
+// ============================================================================
+
+TEST_CASE("stripTrailingSeparator.drops_the_artifact_left_by_lexically_normal", "[platform]")
+{
+    // A final "." or ".." makes lexically_normal() keep a trailing separator, which would
+    // otherwise not compare equal to the same path spelled without one.
+    CHECK(stripTrailingSeparator("/test/.") == "/test");
+    CHECK(stripTrailingSeparator("/test/sub/..") == "/test");
+    CHECK(stripTrailingSeparator("/test/") == "/test");
+    CHECK(stripTrailingSeparator("/test") == "/test");
+    // Relative paths keep their spelling, minus the separator.
+    CHECK(stripTrailingSeparator("foo/") == "foo");
+    CHECK(stripTrailingSeparator("foo/.") == "foo");
+}
+
+TEST_CASE("stripTrailingSeparator.never_strips_into_the_root", "[platform]")
+{
+    // The root is the one path whose trailing separator carries meaning: "/" is the root
+    // directory, whereas "" is no path at all.
+    CHECK(stripTrailingSeparator("/") == "/");
+    CHECK(stripTrailingSeparator("/.") == "/");
+
+#if defined(_WIN32)
+    // Likewise a drive root: "C:/" is the root of drive C, while "C:" names that drive's
+    // current directory -- a different location entirely.
+    CHECK(stripTrailingSeparator("C:/") == "C:/");
+    CHECK(stripTrailingSeparator("C:/.") == "C:/");
+    CHECK(stripTrailingSeparator("C:/test/") == "C:/test");
+#endif
+}
+
+// ============================================================================
 // isCaseOnlyRename
 // ============================================================================
 

--- a/src/platform/testing/InMemoryFileSystem.cpp
+++ b/src/platform/testing/InMemoryFileSystem.cpp
@@ -243,34 +243,45 @@ std::expected<void, std::string> InMemoryFileSystem::appendFile(std::filesystem:
     return {};
 }
 
-std::unique_ptr<std::istream> InMemoryFileSystem::openRead(std::filesystem::path const& path) const
+std::optional<std::string> InMemoryFileSystem::refuseOpen(std::string const& key) const
+{
+    if (_deniedPaths.contains(key))
+        return "Permission denied";
+    if (_directories.contains(key))
+        return "Is a directory";
+    return std::nullopt;
+}
+
+std::expected<std::unique_ptr<std::istream>, std::string> InMemoryFileSystem::openRead(
+    std::filesystem::path const& path) const
 {
     auto const key = normalize(path);
-    if (_deniedPaths.contains(key))
-        return nullptr;
+    if (auto refusal = refuseOpen(key))
+        return std::unexpected(std::move(*refusal));
     auto const it = _files.find(key);
     if (it == _files.end())
-        return nullptr;
+        return std::unexpected("No such file or directory");
     return std::make_unique<MemoryIStream>(it->second);
 }
 
-std::unique_ptr<std::ostream> InMemoryFileSystem::openWrite(std::filesystem::path const& path,
-                                                            bool append) const
+std::expected<std::unique_ptr<std::ostream>, std::string> InMemoryFileSystem::openWrite(
+    std::filesystem::path const& path, bool append) const
 {
     auto const key = normalize(path);
-    if (_deniedPaths.contains(key))
-        return nullptr;
+    if (auto refusal = refuseOpen(key))
+        return std::unexpected(std::move(*refusal));
     ensureParentDirectories(path);
     if (!_files.contains(key))
         _files[key] = {};
     return std::make_unique<MemoryOStream>(&_files[key], append);
 }
 
-std::unique_ptr<std::iostream> InMemoryFileSystem::openReadWrite(std::filesystem::path const& path) const
+std::expected<std::unique_ptr<std::iostream>, std::string> InMemoryFileSystem::openReadWrite(
+    std::filesystem::path const& path) const
 {
     auto const key = normalize(path);
-    if (_deniedPaths.contains(key))
-        return nullptr;
+    if (auto refusal = refuseOpen(key))
+        return std::unexpected(std::move(*refusal));
     ensureParentDirectories(path);
     if (!_files.contains(key))
         _files[key] = {};

--- a/src/platform/testing/InMemoryFileSystem.cpp
+++ b/src/platform/testing/InMemoryFileSystem.cpp
@@ -165,6 +165,21 @@ void InMemoryFileSystem::ensureParentDirectories(std::filesystem::path const& pa
         _directories.insert(p.string());
 }
 
+std::string InMemoryFileSystem::resolveSymlinks(std::string key) const
+{
+    // Bounded so a cycle terminates; the real filesystem answers ELOOP, and every caller here
+    // treats "not a file and not a directory" the same way it would treat that.
+    constexpr auto MaxHops = 32;
+    for (auto hop = 0; hop < MaxHops; ++hop)
+    {
+        auto const it = _symlinks.find(key);
+        if (it == _symlinks.end())
+            return key;
+        key = normalize(it->second);
+    }
+    return key;
+}
+
 bool InMemoryFileSystem::exists(std::filesystem::path const& path) const
 {
     auto const key = normalize(path);
@@ -173,12 +188,12 @@ bool InMemoryFileSystem::exists(std::filesystem::path const& path) const
 
 bool InMemoryFileSystem::isDirectory(std::filesystem::path const& path) const
 {
-    return _directories.contains(normalize(path));
+    return _directories.contains(resolveSymlinks(normalize(path)));
 }
 
 bool InMemoryFileSystem::isRegularFile(std::filesystem::path const& path) const
 {
-    return _files.contains(normalize(path));
+    return _files.contains(resolveSymlinks(normalize(path)));
 }
 
 bool InMemoryFileSystem::isSymlink(std::filesystem::path const& path) const
@@ -255,7 +270,7 @@ std::optional<std::string> InMemoryFileSystem::refuseOpen(std::string const& key
 std::expected<std::unique_ptr<std::istream>, std::string> InMemoryFileSystem::openRead(
     std::filesystem::path const& path) const
 {
-    auto const key = normalize(path);
+    auto const key = resolveSymlinks(normalize(path));
     if (auto refusal = refuseOpen(key))
         return std::unexpected(std::move(*refusal));
     auto const it = _files.find(key);
@@ -625,8 +640,13 @@ std::expected<std::filesystem::path, std::string> InMemoryFileSystem::createTemp
 
 void InMemoryFileSystem::setCurrentPath(std::filesystem::path const& path)
 {
-    _currentPath = path;
-    _directories.insert(path.string());
+    // Normalized, like every other key: an unnormalized one (a trailing separator, or the
+    // backslashes operator/ inserts on Windows) would name a directory no lookup can ever
+    // find, since every query spells its key through normalize(). Normalizing first also
+    // resolves a relative path against the previous working directory, as chdir() does.
+    auto key = normalize(path);
+    _currentPath = std::filesystem::path(key);
+    _directories.insert(std::move(key));
 }
 
 void InMemoryFileSystem::addFile(std::filesystem::path const& path,

--- a/src/platform/testing/InMemoryFileSystem.cpp
+++ b/src/platform/testing/InMemoryFileSystem.cpp
@@ -3,6 +3,7 @@
 #include <format>
 #include <sstream>
 
+#include <platform/PathUtils.hpp>
 #include <platform/testing/InMemoryFileSystem.hpp>
 
 namespace endo::platform::testing
@@ -140,11 +141,11 @@ InMemoryFileSystem::InMemoryFileSystem(std::initializer_list<FileEntry> entries)
 
 std::string InMemoryFileSystem::normalize(std::filesystem::path const& path) const
 {
-    auto result = path.is_relative() ? (_currentPath / path).lexically_normal().string()
-                                     : path.lexically_normal().string();
-    // Normalize to forward slashes for cross-platform consistency
-    std::ranges::replace(result, '\\', '/');
-    return result;
+    // stripTrailingSeparator() normalizes, spells the result with forward slashes for
+    // cross-platform consistency, and drops the trailing separator lexically_normal()
+    // leaves behind for a final "." or ".." -- without which "/test/." would never match
+    // the "/test" held in the directory set.
+    return platform::stripTrailingSeparator(path.is_relative() ? _currentPath / path : path);
 }
 
 void InMemoryFileSystem::ensureParentDirectories(std::filesystem::path const& path) const

--- a/src/platform/testing/InMemoryFileSystem.cpp
+++ b/src/platform/testing/InMemoryFileSystem.cpp
@@ -145,7 +145,12 @@ std::string InMemoryFileSystem::normalize(std::filesystem::path const& path) con
     // cross-platform consistency, and drops the trailing separator lexically_normal()
     // leaves behind for a final "." or ".." -- without which "/test/." would never match
     // the "/test" held in the directory set.
-    return platform::stripTrailingSeparator(path.is_relative() ? _currentPath / path : path);
+    auto result = platform::stripTrailingSeparator(path.is_relative() ? _currentPath / path : path);
+    // generic_string() only folds separators the host platform recognises, so a Windows-style
+    // fixture path keeps its backslashes on POSIX and would never match a key spelled with
+    // forward slashes. Fold them unconditionally: this filesystem is keyed by spelling.
+    std::ranges::replace(result, '\\', '/');
+    return result;
 }
 
 void InMemoryFileSystem::ensureParentDirectories(std::filesystem::path const& path) const

--- a/src/platform/testing/InMemoryFileSystem.hpp
+++ b/src/platform/testing/InMemoryFileSystem.hpp
@@ -3,6 +3,7 @@
 
 #include <initializer_list>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 
@@ -59,10 +60,11 @@ class InMemoryFileSystem final: public FileSystem
                                                              std::string_view content) const override;
     [[nodiscard]] std::expected<void, std::string> appendFile(std::filesystem::path const& path,
                                                               std::string_view content) const override;
-    [[nodiscard]] std::unique_ptr<std::istream> openRead(std::filesystem::path const& path) const override;
-    [[nodiscard]] std::unique_ptr<std::ostream> openWrite(std::filesystem::path const& path,
-                                                          bool append = false) const override;
-    [[nodiscard]] std::unique_ptr<std::iostream> openReadWrite(
+    [[nodiscard]] std::expected<std::unique_ptr<std::istream>, std::string> openRead(
+        std::filesystem::path const& path) const override;
+    [[nodiscard]] std::expected<std::unique_ptr<std::ostream>, std::string> openWrite(
+        std::filesystem::path const& path, bool append = false) const override;
+    [[nodiscard]] std::expected<std::unique_ptr<std::iostream>, std::string> openReadWrite(
         std::filesystem::path const& path) const override;
 
     // Directory ops
@@ -98,6 +100,11 @@ class InMemoryFileSystem final: public FileSystem
     // Temp files
     [[nodiscard]] std::expected<std::filesystem::path, std::string> createTempFile(
         std::string_view prefix) const override;
+
+    /// @brief Refuses an open the model can answer without looking at content.
+    /// @param key A normalized path.
+    /// @return The reason to refuse, or nullopt to proceed.
+    [[nodiscard]] std::optional<std::string> refuseOpen(std::string const& key) const;
 
     // --- Test helpers ---
 

--- a/src/platform/testing/InMemoryFileSystem.hpp
+++ b/src/platform/testing/InMemoryFileSystem.hpp
@@ -101,11 +101,6 @@ class InMemoryFileSystem final: public FileSystem
     [[nodiscard]] std::expected<std::filesystem::path, std::string> createTempFile(
         std::string_view prefix) const override;
 
-    /// @brief Refuses an open the model can answer without looking at content.
-    /// @param key A normalized path.
-    /// @return The reason to refuse, or nullopt to proceed.
-    [[nodiscard]] std::optional<std::string> refuseOpen(std::string const& key) const;
-
     // --- Test helpers ---
 
     /// Sets the current working directory for the virtual filesystem.
@@ -130,8 +125,25 @@ class InMemoryFileSystem final: public FileSystem
     void denyAccess(std::filesystem::path const& path);
 
   private:
+    /// @brief Follows a symlink chain to the key it ultimately names.
+    ///
+    /// std::filesystem's is_regular_file(), is_directory() and the stream opens all follow
+    /// symlinks; only is_symlink() and symlink_status() do not. This model has to agree, or a
+    /// shell reading through it would classify a symlink as neither file nor directory and
+    /// take a path meant for FIFOs and devices.
+    ///
+    /// @param key A normalized path.
+    /// @return The normalized key the chain ends at, or @p key when it is not a symlink. A
+    ///         cycle resolves to the last key reached rather than looping.
+    [[nodiscard]] std::string resolveSymlinks(std::string key) const;
+
     [[nodiscard]] std::string normalize(std::filesystem::path const& path) const;
     void ensureParentDirectories(std::filesystem::path const& path) const;
+
+    /// @brief Refuses an open the model can answer without looking at content.
+    /// @param key A normalized path.
+    /// @return The reason to refuse, or nullopt to proceed.
+    [[nodiscard]] std::optional<std::string> refuseOpen(std::string const& key) const;
 
     mutable std::map<std::string, std::string> _files;                  ///< path -> content
     mutable std::set<std::string> _directories;                         ///< known directories

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -331,6 +331,7 @@ if(ENDO_TESTING)
         output/OutputDefinitionRegistry_test.cpp
         output/OutputParser_test.cpp
         util/CommandResolver_test.cpp
+        util/GlobMatcher_test.cpp
         util/Suggestions_test.cpp
         util/ShellQuoting_test.cpp
         ui/RichConsoleReport_test.cpp

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -365,6 +365,13 @@ if(ENDO_TESTING)
                 --endo-path $<TARGET_FILE:endo-bin>
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         )
+        add_test(
+            NAME check-test-isolation
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/check-test-isolation.py
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        )
+        set_tests_properties(check-test-isolation PROPERTIES TIMEOUT 60)
+
         set_tests_properties(check-doc-snippets PROPERTIES
             TIMEOUT 120
             LABELS "docs"

--- a/src/shell/CrashHandler_test.cpp
+++ b/src/shell/CrashHandler_test.cpp
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <catch2/catch_test_macros.hpp>
 
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <string>
 
+#include <testing/EnvHelper.hpp>
+#include <testing/ScopedTempDir.hpp>
+
 #if !defined(_WIN32)
+
     #include <sys/wait.h>
 
-    #include <csignal>
     #include <unistd.h>
 #else
     #include <stdlib.h> // _putenv_s
@@ -23,9 +25,8 @@
 TEST_CASE("CrashHandler.creates_crash_log_on_sigsegv", "[crash]")
 {
     // Use a temp directory as HOME so we don't pollute the real one.
-    auto const tmpDir = std::filesystem::temp_directory_path() / "endo-crash-test";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir);
+    auto const tmpDirGuard = endo::testing::ScopedTempDir { "endo-crash-test" };
+    auto const& tmpDir = tmpDirGuard.path();
 
     auto const pid = fork();
     REQUIRE(pid >= 0);
@@ -75,32 +76,23 @@ TEST_CASE("CrashHandler.creates_crash_log_on_sigsegv", "[crash]")
         CHECK(content.find("0.1.0-test") != std::string::npos);
         CHECK(content.find("Backtrace:") != std::string::npos);
     }
-
-    // Cleanup.
-    std::filesystem::remove_all(tmpDir);
 }
 
 TEST_CASE("CrashHandler.creates_crash_directory", "[crash]")
 {
-    auto const tmpDir = std::filesystem::temp_directory_path() / "endo-crash-dir-test";
-    std::filesystem::remove_all(tmpDir);
+    auto const tmpDirGuard = endo::testing::ScopedTempDir { "endo-crash-dir-test" };
+    auto const& tmpDir = tmpDirGuard.path();
 
-    // Set HOME and initialize — should create the directory tree.
-    auto const* originalHome = std::getenv("HOME");
-    auto const savedHome = originalHome ? std::string(originalHome) : std::string();
-    setenv("HOME", tmpDir.c_str(), 1);
-
-    endo::CrashHandler::initialize("0.1.0-test");
-
-    // Restore HOME.
-    if (!savedHome.empty())
-        setenv("HOME", savedHome.c_str(), 1);
+    // Set HOME and initialize — should create the directory tree. Scoped, because $HOME is
+    // process-global and other fixtures read it while constructing a shell.
+    {
+        auto const scopedHome = endo::testing::ScopedEnv { "HOME", tmpDir.string() };
+        endo::CrashHandler::initialize("0.1.0-test");
+    }
 
     auto const crashDir = tmpDir / ".local" / "state" / "endo" / "crash";
     CHECK(std::filesystem::exists(crashDir));
     CHECK(std::filesystem::is_directory(crashDir));
-
-    std::filesystem::remove_all(tmpDir);
 }
 
 #else // _WIN32
@@ -181,9 +173,8 @@ static auto buildEnvironmentBlock(std::filesystem::path const& localAppData) -> 
 
 TEST_CASE("CrashHandler.creates_crash_log_on_access_violation", "[crash]")
 {
-    auto const tmpDir = std::filesystem::temp_directory_path() / "endo-crash-test";
-    std::filesystem::remove_all(tmpDir);
-    std::filesystem::create_directories(tmpDir);
+    auto const tmpDirGuard = endo::testing::ScopedTempDir { "endo-crash-test" };
+    auto const& tmpDir = tmpDirGuard.path();
 
     // Build command line: run the hidden crash-child helper test.
     auto const exePath = getTestExecutablePath();
@@ -246,35 +237,25 @@ TEST_CASE("CrashHandler.creates_crash_log_on_access_violation", "[crash]")
         CHECK(content.find("0.1.0-test") != std::string::npos);
         CHECK(content.find("Backtrace:") != std::string::npos);
     }
-
-    // Cleanup.
-    std::filesystem::remove_all(tmpDir);
 }
 
 TEST_CASE("CrashHandler.creates_crash_directory", "[crash]")
 {
-    auto const tmpDir = std::filesystem::temp_directory_path() / "endo-crash-dir-test";
-    std::filesystem::remove_all(tmpDir);
+    auto const tmpDirGuard = endo::testing::ScopedTempDir { "endo-crash-dir-test" };
+    auto const& tmpDir = tmpDirGuard.path();
 
-    // Save original LOCALAPPDATA and override it for the test.
-    auto const* originalLocalAppData = std::getenv("LOCALAPPDATA");
-    std::string savedLocalAppData;
-    if (originalLocalAppData)
-        savedLocalAppData = originalLocalAppData;
-
-    _putenv_s("LOCALAPPDATA", tmpDir.string().c_str());
-
-    endo::CrashHandler::initialize("0.1.0-test");
-
-    // Restore LOCALAPPDATA.
-    if (!savedLocalAppData.empty())
-        _putenv_s("LOCALAPPDATA", savedLocalAppData.c_str());
+    // Override %LOCALAPPDATA% and initialize — should create the directory tree. Scoped,
+    // because the environment is process-global: restoring by hand skipped the restore
+    // whenever the variable had been unset, and leaked the override entirely when an
+    // assertion threw first.
+    {
+        auto const scopedLocalAppData = endo::testing::ScopedEnv { "LOCALAPPDATA", tmpDir.string() };
+        endo::CrashHandler::initialize("0.1.0-test");
+    }
 
     auto const crashDir = tmpDir / "endo" / "crash";
     CHECK(std::filesystem::exists(crashDir));
     CHECK(std::filesystem::is_directory(crashDir));
-
-    std::filesystem::remove_all(tmpDir);
 }
 
 #endif

--- a/src/shell/DirectoryConfig_test.cpp
+++ b/src/shell/DirectoryConfig_test.cpp
@@ -8,12 +8,9 @@
 
 #include <algorithm>
 #include <filesystem>
-#include <format>
-#include <fstream>
-#include <functional>
-#include <ranges>
+#include <memory>
 
-#include <platform/NativeFileSystem.hpp>
+#include <platform/testing/InMemoryFileSystem.hpp>
 #include <platform/testing/TestEnvironmentProvider.hpp>
 
 using namespace std::string_view_literals;
@@ -30,59 +27,53 @@ endo::DiagnosticSink silentDiag()
     };
 }
 
-/// Returns the NativeFileSystem singleton for test use.
-endo::FileSystem& testFs()
-{
-    return endo::NativeFileSystem::instance();
-}
-
-struct TestShell
+struct InMemoryShell
 {
     endo::TestPTY pty;
-    endo::TestEnvironment env;
+    endo::InMemoryFileSystem fs;
+    endo::TestEnvironment env { "/test" };
     int exitCode = -1;
 
-    endo::Shell shell { pty, env };
+    endo::Shell shell { pty, env, fs };
 
     std::string output() const { return pty.output(); }
 
-    TestShell()
+    InMemoryShell()
     {
-        if (auto const* path = std::getenv("PATH"))
-            env.set("PATH", path);
-        if (auto const* home = std::getenv("HOME"))
-            env.set("HOME", home);
+        // $HOME decides where the trust store lives, so it must point into the injected
+        // filesystem rather than at the host's -- otherwise every test shares one real
+        // trusted-dirs.json. There is no reason to seed $PATH: nothing here spawns.
+        fs.addDirectory("/test");
+        // Keep the filesystem's working directory in step with the environment's, so a
+        // relative path resolves to the same place through both.
+        fs.setCurrentPath("/test");
+        env.set("HOME", "/test/home");
+        env.set("PWD", "/test");
+        // Never probe the test PTY for Sixel support: the query would leak escape bytes
+        // into the captured output and stall on timeout.
+        shell.setSixelCapability(std::make_unique<endo::StaticSixelCapability>(false));
     }
 
-    TestShell& operator()(std::string_view cmd)
+    InMemoryShell& operator()(std::string_view cmd)
     {
         exitCode = shell.execute(std::string(cmd));
         return *this;
     }
 };
 
-/// RAII temporary directory with optional .local-env.endo config file.
-struct TempConfigDir
+/// @brief Creates a directory under /test, optionally holding a .local-env.endo config.
+/// @param fileSystem Filesystem to create it in.
+/// @param name       Directory name below /test.
+/// @param config     Config file contents; no file is written when empty.
+/// @return The directory's path.
+fs::path makeDir(endo::InMemoryFileSystem& fileSystem, std::string const& name, std::string_view config = {})
 {
-    fs::path dir;
-
-    explicit TempConfigDir(std::string const& suffix, std::string const& configContent = "")
-    {
-        dir = fs::temp_directory_path() / ("endo-test-dirconfig-" + suffix);
-        fs::remove_all(dir); // Clean up from previous runs
-        fs::create_directories(dir);
-        if (!configContent.empty())
-        {
-            auto ofs = std::ofstream(dir / ".local-env.endo");
-            ofs << configContent;
-        }
-    }
-
-    ~TempConfigDir() { fs::remove_all(dir); }
-
-    TempConfigDir(TempConfigDir const&) = delete;
-    TempConfigDir& operator=(TempConfigDir const&) = delete;
-};
+    auto const dir = fs::path("/test") / name;
+    fileSystem.addDirectory(dir);
+    if (!config.empty())
+        fileSystem.addFile(dir / ".local-env.endo", std::string(config));
+    return dir;
+}
 
 /// Helper: set the test environment CWD and register the path as valid.
 void setCwd(endo::TestEnvironment& env, fs::path const& dir)
@@ -100,23 +91,20 @@ void setCwd(endo::TestEnvironment& env, fs::path const& dir)
 
 TEST_CASE("dirconfig.trust_store.round_trip")
 {
-    auto const tmpDir = fs::temp_directory_path() / "endo-test-trust";
-    fs::remove_all(tmpDir);
-    fs::create_directories(tmpDir);
-
+    endo::InMemoryFileSystem fileSystem;
     endo::TestEnvironment env;
-    env.set("HOME", tmpDir.string());
+    env.set("HOME", "/test/home");
 
     // Create, set trust, save
     {
-        auto store = endo::DirectoryConfigTrustStore(testFs(), env, silentDiag());
+        auto store = endo::DirectoryConfigTrustStore(fileSystem, env, silentDiag());
         store.setTrust("/projects/foo/.local-env.endo", "abc123", true);
         store.setTrust("/projects/bar/.local-env.endo", "def456", false);
     }
 
     // Reload and verify
     {
-        auto store = endo::DirectoryConfigTrustStore(testFs(), env, silentDiag());
+        auto store = endo::DirectoryConfigTrustStore(fileSystem, env, silentDiag());
         store.load();
 
         auto const& entries = store.entries();
@@ -130,20 +118,15 @@ TEST_CASE("dirconfig.trust_store.round_trip")
         REQUIRE(trust2.has_value());
         CHECK(*trust2 == false);
     }
-
-    fs::remove_all(tmpDir);
 }
 
 TEST_CASE("dirconfig.trust_store.hash_change_invalidates")
 {
-    auto const tmpDir = fs::temp_directory_path() / "endo-test-trust-hash";
-    fs::remove_all(tmpDir);
-    fs::create_directories(tmpDir);
-
+    endo::InMemoryFileSystem fileSystem;
     endo::TestEnvironment env;
-    env.set("HOME", tmpDir.string());
+    env.set("HOME", "/test/home");
 
-    auto store = endo::DirectoryConfigTrustStore(testFs(), env, silentDiag());
+    auto store = endo::DirectoryConfigTrustStore(fileSystem, env, silentDiag());
     store.setTrust("/projects/foo/.local-env.endo", "original_hash", true);
 
     // Same hash -> trusted
@@ -154,27 +137,20 @@ TEST_CASE("dirconfig.trust_store.hash_change_invalidates")
     // Different hash -> unknown (requires re-approval)
     auto const trustChanged = store.checkTrust("/projects/foo/.local-env.endo", "new_hash");
     CHECK(!trustChanged.has_value());
-
-    fs::remove_all(tmpDir);
 }
 
 TEST_CASE("dirconfig.trust_store.revoke")
 {
-    auto const tmpDir = fs::temp_directory_path() / "endo-test-trust-revoke";
-    fs::remove_all(tmpDir);
-    fs::create_directories(tmpDir);
-
+    endo::InMemoryFileSystem fileSystem;
     endo::TestEnvironment env;
-    env.set("HOME", tmpDir.string());
+    env.set("HOME", "/test/home");
 
-    auto store = endo::DirectoryConfigTrustStore(testFs(), env, silentDiag());
+    auto store = endo::DirectoryConfigTrustStore(fileSystem, env, silentDiag());
     store.setTrust("/projects/foo/.local-env.endo", "hash1", true);
     CHECK(store.checkTrust("/projects/foo/.local-env.endo", "hash1").has_value());
 
     store.revokeTrust("/projects/foo/.local-env.endo");
     CHECK(!store.checkTrust("/projects/foo/.local-env.endo", "hash1").has_value());
-
-    fs::remove_all(tmpDir);
 }
 
 // ============================================================================
@@ -183,15 +159,13 @@ TEST_CASE("dirconfig.trust_store.revoke")
 
 TEST_CASE("dirconfig.discovery.untrusted_config_not_loaded")
 {
-    auto const tmpDir = TempConfigDir("discovery-untrusted", "let x = 42\n");
+    InMemoryShell ts;
+    auto const tmpDir = makeDir(ts.fs, "discovery-untrusted", "let x = 42\n");
+    setCwd(ts.env, tmpDir);
 
-    TestShell ts;
-    ts.env.set("HOME", fs::temp_directory_path().string());
-    setCwd(ts.env, tmpDir.dir);
-
-    auto mgr = endo::DirectoryConfigManager(ts.shell, testFs(), ts.env, silentDiag());
+    auto mgr = endo::DirectoryConfigManager(ts.shell, ts.fs, ts.env, silentDiag());
     // Config exists but is not trusted — should not be loaded
-    mgr.onDirectoryChanged(tmpDir.dir.string());
+    mgr.onDirectoryChanged(tmpDir.string());
     CHECK(mgr.activeScopes().empty());
     // Should have diagnostic about untrusted config
     CHECK(!mgr.diagnostics().empty());
@@ -199,20 +173,14 @@ TEST_CASE("dirconfig.discovery.untrusted_config_not_loaded")
 
 TEST_CASE("dirconfig.discovery.no_config_file")
 {
-    auto const tmpDir = fs::temp_directory_path() / "endo-test-no-config";
-    fs::remove_all(tmpDir);
-    fs::create_directories(tmpDir);
-
-    TestShell ts;
-    ts.env.set("HOME", fs::temp_directory_path().string());
+    InMemoryShell ts;
+    auto const tmpDir = makeDir(ts.fs, "no-config");
     setCwd(ts.env, tmpDir);
 
-    auto mgr = endo::DirectoryConfigManager(ts.shell, testFs(), ts.env, silentDiag());
+    auto mgr = endo::DirectoryConfigManager(ts.shell, ts.fs, ts.env, silentDiag());
     mgr.onDirectoryChanged(tmpDir.string());
     CHECK(mgr.activeScopes().empty());
     CHECK(mgr.diagnostics().empty());
-
-    fs::remove_all(tmpDir);
 }
 
 // ============================================================================
@@ -221,14 +189,12 @@ TEST_CASE("dirconfig.discovery.no_config_file")
 
 TEST_CASE("dirconfig.load.trusted_config_introduces_function")
 {
-    auto const tmpDir = TempConfigDir("load-func", "let greet name = print name\n");
+    InMemoryShell ts;
+    auto const tmpDir = makeDir(ts.fs, "load-func", "let greet name = print name\n");
+    setCwd(ts.env, tmpDir);
 
-    TestShell ts;
-    ts.env.set("HOME", fs::temp_directory_path().string());
-    setCwd(ts.env, tmpDir.dir);
-
-    auto mgr = endo::DirectoryConfigManager(ts.shell, testFs(), ts.env, silentDiag());
-    mgr.allowConfig(tmpDir.dir);
+    auto mgr = endo::DirectoryConfigManager(ts.shell, ts.fs, ts.env, silentDiag());
+    mgr.allowConfig(tmpDir);
 
     // Verify function was loaded
     CHECK(ts.shell.fsharpState().functions.contains("greet"));
@@ -239,19 +205,15 @@ TEST_CASE("dirconfig.load.trusted_config_introduces_function")
 
 TEST_CASE("dirconfig.unload.removes_function_on_cd_away")
 {
-    auto const tmpDir = TempConfigDir("unload-func", "let greet name = print name\n");
-    auto const otherDir = fs::temp_directory_path() / "endo-test-other";
-    fs::remove_all(otherDir);
-    fs::create_directories(otherDir);
+    InMemoryShell ts;
+    auto const tmpDir = makeDir(ts.fs, "unload-func", "let greet name = print name\n");
+    auto const otherDir = makeDir(ts.fs, "otherDir");
+    setCwd(ts.env, tmpDir);
 
-    TestShell ts;
-    ts.env.set("HOME", fs::temp_directory_path().string());
-    setCwd(ts.env, tmpDir.dir);
-
-    auto mgr = endo::DirectoryConfigManager(ts.shell, testFs(), ts.env, silentDiag());
+    auto mgr = endo::DirectoryConfigManager(ts.shell, ts.fs, ts.env, silentDiag());
 
     // Trust and load
-    mgr.allowConfig(tmpDir.dir);
+    mgr.allowConfig(tmpDir);
     REQUIRE(ts.shell.fsharpState().functions.contains("greet"));
 
     // cd to unrelated directory — function should be removed
@@ -259,20 +221,16 @@ TEST_CASE("dirconfig.unload.removes_function_on_cd_away")
     mgr.onDirectoryChanged(otherDir.string());
     CHECK(!ts.shell.fsharpState().functions.contains("greet"));
     CHECK(mgr.activeScopes().empty());
-
-    fs::remove_all(otherDir);
 }
 
 TEST_CASE("dirconfig.load.trusted_config_introduces_binding")
 {
-    auto const tmpDir = TempConfigDir("load-binding", "let project_name = \"my-project\"\n");
+    InMemoryShell ts;
+    auto const tmpDir = makeDir(ts.fs, "load-binding", "let project_name = \"my-project\"\n");
+    setCwd(ts.env, tmpDir);
 
-    TestShell ts;
-    ts.env.set("HOME", fs::temp_directory_path().string());
-    setCwd(ts.env, tmpDir.dir);
-
-    auto mgr = endo::DirectoryConfigManager(ts.shell, testFs(), ts.env, silentDiag());
-    mgr.allowConfig(tmpDir.dir);
+    auto mgr = endo::DirectoryConfigManager(ts.shell, ts.fs, ts.env, silentDiag());
+    mgr.allowConfig(tmpDir);
 
     // Verify binding was loaded
     auto const& bindings = ts.shell.fsharpState().valueBindings;
@@ -285,17 +243,13 @@ TEST_CASE("dirconfig.load.trusted_config_introduces_binding")
 
 TEST_CASE("dirconfig.unload.removes_binding_on_cd_away")
 {
-    auto const tmpDir = TempConfigDir("unload-binding", "let project_name = \"my-project\"\n");
-    auto const otherDir = fs::temp_directory_path() / "endo-test-other-bind";
-    fs::remove_all(otherDir);
-    fs::create_directories(otherDir);
+    InMemoryShell ts;
+    auto const tmpDir = makeDir(ts.fs, "unload-binding", "let project_name = \"my-project\"\n");
+    auto const otherDir = makeDir(ts.fs, "otherDir");
+    setCwd(ts.env, tmpDir);
 
-    TestShell ts;
-    ts.env.set("HOME", fs::temp_directory_path().string());
-    setCwd(ts.env, tmpDir.dir);
-
-    auto mgr = endo::DirectoryConfigManager(ts.shell, testFs(), ts.env, silentDiag());
-    mgr.allowConfig(tmpDir.dir);
+    auto mgr = endo::DirectoryConfigManager(ts.shell, ts.fs, ts.env, silentDiag());
+    mgr.allowConfig(tmpDir);
 
     auto const& bindings = ts.shell.fsharpState().valueBindings;
     REQUIRE(std::ranges::any_of(bindings, [](auto const& vb) { return vb.name == "project_name"; }));
@@ -303,8 +257,6 @@ TEST_CASE("dirconfig.unload.removes_binding_on_cd_away")
     setCwd(ts.env, otherDir);
     mgr.onDirectoryChanged(otherDir.string());
     CHECK(!std::ranges::any_of(bindings, [](auto const& vb) { return vb.name == "project_name"; }));
-
-    fs::remove_all(otherDir);
 }
 
 // ============================================================================
@@ -313,26 +265,24 @@ TEST_CASE("dirconfig.unload.removes_binding_on_cd_away")
 
 TEST_CASE("dirconfig.sibling_transition.swaps_configs")
 {
-    auto const projectA = TempConfigDir("sibling-a", "let project_a = 1\n");
-    auto const projectB = TempConfigDir("sibling-b", "let project_b = 2\n");
+    InMemoryShell ts;
+    auto const projectA = makeDir(ts.fs, "sibling-a", "let project_a = 1\n");
+    auto const projectB = makeDir(ts.fs, "sibling-b", "let project_b = 2\n");
 
-    TestShell ts;
-    ts.env.set("HOME", fs::temp_directory_path().string());
-
-    auto mgr = endo::DirectoryConfigManager(ts.shell, testFs(), ts.env, silentDiag());
+    auto mgr = endo::DirectoryConfigManager(ts.shell, ts.fs, ts.env, silentDiag());
 
     // Start in project A
-    setCwd(ts.env, projectA.dir);
-    mgr.allowConfig(projectA.dir);
+    setCwd(ts.env, projectA);
+    mgr.allowConfig(projectA);
     REQUIRE(std::ranges::any_of(ts.shell.fsharpState().valueBindings,
                                 [](auto const& vb) { return vb.name == "project_a"; }));
 
     // Pre-trust B so onDirectoryChanged picks it up
-    setCwd(ts.env, projectB.dir);
-    mgr.allowConfig(projectB.dir);
+    setCwd(ts.env, projectB);
+    mgr.allowConfig(projectB);
 
-    setCwd(ts.env, projectB.dir);
-    mgr.onDirectoryChanged(projectB.dir.string());
+    setCwd(ts.env, projectB);
+    mgr.onDirectoryChanged(projectB.string());
 
     // project_a should be gone, project_b should be present
     auto const& bindings = ts.shell.fsharpState().valueBindings;
@@ -346,7 +296,7 @@ TEST_CASE("dirconfig.sibling_transition.swaps_configs")
 
 TEST_CASE("dirconfig.builtin.list_empty")
 {
-    TestShell ts;
+    InMemoryShell ts;
     ts("dirconfig list");
     CHECK(ts.exitCode == 0);
     CHECK(ts.output().find("No directory configs") != std::string_view::npos);
@@ -354,7 +304,7 @@ TEST_CASE("dirconfig.builtin.list_empty")
 
 TEST_CASE("dirconfig.builtin.unknown_subcommand")
 {
-    TestShell ts;
+    InMemoryShell ts;
     ts("dirconfig foobar");
     CHECK(ts.exitCode == 1);
 }
@@ -365,14 +315,12 @@ TEST_CASE("dirconfig.builtin.unknown_subcommand")
 
 TEST_CASE("dirconfig.diagnostics.untrusted_message_captured")
 {
-    auto const tmpDir = TempConfigDir("diag-capture", "let x = 1\n");
+    InMemoryShell ts;
+    auto const tmpDir = makeDir(ts.fs, "diag-capture", "let x = 1\n");
+    setCwd(ts.env, tmpDir);
 
-    TestShell ts;
-    ts.env.set("HOME", fs::temp_directory_path().string());
-    setCwd(ts.env, tmpDir.dir);
-
-    auto mgr = endo::DirectoryConfigManager(ts.shell, testFs(), ts.env, silentDiag());
-    mgr.onDirectoryChanged(tmpDir.dir.string());
+    auto mgr = endo::DirectoryConfigManager(ts.shell, ts.fs, ts.env, silentDiag());
+    mgr.onDirectoryChanged(tmpDir.string());
 
     // Should have captured diagnostic about untrusted config
     auto const& diags = mgr.diagnostics();

--- a/src/shell/DirectoryConfig_test.cpp
+++ b/src/shell/DirectoryConfig_test.cpp
@@ -3,6 +3,7 @@
 #include <shell/DirectoryConfig.hpp>
 #include <shell/Shell.hpp>
 #include <shell/TTY.hpp>
+#include <shell/testing/InjectedShell.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -19,6 +20,7 @@ namespace fs = std::filesystem;
 
 namespace
 {
+using endo::testing::InMemoryShell;
 
 /// Silent diagnostic sink for tests — collects messages without printing.
 endo::DiagnosticSink silentDiag()
@@ -26,40 +28,6 @@ endo::DiagnosticSink silentDiag()
     return [](std::string const&) {
     };
 }
-
-struct InMemoryShell
-{
-    endo::TestPTY pty;
-    endo::InMemoryFileSystem fs;
-    endo::TestEnvironment env { "/test" };
-    int exitCode = -1;
-
-    endo::Shell shell { pty, env, fs };
-
-    std::string output() const { return pty.output(); }
-
-    InMemoryShell()
-    {
-        // $HOME decides where the trust store lives, so it must point into the injected
-        // filesystem rather than at the host's -- otherwise every test shares one real
-        // trusted-dirs.json. There is no reason to seed $PATH: nothing here spawns.
-        fs.addDirectory("/test");
-        // Keep the filesystem's working directory in step with the environment's, so a
-        // relative path resolves to the same place through both.
-        fs.setCurrentPath("/test");
-        env.set("HOME", "/test/home");
-        env.set("PWD", "/test");
-        // Never probe the test PTY for Sixel support: the query would leak escape bytes
-        // into the captured output and stall on timeout.
-        shell.setSixelCapability(std::make_unique<endo::StaticSixelCapability>(false));
-    }
-
-    InMemoryShell& operator()(std::string_view cmd)
-    {
-        exitCode = shell.execute(std::string(cmd));
-        return *this;
-    }
-};
 
 /// @brief Creates a directory under /test, optionally holding a .local-env.endo config.
 /// @param fileSystem Filesystem to create it in.

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -629,17 +629,24 @@ void Shell::setSixelCapability(std::unique_ptr<SixelCapabilityProvider> provider
 }
 
 Shell::Shell(TTY& tty, EnvironmentProvider& env, FileSystem& fs):
+    Shell(tty,
+          env,
+          fs,
+#if defined(_WIN32)
+          WindowsProcessManager::instance()
+#else
+          PosixProcessManager::instance()
+#endif
+    )
+{
+}
+
+Shell::Shell(TTY& tty, EnvironmentProvider& env, FileSystem& fs, ProcessManager& processManager):
     _fs { fs },
     _env { env },
     _tty { tty },
     _sixelCapability { std::make_unique<TerminalSixelCapability>(tty, env) },
-    _processManager {
-#if defined(_WIN32)
-        WindowsProcessManager::instance()
-#else
-        PosixProcessManager::instance()
-#endif
-    }
+    _processManager { processManager }
 {
     _currentPipelineBuilder.defaultStdinFd = _tty.inputFd();
     _currentPipelineBuilder.defaultStdoutFd = _tty.outputFd();

--- a/src/shell/Shell.hpp
+++ b/src/shell/Shell.hpp
@@ -90,6 +90,15 @@ class Shell final: public SignalCallback
     Shell(TTY& tty, EnvironmentProvider& env);
     Shell(TTY& tty, EnvironmentProvider& env, FileSystem& fs);
 
+    /// @brief Constructs a shell over fully injected collaborators.
+    /// @param tty Terminal abstraction.
+    /// @param env Environment abstraction.
+    /// @param fs Filesystem the builtins read and write through.
+    /// @param processManager Spawns processes and opens the descriptors handed to them.
+    ///                       Anything a forked child must inherit goes through here, so a
+    ///                       mock only suits a shell that spawns nothing.
+    Shell(TTY& tty, EnvironmentProvider& env, FileSystem& fs, ProcessManager& processManager);
+
     /// @brief Replaces the Sixel capability provider.
     ///
     /// Lets tests force Sixel on or off without a terminal probe.

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -5103,7 +5103,8 @@ TEST_CASE("shell.builtin.cat_never_falls_back_to_the_host_filesystem")
 
 TEST_CASE("shell.builtin.cat_distinguishes_why_a_file_could_not_be_read")
 {
-    // openRead() reports every failure the same way, so cat has to tell these apart itself.
+    // Each reason reaches the user as the filesystem stated it, rather than being inferred
+    // from a follow-up probe that can only guess between two of them.
     InMemoryShell shell;
     shell.fs.addDirectory("/test/adir");
     shell.fs.addFile("/test/locked.txt", "secret\n");

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -35,6 +35,7 @@ using crispy::escape;
 #include <platform/InstallPaths.hpp>
 #include <platform/NativeFileSystem.hpp>
 #include <platform/testing/InMemoryFileSystem.hpp>
+#include <platform/testing/MockProcessManager.hpp>
 #include <platform/testing/TestEnvironmentProvider.hpp>
 #include <testing/ScopedTempDir.hpp>
 #include <testing/ScopedWorkingDirectory.hpp>
@@ -74,6 +75,27 @@ struct TestShell
     }
 };
 
+/// @brief Seeds the "/test" convention every injected-filesystem fixture shares.
+///
+/// Kept in one place because a fixture that seeds it differently is not a variant, it is a
+/// bug: the shell resolves a relative path through the filesystem and the environment both,
+/// so the two views of the working directory have to agree.
+///
+/// @param fs    The injected filesystem to seed.
+/// @param env   The injected environment to keep in step with it.
+/// @param shell The shell owning them.
+void seedInjectedShell(endo::InMemoryFileSystem& fs, endo::TestEnvironment& env, endo::Shell& shell)
+{
+    fs.addDirectory("/test");
+    fs.setCurrentPath("/test");
+    env.set("HOME", "/test/home");
+    env.set("PWD", "/test");
+    shell.addModuleSearchPath("/test");
+    // Never probe the test PTY for Sixel support: the query would leak escape bytes into
+    // the captured output and stall on timeout.
+    shell.setSixelCapability(std::make_unique<endo::StaticSixelCapability>(false));
+}
+
 /// @brief A shell whose filesystem is private to the test case.
 ///
 /// Builtins reach the filesystem through Shell's injected FileSystem, so pointing that at
@@ -90,6 +112,7 @@ struct TestShell
 /// reports "now", weaklyCanonical() never resolves symlinks, symlinks are metadata only,
 /// and permissions are not enforced beyond denyAccess(). A test whose assertion depends on
 /// any of those would pass vacuously here and belongs on TestShell.
+
 struct InMemoryShell
 {
     endo::TestPTY pty;
@@ -101,19 +124,7 @@ struct InMemoryShell
 
     std::string output() const { return pty.output(); }
 
-    InMemoryShell()
-    {
-        fs.addDirectory("/test");
-        // Keep the filesystem's idea of the working directory in step with the
-        // environment's, so a relative path resolves the same way through both.
-        fs.setCurrentPath("/test");
-        env.set("HOME", "/test/home");
-        env.set("PWD", "/test");
-        shell.addModuleSearchPath("/test");
-        // Never probe the test PTY for Sixel support: the query would leak escape bytes
-        // into the captured output and stall on timeout.
-        shell.setSixelCapability(std::make_unique<endo::StaticSixelCapability>(false));
-    }
+    InMemoryShell() { seedInjectedShell(fs, env, shell); }
 
     InMemoryShell& operator()(std::string_view cmd)
     {
@@ -129,6 +140,33 @@ struct InMemoryShell
     [[nodiscard]] std::string content(std::filesystem::path const& path) const
     {
         return fs.readFile(path).value_or(std::string {});
+    }
+};
+
+/// A shell whose every OS collaborator is injected -- filesystem, environment and process
+/// manager. Spawning is recorded rather than performed, so a test can assert on what the
+/// shell would run without the program existing or a child being forked.
+struct MockedProcessShell
+{
+    endo::TestPTY pty;
+    endo::InMemoryFileSystem fs;
+    endo::TestEnvironment env { "/test" };
+    endo::platform::testing::MockProcessManager processManager;
+    int exitCode = -1;
+
+    endo::Shell shell { pty, env, fs, processManager };
+
+    [[nodiscard]] std::string output() const { return pty.output(); }
+
+    /// @return The configs the shell handed to the process manager, in spawn order.
+    [[nodiscard]] auto const& spawned() const noexcept { return processManager.spawnedConfigs(); }
+
+    MockedProcessShell() { seedInjectedShell(fs, env, shell); }
+
+    MockedProcessShell& operator()(std::string_view cmd)
+    {
+        exitCode = shell.execute(std::string(cmd));
+        return *this;
     }
 };
 
@@ -913,12 +951,10 @@ TEST_CASE("shell.builtin.cat_help_shows_image_options")
 
 TEST_CASE("shell.builtin.cat_raw_flag")
 {
-    auto const tempDir = endo::testing::ScopedTempDir { "endo_shell_test" };
-    auto const rawPpmPath = (tempDir / "raw.ppm").generic_string();
-    // Write a PPM image and cat it with --raw — should get raw bytes
-    TestShell shell;
-    // Create a minimal PPM file
-    shell(std::format(R"(echo -e 'P6\n1 1\n255\n' > {})", rawPpmPath));
+    // A minimal PPM: an image extension, so --raw is what keeps this out of the sixel path.
+    InMemoryShell shell;
+    auto const rawPpmPath = std::string { "/test/raw.ppm" };
+    shell.fs.addFile(rawPpmPath, "P6\n1 1\n255\n");
     auto output = shell(std::format("cat --raw {}", rawPpmPath)).output();
     CHECK(output.find("P6") != std::string::npos);
 }
@@ -926,28 +962,20 @@ TEST_CASE("shell.builtin.cat_raw_flag")
 #if !defined(_WIN32)
 TEST_CASE("shell.builtin.cat_binary_file_refuses_output")
 {
-    auto const tempDir = endo::testing::ScopedTempDir { "endo_shell_test" };
-    auto const binaryPath = (tempDir / "binary.dat").generic_string();
-    // Create a file with null bytes directly (endo shell does not interpret \x00 in strings)
-    {
-        std::ofstream f(binaryPath, std::ios::binary);
-        f << "hello" << '\0' << "world";
-    }
-    TestShell shell;
+    // Null bytes are seeded directly: the endo shell does not interpret \x00 in strings.
+    InMemoryShell shell;
+    auto const binaryPath = std::string { "/test/binary.dat" };
+    shell.fs.addFile(binaryPath, std::string("hello\0world", 11));
     shell(std::format("cat {}", binaryPath));
     CHECK(shell.exitCode == 1);
 }
 
 TEST_CASE("shell.builtin.cat_binary_file_raw_mode")
 {
-    auto const tempDir = endo::testing::ScopedTempDir { "endo_shell_test" };
-    auto const binaryRawPath = (tempDir / "binary.dat").generic_string();
-    // Create a file with null bytes directly (endo shell does not interpret \x00 in strings)
-    {
-        std::ofstream f(binaryRawPath, std::ios::binary);
-        f << "hello" << '\0' << "world";
-    }
-    TestShell shell;
+    // Null bytes are seeded directly: the endo shell does not interpret \x00 in strings.
+    InMemoryShell shell;
+    auto const binaryRawPath = std::string { "/test/binary.dat" };
+    shell.fs.addFile(binaryRawPath, std::string("hello\0world", 11));
     static_cast<void>(shell(std::format("cat --raw {}", binaryRawPath)).output());
     // With --raw, binary data should pass through (exit code 0)
     CHECK(shell.exitCode == 0);
@@ -4964,10 +4992,10 @@ constexpr auto MarkdownFixture = "# Title\n\nSee [Docs](https://endo-lang.org/).
 
 TEST_CASE("shell.builtin.cat_markdown_renders_on_tty")
 {
-    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
-    auto const path = writeMarkdownFixture(markdownDir.path(), "render.md", MarkdownFixture);
+    InMemoryShell shell;
+    auto const path = std::filesystem::path { "/test/render.md" };
+    shell.fs.addFile(path, std::string(MarkdownFixture));
 
-    TestShell shell;
     shell(std::format("cat {}", path.string()));
     auto const output = std::string(shell.output());
 
@@ -4988,10 +5016,10 @@ TEST_CASE("shell.builtin.cat_markdown_renders_on_tty")
 
 TEST_CASE("shell.builtin.cat_markdown_is_indented_by_default")
 {
-    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
-    auto const path = writeMarkdownFixture(markdownDir.path(), "indent_default.md", "Hello\n"sv);
+    InMemoryShell shell;
+    auto const path = std::filesystem::path { "/test/indent_default.md" };
+    shell.fs.addFile(path, std::string("Hello\n"sv));
 
-    TestShell shell;
     shell(std::format("cat {}", path.string()));
     auto const output = std::string(shell.output());
 
@@ -5003,10 +5031,10 @@ TEST_CASE("shell.builtin.cat_markdown_is_indented_by_default")
 
 TEST_CASE("shell.builtin.cat_markdown_indent_flag_overrides_the_default")
 {
-    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
-    auto const path = writeMarkdownFixture(markdownDir.path(), "indent_flag.md", "Hello\n"sv);
+    InMemoryShell shell;
+    auto const path = std::filesystem::path { "/test/indent_flag.md" };
+    shell.fs.addFile(path, std::string("Hello\n"sv));
 
-    TestShell shell;
     shell(std::format("cat --indent 5 {}", path.string()));
     auto const output = std::string(shell.output());
 
@@ -5018,10 +5046,10 @@ TEST_CASE("shell.builtin.cat_markdown_indent_flag_overrides_the_default")
 
 TEST_CASE("shell.builtin.cat_markdown_indent_zero_hugs_the_left_edge")
 {
-    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
-    auto const path = writeMarkdownFixture(markdownDir.path(), "indent_zero.md", "Hello\n"sv);
+    InMemoryShell shell;
+    auto const path = std::filesystem::path { "/test/indent_zero.md" };
+    shell.fs.addFile(path, std::string("Hello\n"sv));
 
-    TestShell shell;
     shell(std::format("cat --indent=0 {}", path.string()));
     auto const output = std::string(shell.output());
 
@@ -5034,10 +5062,10 @@ TEST_CASE("shell.builtin.cat_markdown_indent_zero_hugs_the_left_edge")
 
 TEST_CASE("shell.builtin.cat_indent_rejects_invalid_values")
 {
-    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
-    auto const path = writeMarkdownFixture(markdownDir.path(), "indent_bad.md", "Hello\n"sv);
+    InMemoryShell bad;
+    auto const path = std::filesystem::path { "/test/indent_bad.md" };
+    bad.fs.addFile(path, std::string("Hello\n"sv));
 
-    TestShell bad;
     bad(std::format("cat --indent abc {}", path.string()));
     CHECK(bad.exitCode == 1);
 
@@ -5052,10 +5080,10 @@ TEST_CASE("shell.builtin.cat_indent_rejects_invalid_values")
 
 TEST_CASE("shell.builtin.cat_indent_does_not_affect_raw_output")
 {
-    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
-    auto const path = writeMarkdownFixture(markdownDir.path(), "indent_raw.md", "Hello\n"sv);
+    InMemoryShell shell;
+    auto const path = std::filesystem::path { "/test/indent_raw.md" };
+    shell.fs.addFile(path, std::string("Hello\n"sv));
 
-    TestShell shell;
     shell(std::format("cat --raw --indent 5 {}", path.string()));
 
     CHECK(shell.exitCode == 0);
@@ -5064,10 +5092,10 @@ TEST_CASE("shell.builtin.cat_indent_does_not_affect_raw_output")
 
 TEST_CASE("shell.builtin.cat_markdown_raw_flag_emits_source_bytes")
 {
-    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
-    auto const path = writeMarkdownFixture(markdownDir.path(), "raw.md", MarkdownFixture);
+    InMemoryShell shell;
+    auto const path = std::filesystem::path { "/test/raw.md" };
+    shell.fs.addFile(path, std::string(MarkdownFixture));
 
-    TestShell shell;
     shell(std::format("cat --raw {}", path.string()));
     auto const output = std::string(shell.output());
 
@@ -5079,11 +5107,11 @@ TEST_CASE("shell.builtin.cat_markdown_raw_flag_emits_source_bytes")
 
 TEST_CASE("shell.builtin.cat_markdown_piped_is_not_rendered")
 {
-    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
-    auto const path = writeMarkdownFixture(markdownDir.path(), "piped.md", MarkdownFixture);
+    InMemoryShell shell;
+    auto const path = std::filesystem::path { "/test/piped.md" };
+    shell.fs.addFile(path, std::string(MarkdownFixture));
 
     // The first `cat` writes into a pipe, so its output handle is not a terminal.
-    TestShell shell;
     shell(std::format("cat {} | cat", path.string()));
     auto const output = std::string(shell.output());
 
@@ -5094,11 +5122,11 @@ TEST_CASE("shell.builtin.cat_markdown_piped_is_not_rendered")
 
 TEST_CASE("shell.builtin.cat_markdown_number_flag_shows_source")
 {
-    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
-    auto const path = writeMarkdownFixture(markdownDir.path(), "numbered.md", MarkdownFixture);
+    InMemoryShell shell;
+    auto const path = std::filesystem::path { "/test/numbered.md" };
+    shell.fs.addFile(path, std::string(MarkdownFixture));
 
     // -n asks for a literal view of the source, so rendering is suppressed.
-    TestShell shell;
     shell(std::format("cat -n {}", path.string()));
     auto const output = std::string(shell.output());
 
@@ -5111,6 +5139,8 @@ TEST_CASE("shell.builtin.cat_markdown_number_flag_shows_source")
 TEST_CASE("shell.builtin.cat_markdown_redirect_writes_source_bytes")
 {
     namespace fs = std::filesystem;
+    // Real filesystem: `>` opens its target as a descriptor, which an injected filesystem
+    // cannot supply -- see the redirect note on Shell::applyRedirects.
     auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
     auto const path = writeMarkdownFixture(markdownDir.path(), "redirect.md", MarkdownFixture);
     auto const target = path.parent_path() / "redirect.out";
@@ -5125,12 +5155,39 @@ TEST_CASE("shell.builtin.cat_markdown_redirect_writes_source_bytes")
     CHECK(written == std::string(MarkdownFixture));
 }
 
+TEST_CASE("shell.builtin.cat_distinguishes_why_a_file_could_not_be_read")
+{
+    // openRead() reports every failure the same way, so cat has to tell these apart itself.
+    InMemoryShell shell;
+    shell.fs.addDirectory("/test/adir");
+    shell.fs.addFile("/test/locked.txt", "secret\n");
+    shell.fs.denyAccess("/test/locked.txt");
+
+    CHECK(shell("cat /test/missing.txt").output().find("No such file or directory") != std::string::npos);
+    CHECK(shell("cat /test/adir").output().find("Is a directory") != std::string::npos);
+    CHECK(shell("cat /test/locked.txt").output().find("Permission denied") != std::string::npos);
+}
+
+TEST_CASE("shell.spawn.external_commands_go_through_the_injected_process_manager")
+{
+    MockedProcessShell shell;
+    // An executable that exists only in the injected filesystem: nothing is forked, so the
+    // program never has to be real.
+    shell.fs.addExecutable("/test/tool");
+
+    shell("/test/tool --flag value");
+
+    REQUIRE(shell.spawned().size() == 1);
+    CHECK(shell.spawned()[0].program == "/test/tool");
+    CHECK(shell.spawned()[0].arguments == std::vector<std::string> { "--flag", "value" });
+}
+
 TEST_CASE("shell.builtin.cat_non_markdown_is_unaffected")
 {
-    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
-    auto const path = writeMarkdownFixture(markdownDir.path(), "plain.txt", "hello world\n"sv);
+    InMemoryShell shell;
+    auto const path = std::filesystem::path { "/test/plain.txt" };
+    shell.fs.addFile(path, std::string("hello world\n"sv));
 
-    TestShell shell;
     shell(std::format("cat {}", path.string()));
 
     CHECK(shell.exitCode == 0);

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -5090,6 +5090,17 @@ TEST_CASE("shell.builtin.cat_markdown_redirect_writes_source_bytes")
     CHECK(written == std::string(MarkdownFixture));
 }
 
+TEST_CASE("shell.builtin.grep_reports_an_unreadable_file_with_or_without_binary_skipping")
+{
+    // -I asks to skip binary files, not to fall silent about unreadable ones.
+    InMemoryShell shell;
+    shell.fs.addFile("/test/locked.txt", "needle\n");
+    shell.fs.denyAccess("/test/locked.txt");
+
+    CHECK(shell("grep needle /test/locked.txt").output().find("Permission denied") != std::string::npos);
+    CHECK(shell("grep -I needle /test/locked.txt").output().find("Permission denied") != std::string::npos);
+}
+
 TEST_CASE("shell.builtin.cat_never_falls_back_to_the_host_filesystem")
 {
     // A path absent from the injected filesystem must be reported as absent, never opened

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -25,6 +25,7 @@ using crispy::escape;
 #include <shell/completion/ScriptedCompleter.hpp>
 #include <shell/history/PersistentHistory.hpp>
 #include <shell/output/TableFormatter.hpp>
+#include <shell/testing/InjectedShell.hpp>
 
 #include <endo-language/ide/CompletionContext.hpp>
 
@@ -42,6 +43,8 @@ using crispy::escape;
 
 namespace
 {
+using endo::testing::InMemoryShell;
+
 struct TestShell
 {
     endo::TestPTY pty;
@@ -75,74 +78,6 @@ struct TestShell
     }
 };
 
-/// @brief Seeds the "/test" convention every injected-filesystem fixture shares.
-///
-/// Kept in one place because a fixture that seeds it differently is not a variant, it is a
-/// bug: the shell resolves a relative path through the filesystem and the environment both,
-/// so the two views of the working directory have to agree.
-///
-/// @param fs    The injected filesystem to seed.
-/// @param env   The injected environment to keep in step with it.
-/// @param shell The shell owning them.
-void seedInjectedShell(endo::InMemoryFileSystem& fs, endo::TestEnvironment& env, endo::Shell& shell)
-{
-    fs.addDirectory("/test");
-    fs.setCurrentPath("/test");
-    env.set("HOME", "/test/home");
-    env.set("PWD", "/test");
-    shell.addModuleSearchPath("/test");
-    // Never probe the test PTY for Sixel support: the query would leak escape bytes into
-    // the captured output and stall on timeout.
-    shell.setSixelCapability(std::make_unique<endo::StaticSixelCapability>(false));
-}
-
-/// @brief A shell whose filesystem is private to the test case.
-///
-/// Builtins reach the filesystem through Shell's injected FileSystem, so pointing that at
-/// an in-memory implementation gives each test a private tree with nothing to clean up.
-/// This mirrors the wiring endo-test uses for `# mode: shell` tests
-/// (src/endo-test/TestExecutor.cpp).
-///
-/// Not usable by every test. A builtin whose output travels through a real file descriptor
-/// -- a redirection target, or anything inherited by a forked child -- cannot see this
-/// filesystem, because a child process cannot read an in-memory file through an fd. Those
-/// tests keep using TestShell and the real filesystem.
-///
-/// The in-memory model is also deliberately shallow in places: lastWriteTime() always
-/// reports "now", weaklyCanonical() never resolves symlinks, symlinks are metadata only,
-/// and permissions are not enforced beyond denyAccess(). A test whose assertion depends on
-/// any of those would pass vacuously here and belongs on TestShell.
-
-struct InMemoryShell
-{
-    endo::TestPTY pty;
-    endo::InMemoryFileSystem fs;
-    endo::TestEnvironment env { "/test" };
-    int exitCode = -1;
-
-    endo::Shell shell { pty, env, fs };
-
-    std::string output() const { return pty.output(); }
-
-    InMemoryShell() { seedInjectedShell(fs, env, shell); }
-
-    InMemoryShell& operator()(std::string_view cmd)
-    {
-        exitCode = shell.execute(std::string(cmd));
-        return *this;
-    }
-
-    /// @brief Returns a file's entire contents, or an empty string if it cannot be read.
-    ///
-    /// Whole contents rather than the first line: the fixtures these assertions replaced
-    /// used std::getline only because std::ifstream made that the easy call, so truncating
-    /// here would let a copy that dropped everything after the first newline pass.
-    [[nodiscard]] std::string content(std::filesystem::path const& path) const
-    {
-        return fs.readFile(path).value_or(std::string {});
-    }
-};
-
 /// A shell whose every OS collaborator is injected -- filesystem, environment and process
 /// manager. Spawning is recorded rather than performed, so a test can assert on what the
 /// shell would run without the program existing or a child being forked.
@@ -161,7 +96,7 @@ struct MockedProcessShell
     /// @return The configs the shell handed to the process manager, in spawn order.
     [[nodiscard]] auto const& spawned() const noexcept { return processManager.spawnedConfigs(); }
 
-    MockedProcessShell() { seedInjectedShell(fs, env, shell); }
+    MockedProcessShell() { endo::testing::seedInjectedShell(fs, env, shell); }
 
     MockedProcessShell& operator()(std::string_view cmd)
     {
@@ -5153,6 +5088,17 @@ TEST_CASE("shell.builtin.cat_markdown_redirect_writes_source_bytes")
     auto stream = std::ifstream(target, std::ios::binary);
     auto const written = std::string(std::istreambuf_iterator<char>(stream), {});
     CHECK(written == std::string(MarkdownFixture));
+}
+
+TEST_CASE("shell.builtin.cat_never_falls_back_to_the_host_filesystem")
+{
+    // A path absent from the injected filesystem must be reported as absent, never opened
+    // on the host's disk -- which is what a descriptor fallback would silently do.
+    InMemoryShell shell;
+    auto const output = shell("cat /etc/hostname").output();
+
+    CHECK(shell.exitCode != 0);
+    CHECK(output.find("No such file or directory") != std::string::npos);
 }
 
 TEST_CASE("shell.builtin.cat_distinguishes_why_a_file_could_not_be_read")

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -33,9 +33,10 @@ using crispy::escape;
 #include "Shell.hpp"
 #include "TTY.hpp"
 #include <platform/InstallPaths.hpp>
-#include <platform/NativeFileSystem.hpp>
 #include <platform/testing/InMemoryFileSystem.hpp>
 #include <platform/testing/TestEnvironmentProvider.hpp>
+#include <testing/ScopedTempDir.hpp>
+#include <testing/ScopedWorkingDirectory.hpp>
 
 namespace
 {
@@ -911,43 +912,44 @@ TEST_CASE("shell.builtin.cat_help_shows_image_options")
 
 TEST_CASE("shell.builtin.cat_raw_flag")
 {
+    auto const tempDir = endo::testing::ScopedTempDir { "endo_shell_test" };
+    auto const rawPpmPath = (tempDir / "raw.ppm").generic_string();
     // Write a PPM image and cat it with --raw — should get raw bytes
     TestShell shell;
     // Create a minimal PPM file
-    shell(R"(echo -e 'P6\n1 1\n255\n' > /tmp/endo_test_cat_raw.ppm)");
-    auto output = shell("cat --raw /tmp/endo_test_cat_raw.ppm").output();
+    shell(std::format(R"(echo -e 'P6\n1 1\n255\n' > {})", rawPpmPath));
+    auto output = shell(std::format("cat --raw {}", rawPpmPath)).output();
     CHECK(output.find("P6") != std::string::npos);
-    std::filesystem::remove("/tmp/endo_test_cat_raw.ppm");
 }
 
 #if !defined(_WIN32)
 TEST_CASE("shell.builtin.cat_binary_file_refuses_output")
 {
+    auto const tempDir = endo::testing::ScopedTempDir { "endo_shell_test" };
+    auto const binaryPath = (tempDir / "binary.dat").generic_string();
     // Create a file with null bytes directly (endo shell does not interpret \x00 in strings)
     {
-        std::ofstream f("/tmp/endo_test_binary.dat", std::ios::binary);
+        std::ofstream f(binaryPath, std::ios::binary);
         f << "hello" << '\0' << "world";
     }
     TestShell shell;
-    shell("cat /tmp/endo_test_binary.dat");
+    shell(std::format("cat {}", binaryPath));
     CHECK(shell.exitCode == 1);
-    std::error_code ec;
-    std::filesystem::remove("/tmp/endo_test_binary.dat", ec);
 }
 
 TEST_CASE("shell.builtin.cat_binary_file_raw_mode")
 {
+    auto const tempDir = endo::testing::ScopedTempDir { "endo_shell_test" };
+    auto const binaryRawPath = (tempDir / "binary.dat").generic_string();
     // Create a file with null bytes directly (endo shell does not interpret \x00 in strings)
     {
-        std::ofstream f("/tmp/endo_test_binary_raw.dat", std::ios::binary);
+        std::ofstream f(binaryRawPath, std::ios::binary);
         f << "hello" << '\0' << "world";
     }
     TestShell shell;
-    static_cast<void>(shell("cat --raw /tmp/endo_test_binary_raw.dat").output());
+    static_cast<void>(shell(std::format("cat --raw {}", binaryRawPath)).output());
     // With --raw, binary data should pass through (exit code 0)
     CHECK(shell.exitCode == 0);
-    std::error_code ec;
-    std::filesystem::remove("/tmp/endo_test_binary_raw.dat", ec);
 }
 #endif
 
@@ -1160,15 +1162,15 @@ TEST_CASE("shell.builtin.rm_file")
 
 TEST_CASE("shell.builtin.rm_nonexistent")
 {
-    TestShell shell;
-    shell("rm /tmp/endo_rm_test_nonexistent_file_xyz");
+    InMemoryShell shell;
+    shell("rm /test/does_not_exist");
     CHECK(shell.exitCode == 1);
 }
 
 TEST_CASE("shell.builtin.rm_force_nonexistent")
 {
-    TestShell shell;
-    shell("rm -f /tmp/endo_rm_test_nonexistent_file_xyz");
+    InMemoryShell shell;
+    shell("rm -f /test/does_not_exist");
     CHECK(shell.exitCode == 0);
 }
 
@@ -1756,8 +1758,8 @@ TEST_CASE("shell.builtin.mv_double_dash")
 TEST_CASE("shell.builtin.mv_multiple_to_dir")
 {
     namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_multidir";
-    fs::remove_all(base);
+    auto const baseGuard = endo::testing::ScopedTempDir { "endo_mv_test_multidir" };
+    auto const& base = baseGuard.path();
     fs::create_directories(base / "target");
     auto const src1 = base / "a.txt";
     auto const src2 = base / "b.txt";
@@ -1774,16 +1776,13 @@ TEST_CASE("shell.builtin.mv_multiple_to_dir")
     CHECK(!fs::exists(src2));
     CHECK(fs::exists(base / "target" / "a.txt"));
     CHECK(fs::exists(base / "target" / "b.txt"));
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("shell.builtin.mv_multiple_to_file")
 {
     namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_multifile";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    auto const baseGuard = endo::testing::ScopedTempDir { "endo_mv_test_multifile" };
+    auto const& base = baseGuard.path();
     auto const src1 = base / "a.txt";
     auto const src2 = base / "b.txt";
     auto const dst = base / "notadir.txt";
@@ -1797,15 +1796,13 @@ TEST_CASE("shell.builtin.mv_multiple_to_file")
     TestShell shell;
     shell(std::format("mv {} {} {}", src1.string(), src2.string(), dst.string()));
     CHECK(shell.exitCode == 1);
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("shell.builtin.mv_directory")
 {
     namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_dir";
-    fs::remove_all(base);
+    auto const baseGuard = endo::testing::ScopedTempDir { "endo_mv_test_dir" };
+    auto const& base = baseGuard.path();
     fs::create_directories(base / "srcdir" / "sub");
     auto const dst = base / "dstdir";
 
@@ -1820,16 +1817,13 @@ TEST_CASE("shell.builtin.mv_directory")
     CHECK(!fs::exists(base / "srcdir"));
     CHECK(fs::exists(dst / "file.txt"));
     CHECK(fs::exists(dst / "sub" / "nested.txt"));
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("shell.builtin.mv_combined_flags")
 {
     namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_combined";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    auto const baseGuard = endo::testing::ScopedTempDir { "endo_mv_test_combined" };
+    auto const& base = baseGuard.path();
     auto const src = base / "source.txt";
     auto const dst = base / "dest.txt";
 
@@ -1843,8 +1837,6 @@ TEST_CASE("shell.builtin.mv_combined_flags")
     shell(std::format("mv -nv {} {}", src.string(), dst.string()));
     CHECK(shell.exitCode == 0);
     CHECK(fs::exists(src)); // Source still exists (no-clobber)
-
-    fs::remove_all(base);
 }
 
 namespace
@@ -1871,8 +1863,8 @@ std::filesystem::path onDiskName(std::filesystem::path const& parent, std::strin
 TEST_CASE("shell.builtin.mv_case_only_rename_directory")
 {
     namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_recase_dir";
-    fs::remove_all(base);
+    auto const baseGuard = endo::testing::ScopedTempDir { "endo_mv_test_recase_dir" };
+    auto const& base = baseGuard.path();
     fs::create_directories(base / "foo");
     std::ofstream(base / "foo" / "keep.txt") << "data";
 
@@ -1884,16 +1876,13 @@ TEST_CASE("shell.builtin.mv_case_only_rename_directory")
     CHECK(onDiskName(base, "foo") == "Foo");
     CHECK(fs::exists(base / "Foo" / "keep.txt"));
     CHECK(!fs::exists(base / "Foo" / "foo"));
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("shell.builtin.mv_case_only_rename_file")
 {
     namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_recase_file";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    auto const baseGuard = endo::testing::ScopedTempDir { "endo_mv_test_recase_file" };
+    auto const& base = baseGuard.path();
     std::ofstream(base / "readme.txt") << "hello";
 
     TestShell shell;
@@ -1907,8 +1896,6 @@ TEST_CASE("shell.builtin.mv_case_only_rename_file")
         std::getline(ifs, content);
         CHECK(content == "hello");
     }
-
-    fs::remove_all(base);
 }
 
 // ============================================================================
@@ -2084,48 +2071,48 @@ TEST_CASE("shell.variable.single_char_name")
 
 TEST_CASE("shell.redirect.output_to_file")
 {
+    auto const tempDir = endo::testing::ScopedTempDir { "endo_shell_test" };
+    auto const outputPath = (tempDir / "output.txt").generic_string();
     TestShell shell;
-    shell("echo hello > /tmp/endo_test_output.txt");
+    shell(std::format("echo hello > {}", outputPath));
     // Read the file to verify content
-    std::ifstream file("/tmp/endo_test_output.txt");
+    std::ifstream file(outputPath);
     std::string content;
     std::getline(file, content);
     CHECK(content == "hello");
-    std::error_code ec;
-    std::filesystem::remove("/tmp/endo_test_output.txt", ec);
 }
 
 TEST_CASE("shell.redirect.output_append")
 {
+    auto const tempDir = endo::testing::ScopedTempDir { "endo_shell_test" };
+    auto const appendPath = (tempDir / "append.txt").generic_string();
     TestShell shell;
     // Create initial file
-    shell("echo line1 > /tmp/endo_test_append.txt");
+    shell(std::format("echo line1 > {}", appendPath));
     // Append to it
-    shell("echo line2 >> /tmp/endo_test_append.txt");
+    shell(std::format("echo line2 >> {}", appendPath));
     // Verify both lines present
-    std::ifstream file("/tmp/endo_test_append.txt");
+    std::ifstream file(appendPath);
     auto line1 = std::string {};
     auto line2 = std::string {};
     std::getline(file, line1);
     std::getline(file, line2);
     CHECK(line1 == "line1");
     CHECK(line2 == "line2");
-    std::error_code ec;
-    std::filesystem::remove("/tmp/endo_test_append.txt", ec);
 }
 
 TEST_CASE("shell.redirect.input_from_file")
 {
+    auto const tempDir = endo::testing::ScopedTempDir { "endo_shell_test" };
+    auto const inputPath = (tempDir / "input.txt").generic_string();
     TestShell shell;
     // Create test file (binary mode to avoid \r\n on Windows)
     {
-        std::ofstream file("/tmp/endo_test_input.txt", std::ios::binary);
+        std::ofstream file(inputPath, std::ios::binary);
         file << "test input content\n";
     }
     // Use cat to read from file via redirect
-    CHECK(escape(shell("cat < /tmp/endo_test_input.txt").output()) == escape("test input content\n"));
-    std::error_code ec;
-    std::filesystem::remove("/tmp/endo_test_input.txt", ec);
+    CHECK(escape(shell(std::format("cat < {}", inputPath)).output()) == escape("test input content\n"));
 }
 
 // ============================================================================
@@ -2165,7 +2152,8 @@ TEST_CASE("shell.redirect.stderr_to_stdout")
 TEST_CASE("shell.redirect.fd_to_file")
 {
     TestShell shell;
-    auto const tmpFile = std::filesystem::temp_directory_path() / "endo_test_stderr.txt";
+    auto const tmpDir = endo::testing::ScopedTempDir { "endo_test_stderr" };
+    auto const tmpFile = tmpDir / "stderr.txt";
     auto const tmpFileStr = tmpFile.generic_string();
     // Redirect stderr (fd 2) to a file
 #if defined(_WIN32)
@@ -2178,8 +2166,6 @@ TEST_CASE("shell.redirect.fd_to_file")
     std::string content;
     std::getline(file, content);
     CHECK(!content.empty()); // Should contain error message
-    std::error_code ec;
-    std::filesystem::remove(tmpFile, ec);
 }
 
 // ============================================================================
@@ -2188,22 +2174,22 @@ TEST_CASE("shell.redirect.fd_to_file")
 
 TEST_CASE("shell.redirect.multiple_redirects")
 {
+    auto const tempDir = endo::testing::ScopedTempDir { "endo_shell_test" };
+    auto const multiInPath = (tempDir / "in.txt").generic_string();
+    auto const multiOutPath = (tempDir / "out.txt").generic_string();
     TestShell shell;
     // Create input file (binary mode to avoid \r\n on Windows)
     {
-        std::ofstream file("/tmp/endo_test_multi_in.txt", std::ios::binary);
+        std::ofstream file(multiInPath, std::ios::binary);
         file << "input text\n";
     }
     // Redirect both input and output
-    shell("cat < /tmp/endo_test_multi_in.txt > /tmp/endo_test_multi_out.txt");
+    shell(std::format("cat < {} > {}", multiInPath, multiOutPath));
     // Verify output
-    std::ifstream file("/tmp/endo_test_multi_out.txt");
+    std::ifstream file(multiOutPath);
     std::string content;
     std::getline(file, content);
     CHECK(content == "input text");
-    std::error_code ec;
-    std::filesystem::remove("/tmp/endo_test_multi_in.txt", ec);
-    std::filesystem::remove("/tmp/endo_test_multi_out.txt", ec);
 }
 
 // ============================================================================
@@ -2390,12 +2376,13 @@ TEST_CASE("shell.subst.process_read_basic")
 
 TEST_CASE("shell.subst.process_read_multiple_lines")
 {
+    auto const tempDir = endo::testing::ScopedTempDir { "endo_shell_test" };
+    auto const procSubstPath = (tempDir / "procsubst.txt").generic_string();
     // Process substitution with multiple lines
     TestShell shell;
-    shell("echo line1 > /tmp/endo_test_procsubst.txt");
-    shell("echo line2 >> /tmp/endo_test_procsubst.txt");
-    CHECK(escape(shell("cat <(cat /tmp/endo_test_procsubst.txt)").output()) == escape("line1\nline2\n"));
-    std::filesystem::remove("/tmp/endo_test_procsubst.txt");
+    shell(std::format("echo line1 > {}", procSubstPath));
+    shell(std::format("echo line2 >> {}", procSubstPath));
+    CHECK(escape(shell(std::format("cat <(cat {})", procSubstPath)).output()) == escape("line1\nline2\n"));
 }
 #endif
 
@@ -2668,17 +2655,18 @@ TEST_CASE("shell.expand.param_remove_suffix_long")
 
 TEST_CASE("shell.expand.glob_star")
 {
+    auto const globDirGuard = endo::testing::ScopedTempDir { "endo_glob" };
+    auto const globDir = globDirGuard.string();
     // *.txt should match .txt files in current directory
-    // We use /tmp to create test files
     TestShell shell;
 
     // Create test files
-    shell("echo test > /tmp/glob_test_a.txt");
-    shell("echo test > /tmp/glob_test_b.txt");
-    shell("echo test > /tmp/glob_test_c.log");
+    shell(std::format("echo test > {}/glob_test_a.txt", globDir));
+    shell(std::format("echo test > {}/glob_test_b.txt", globDir));
+    shell(std::format("echo test > {}/glob_test_c.log", globDir));
 
     // Run glob expansion
-    auto result = shell("echo /tmp/glob_test_*.txt").output();
+    auto result = shell(std::format("echo {}/glob_test_*.txt", globDir)).output();
 
     // Should contain both .txt files but not the .log file
     CHECK(result.find("glob_test_a.txt") != std::string::npos);
@@ -2686,43 +2674,47 @@ TEST_CASE("shell.expand.glob_star")
     CHECK(result.find("glob_test_c.log") == std::string::npos);
 
     // Cleanup
-    shell("rm /tmp/glob_test_*.txt /tmp/glob_test_*.log");
+    shell(std::format("rm {}/glob_test_*.txt {}/glob_test_*.log", globDir, globDir));
 }
 
 TEST_CASE("shell.expand.glob_question")
 {
+    auto const globDirGuard = endo::testing::ScopedTempDir { "endo_glob" };
+    auto const globDir = globDirGuard.string();
     // ? matches single character
     TestShell shell;
 
     // Create test files
-    shell("echo test > /tmp/glob_qtest_a.txt");
-    shell("echo test > /tmp/glob_qtest_b.txt");
-    shell("echo test > /tmp/glob_qtest_aa.txt");
+    shell(std::format("echo test > {}/glob_qtest_a.txt", globDir));
+    shell(std::format("echo test > {}/glob_qtest_b.txt", globDir));
+    shell(std::format("echo test > {}/glob_qtest_aa.txt", globDir));
 
     // Run glob expansion - should match single character only
-    auto result = shell("echo /tmp/glob_qtest_?.txt").output();
+    auto result = shell(std::format("echo {}/glob_qtest_?.txt", globDir)).output();
 
     CHECK(result.find("glob_qtest_a.txt") != std::string::npos);
     CHECK(result.find("glob_qtest_b.txt") != std::string::npos);
     CHECK(result.find("glob_qtest_aa.txt") == std::string::npos);
 
     // Cleanup
-    shell("rm /tmp/glob_qtest_*.txt");
+    shell(std::format("rm {}/glob_qtest_*.txt", globDir));
 }
 
 TEST_CASE("shell.expand.glob_bracket")
 {
+    auto const globDirGuard = endo::testing::ScopedTempDir { "endo_glob" };
+    auto const globDir = globDirGuard.string();
     // [abc] matches any character in set
     TestShell shell;
 
     // Create test files
-    shell("echo test > /tmp/glob_btest_a.txt");
-    shell("echo test > /tmp/glob_btest_b.txt");
-    shell("echo test > /tmp/glob_btest_c.txt");
-    shell("echo test > /tmp/glob_btest_d.txt");
+    shell(std::format("echo test > {}/glob_btest_a.txt", globDir));
+    shell(std::format("echo test > {}/glob_btest_b.txt", globDir));
+    shell(std::format("echo test > {}/glob_btest_c.txt", globDir));
+    shell(std::format("echo test > {}/glob_btest_d.txt", globDir));
 
     // Run glob expansion - should match a, b, c but not d
-    auto result = shell("echo /tmp/glob_btest_[abc].txt").output();
+    auto result = shell(std::format("echo {}/glob_btest_[abc].txt", globDir)).output();
 
     CHECK(result.find("glob_btest_a.txt") != std::string::npos);
     CHECK(result.find("glob_btest_b.txt") != std::string::npos);
@@ -2730,7 +2722,7 @@ TEST_CASE("shell.expand.glob_bracket")
     CHECK(result.find("glob_btest_d.txt") == std::string::npos);
 
     // Cleanup
-    shell("rm /tmp/glob_btest_*.txt");
+    shell(std::format("rm {}/glob_btest_*.txt", globDir));
 }
 
 TEST_CASE("shell.expand.glob_no_match")
@@ -2743,17 +2735,19 @@ TEST_CASE("shell.expand.glob_no_match")
 
 TEST_CASE("shell.expand.glob_bracket_range")
 {
+    auto const globDirGuard = endo::testing::ScopedTempDir { "endo_glob" };
+    auto const globDir = globDirGuard.string();
     // [a-z] matches a range of characters
     TestShell shell;
 
     // Create test files with letters
-    shell("echo test > /tmp/glob_rtest_a.txt");
-    shell("echo test > /tmp/glob_rtest_c.txt");
-    shell("echo test > /tmp/glob_rtest_z.txt");
-    shell("echo test > /tmp/glob_rtest_1.txt");
+    shell(std::format("echo test > {}/glob_rtest_a.txt", globDir));
+    shell(std::format("echo test > {}/glob_rtest_c.txt", globDir));
+    shell(std::format("echo test > {}/glob_rtest_z.txt", globDir));
+    shell(std::format("echo test > {}/glob_rtest_1.txt", globDir));
 
     // Run glob expansion - should match a, c, z but not 1
-    auto result = shell("echo /tmp/glob_rtest_[a-z].txt").output();
+    auto result = shell(std::format("echo {}/glob_rtest_[a-z].txt", globDir)).output();
 
     CHECK(result.find("glob_rtest_a.txt") != std::string::npos);
     CHECK(result.find("glob_rtest_c.txt") != std::string::npos);
@@ -2761,23 +2755,25 @@ TEST_CASE("shell.expand.glob_bracket_range")
     CHECK(result.find("glob_rtest_1.txt") == std::string::npos);
 
     // Cleanup
-    shell("rm /tmp/glob_rtest_*.txt");
+    shell(std::format("rm {}/glob_rtest_*.txt", globDir));
 }
 
 TEST_CASE("shell.expand.glob_recursive_starstar")
 {
+    auto const globDirGuard = endo::testing::ScopedTempDir { "endo_glob" };
+    auto const globDir = globDirGuard.string();
     // ** matches files recursively
     TestShell shell;
 
     // Create directory structure
-    shell("mkdir -p /tmp/glob_rec_test/sub1/sub2");
-    shell("echo test > /tmp/glob_rec_test/file1.cpp");
-    shell("echo test > /tmp/glob_rec_test/sub1/file2.cpp");
-    shell("echo test > /tmp/glob_rec_test/sub1/sub2/file3.cpp");
-    shell("echo test > /tmp/glob_rec_test/file4.txt");
+    shell(std::format("mkdir -p {}/glob_rec_test/sub1/sub2", globDir));
+    shell(std::format("echo test > {}/glob_rec_test/file1.cpp", globDir));
+    shell(std::format("echo test > {}/glob_rec_test/sub1/file2.cpp", globDir));
+    shell(std::format("echo test > {}/glob_rec_test/sub1/sub2/file3.cpp", globDir));
+    shell(std::format("echo test > {}/glob_rec_test/file4.txt", globDir));
 
     // Run recursive glob expansion
-    auto result = shell("echo /tmp/glob_rec_test/**/*.cpp").output();
+    auto result = shell(std::format("echo {}/glob_rec_test/**/*.cpp", globDir)).output();
 
     // Should find all .cpp files recursively
     CHECK(result.find("file1.cpp") != std::string::npos);
@@ -2786,7 +2782,7 @@ TEST_CASE("shell.expand.glob_recursive_starstar")
     CHECK(result.find("file4.txt") == std::string::npos);
 
     // Cleanup
-    shell("rm -rf /tmp/glob_rec_test");
+    shell(std::format("rm -rf {}/glob_rec_test", globDir));
 }
 
 // ========================================================================
@@ -2978,13 +2974,13 @@ TEST_CASE("shell.jobs.wait_with_job_id")
 TEST_CASE("FileCompleter.prefix_match_scores_higher_than_fuzzy")
 {
     // Create a temporary directory with "src" and "scripts" subdirectories
-    auto tempDir = std::filesystem::temp_directory_path() / "endo_test_completion";
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_test_completion" };
+    auto const& tempDir = tempDirGuard.path();
     std::filesystem::create_directories(tempDir / "src");
     std::filesystem::create_directories(tempDir / "scripts");
 
     // Change to the temp directory for testing
-    auto originalDir = std::filesystem::current_path();
-    std::filesystem::current_path(tempDir);
+    auto const scopedCwd = endo::testing::ScopedWorkingDirectory { tempDir };
 
     endo::TestEnvironment env;
     endo::FileCompleter completer(env);
@@ -2998,10 +2994,6 @@ TEST_CASE("FileCompleter.prefix_match_scores_higher_than_fuzzy")
     };
 
     auto results = completer.complete(context);
-
-    // Clean up
-    std::filesystem::current_path(originalDir);
-    std::filesystem::remove_all(tempDir);
 
     // Verify results
     REQUIRE(results.size() == 2);
@@ -3026,14 +3018,14 @@ TEST_CASE("FileCompleter.relative_prefix_stays_relative")
     // Regression: a relative nested prefix (e.g. "sub/it") must keep its relative
     // form in the completion. On Windows, canonicalizing the parent directory would
     // resolve it to an absolute path and rewrite the user's typed relative prefix.
-    auto const tempDir = std::filesystem::temp_directory_path() / "endo_rel_completion";
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_rel_completion" };
+    auto const& tempDir = tempDirGuard.path();
     std::filesystem::create_directories(tempDir / "sub");
     {
         std::ofstream(tempDir / "sub" / "item.txt");
     }
 
-    auto const originalDir = std::filesystem::current_path();
-    std::filesystem::current_path(tempDir);
+    auto const scopedCwd = endo::testing::ScopedWorkingDirectory { tempDir };
 
     endo::TestEnvironment env;
     endo::FileCompleter completer(env);
@@ -3046,9 +3038,6 @@ TEST_CASE("FileCompleter.relative_prefix_stays_relative")
     };
     auto const results = completer.complete(context);
 
-    std::filesystem::current_path(originalDir);
-    std::filesystem::remove_all(tempDir);
-
     REQUIRE(results.size() == 1);
     CHECK(results[0].text == "sub/item.txt"); // Relative, not an absolute path.
 }
@@ -3059,8 +3048,8 @@ TEST_CASE("FileCompleter.absolute_directory_corrects_case")
     // On case-insensitive filesystems, completing an absolute directory typed in the
     // wrong case must echo the on-disk capitalization (".../foo" -> ".../Foo/") rather
     // than the case the user typed.
-    auto const tempDir = std::filesystem::temp_directory_path() / "endo_case_completion";
-    std::filesystem::remove_all(tempDir);
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_case_completion" };
+    auto const& tempDir = tempDirGuard.path();
     std::filesystem::create_directories(tempDir / "Foo");
 
     endo::TestEnvironment env;
@@ -3076,8 +3065,6 @@ TEST_CASE("FileCompleter.absolute_directory_corrects_case")
     };
     auto const results = completer.complete(context);
 
-    std::filesystem::remove_all(tempDir);
-
     REQUIRE(results.size() == 1);
     CHECK(results[0].displayText == "Foo/");
     CHECK(results[0].text.ends_with("/Foo/"));
@@ -3089,8 +3076,8 @@ TEST_CASE("FileCompleter.partial_prefix_corrects_case")
     // A partial directory name typed in the wrong case (even with leading upper-case,
     // which would otherwise trigger smart-case) must still match and recase on a
     // case-insensitive filesystem (e.g. "Lastrada-to" -> "lastrada-tools/").
-    auto const tempDir = std::filesystem::temp_directory_path() / "endo_partial_case_completion";
-    std::filesystem::remove_all(tempDir);
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_partial_case_completion" };
+    auto const& tempDir = tempDirGuard.path();
     std::filesystem::create_directories(tempDir / "lastrada-tools");
 
     endo::TestEnvironment env;
@@ -3104,8 +3091,6 @@ TEST_CASE("FileCompleter.partial_prefix_corrects_case")
         .fullInput = "cd " + typed,
     };
     auto const results = completer.complete(context);
-
-    std::filesystem::remove_all(tempDir);
 
     REQUIRE(results.size() == 1);
     CHECK(results[0].displayText == "lastrada-tools/");
@@ -3907,8 +3892,8 @@ TEST_CASE("shell.fsharp.fetch.unsupported_protocol")
 TEST_CASE("shell.fsharp.fetch.http_success")
 {
     // Local server returns 200 — fetch should return Ok(filename).
-    auto const tempDir = std::filesystem::temp_directory_path() / "endo_fetch_test";
-    std::filesystem::create_directories(tempDir);
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_fetch_test" };
+    auto const& tempDir = tempDirGuard.path();
 
     auto listener = endo::http::LocalTcpListener {};
     auto const port = listener.start();
@@ -3920,8 +3905,7 @@ TEST_CASE("shell.fsharp.fetch.http_success")
                                "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello");
     });
 
-    auto const prevDir = std::filesystem::current_path();
-    std::filesystem::current_path(tempDir);
+    auto const scopedCwd = endo::testing::ScopedWorkingDirectory { tempDir };
 
     TestShell shell;
     shell.shell.setInteractive(false);
@@ -3931,9 +3915,6 @@ TEST_CASE("shell.fsharp.fetch.http_success")
     serverThread.join();
 
     CHECK(escape(shell.output()) == escape("ok"));
-
-    std::filesystem::current_path(prevDir);
-    std::filesystem::remove_all(tempDir);
 }
 
 TEST_CASE("shell.fsharp.fetch.http_error")
@@ -3974,10 +3955,12 @@ TEST_CASE("shell.exec.program_not_found_exit_code")
 TEST_CASE("shell.exec.program_not_found_does_not_persist_to_history")
 {
     // Invalid commands must not be persisted to history.
-    auto dir = std::filesystem::current_path() / "tmp" / "shell_history_test";
-    std::filesystem::create_directories(dir);
+    // PersistentHistory takes FileSystem const&, so this needs no real directory -- and the
+    // previous one was build-directory-relative, i.e. shared by every run from that tree.
+    auto fs = endo::InMemoryFileSystem {};
+    auto const dir = std::filesystem::path { "/test/history" };
 
-    auto history = endo::PersistentHistory { endo::NativeFileSystem::instance() };
+    auto history = endo::PersistentHistory { fs };
     history.setFilePath(dir / "history.yml");
 
     // Simulate the shell flow: add command, then mark with exit code
@@ -3989,9 +3972,7 @@ TEST_CASE("shell.exec.program_not_found_does_not_persist_to_history")
     CHECK(!history.richEntries().back().persisted); // must remain unpersisted
 
     // Verify it does not survive a roundtrip to disk
-    CHECK(!std::filesystem::exists(dir / "history.yml"));
-
-    std::filesystem::remove_all(dir);
+    CHECK(!fs.exists(dir / "history.yml"));
 }
 
 // ============================================================================
@@ -4214,8 +4195,8 @@ TEST_CASE("shell.builtin.find_not")
 TEST_CASE("shell.builtin.find_empty")
 {
     namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_find_test_empty";
-    fs::remove_all(testDir);
+    auto const testDirGuard = endo::testing::ScopedTempDir { "endo_find_test_empty" };
+    auto const& testDir = testDirGuard.path();
     fs::create_directories(testDir / "emptydir");
     {
         std::ofstream ofs(testDir / "empty.txt");
@@ -4232,8 +4213,6 @@ TEST_CASE("shell.builtin.find_empty")
     CHECK(out.find("empty.txt") != std::string::npos);
     CHECK(out.find("emptydir") != std::string::npos);
     CHECK(out.find("notempty.txt") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.find_print0")
@@ -4393,9 +4372,8 @@ TEST_CASE("shell.builtin.grep_file_no_match_exit_code")
 TEST_CASE("shell.builtin.grep_file_multiple_files")
 {
     namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_grep_test_multi";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
+    auto const testDirGuard = endo::testing::ScopedTempDir { "endo_grep_test_multi" };
+    auto const& testDir = testDirGuard.path();
     auto const file1 = testDir / "a.txt";
     auto const file2 = testDir / "b.txt";
     {
@@ -4410,16 +4388,13 @@ TEST_CASE("shell.builtin.grep_file_multiple_files")
     // With multiple files, filenames should be prefixed
     CHECK(out.find("a.txt:") != std::string::npos);
     CHECK(out.find("b.txt:") != std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.grep_file_with_filename")
 {
     namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_grep_test_Hflag";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
+    auto const testDirGuard = endo::testing::ScopedTempDir { "endo_grep_test_Hflag" };
+    auto const& testDir = testDirGuard.path();
     auto const file1 = testDir / "test.txt";
     {
         std::ofstream(file1) << "hello\n";
@@ -4430,16 +4405,13 @@ TEST_CASE("shell.builtin.grep_file_with_filename")
     CHECK(shell.exitCode == 0);
     auto const out = std::string(shell.output());
     CHECK(out.find("test.txt:") != std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.grep_file_no_filename")
 {
     namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_grep_test_hflag";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
+    auto const testDirGuard = endo::testing::ScopedTempDir { "endo_grep_test_hflag" };
+    auto const& testDir = testDirGuard.path();
     auto const file1 = testDir / "a.txt";
     auto const file2 = testDir / "b.txt";
     {
@@ -4454,16 +4426,13 @@ TEST_CASE("shell.builtin.grep_file_no_filename")
     CHECK(out.find("a.txt:") == std::string::npos);
     CHECK(out.find("b.txt:") == std::string::npos);
     CHECK(out == "hello\nhello\n");
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.grep_files_with_matches")
 {
     namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_grep_test_lflag";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
+    auto const testDirGuard = endo::testing::ScopedTempDir { "endo_grep_test_lflag" };
+    auto const& testDir = testDirGuard.path();
     auto const file1 = testDir / "a.txt";
     auto const file2 = testDir / "b.txt";
     {
@@ -4477,16 +4446,13 @@ TEST_CASE("shell.builtin.grep_files_with_matches")
     auto const out = std::string(shell.output());
     CHECK(out.find("a.txt") != std::string::npos);
     CHECK(out.find("b.txt") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.grep_files_without_match")
 {
     namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_grep_test_Lflag";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
+    auto const testDirGuard = endo::testing::ScopedTempDir { "endo_grep_test_Lflag" };
+    auto const& testDir = testDirGuard.path();
     auto const file1 = testDir / "a.txt";
     auto const file2 = testDir / "b.txt";
     {
@@ -4500,15 +4466,13 @@ TEST_CASE("shell.builtin.grep_files_without_match")
     auto const out = std::string(shell.output());
     CHECK(out.find("a.txt") == std::string::npos);
     CHECK(out.find("b.txt") != std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.grep_recursive")
 {
     namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_grep_test_recursive";
-    fs::remove_all(testDir);
+    auto const testDirGuard = endo::testing::ScopedTempDir { "endo_grep_test_recursive" };
+    auto const& testDir = testDirGuard.path();
     fs::create_directories(testDir / "sub");
     {
         std::ofstream(testDir / "top.txt") << "hello top\n";
@@ -4521,16 +4485,13 @@ TEST_CASE("shell.builtin.grep_recursive")
     auto const out = std::string(shell.output());
     CHECK(out.find("hello top") != std::string::npos);
     CHECK(out.find("hello nested") != std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.grep_recursive_include")
 {
     namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_grep_test_include";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
+    auto const testDirGuard = endo::testing::ScopedTempDir { "endo_grep_test_include" };
+    auto const& testDir = testDirGuard.path();
     {
         std::ofstream(testDir / "a.txt") << "hello\n";
         std::ofstream(testDir / "b.cpp") << "hello\n";
@@ -4542,15 +4503,13 @@ TEST_CASE("shell.builtin.grep_recursive_include")
     auto const out = std::string(shell.output());
     CHECK(out.find("a.txt") != std::string::npos);
     CHECK(out.find("b.cpp") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.grep_recursive_exclude_dir")
 {
     namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_grep_test_exdir";
-    fs::remove_all(testDir);
+    auto const testDirGuard = endo::testing::ScopedTempDir { "endo_grep_test_exdir" };
+    auto const& testDir = testDirGuard.path();
     fs::create_directories(testDir / "src");
     fs::create_directories(testDir / "build");
     {
@@ -4564,16 +4523,13 @@ TEST_CASE("shell.builtin.grep_recursive_exclude_dir")
     auto const out = std::string(shell.output());
     CHECK(out.find("main.cpp") != std::string::npos);
     CHECK(out.find("out.cpp") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.grep_binary_skip")
 {
     namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_grep_test_binary";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
+    auto const testDirGuard = endo::testing::ScopedTempDir { "endo_grep_test_binary" };
+    auto const& testDir = testDirGuard.path();
     auto const binFile = testDir / "binary.bin";
     auto const txtFile = testDir / "text.txt";
     {
@@ -4593,8 +4549,6 @@ TEST_CASE("shell.builtin.grep_binary_skip")
     CHECK(out.find("hello text") != std::string::npos);
     // Binary file should be skipped
     CHECK(out.find("binary.bin") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.grep_line_regexp")
@@ -4658,7 +4612,8 @@ TEST_CASE("shell.builtin.source_env_bat", "[source-env][windows]")
     TestShell shell;
 
     // Create a temp .bat script that sets an environment variable
-    auto const tempDir = std::filesystem::temp_directory_path();
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_source_env" };
+    auto const& tempDir = tempDirGuard.path();
     auto const batPath = tempDir / "endo_test_source_env.bat";
     {
         std::ofstream ofs(batPath);
@@ -4671,15 +4626,14 @@ TEST_CASE("shell.builtin.source_env_bat", "[source-env][windows]")
     INFO("shell output: " << escape(shell.output()));
     CHECK(shell.exitCode == 0);
     CHECK(shell.env.get("ENDO_TEST_SRCENV").value_or("") == "hello_from_bat");
-
-    std::filesystem::remove(batPath);
 }
 
 TEST_CASE("shell.builtin.source_env_bat_with_args", "[source-env][windows]")
 {
     TestShell shell;
 
-    auto const tempDir = std::filesystem::temp_directory_path();
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_source_env" };
+    auto const& tempDir = tempDirGuard.path();
     auto const batPath = tempDir / "endo_test_source_env_args.bat";
     {
         std::ofstream ofs(batPath);
@@ -4691,8 +4645,6 @@ TEST_CASE("shell.builtin.source_env_bat_with_args", "[source-env][windows]")
     shell(cmd);
     CHECK(shell.exitCode == 0);
     CHECK(shell.env.get("ENDO_TEST_ARG").value_or("") == "my_arg_value");
-
-    std::filesystem::remove(batPath);
 }
 #endif
 
@@ -4701,7 +4653,8 @@ TEST_CASE("shell.builtin.source_env_sh", "[source-env][posix]")
 {
     TestShell shell;
 
-    auto const tempDir = std::filesystem::temp_directory_path();
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_source_env" };
+    auto const& tempDir = tempDirGuard.path();
     auto const shPath = tempDir / "endo_test_source_env.sh";
     {
         std::ofstream ofs(shPath);
@@ -4712,15 +4665,14 @@ TEST_CASE("shell.builtin.source_env_sh", "[source-env][posix]")
     shell(cmd);
     CHECK(shell.exitCode == 0);
     CHECK(shell.env.get("ENDO_TEST_SRCENV").value_or("") == "hello_from_sh");
-
-    std::filesystem::remove(shPath);
 }
 
 TEST_CASE("shell.builtin.source_env_sh_with_args", "[source-env][posix]")
 {
     TestShell shell;
 
-    auto const tempDir = std::filesystem::temp_directory_path();
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_source_env" };
+    auto const& tempDir = tempDirGuard.path();
     auto const shPath = tempDir / "endo_test_source_env_args.sh";
     {
         std::ofstream ofs(shPath);
@@ -4731,15 +4683,14 @@ TEST_CASE("shell.builtin.source_env_sh_with_args", "[source-env][posix]")
     shell(cmd);
     CHECK(shell.exitCode == 0);
     CHECK(shell.env.get("ENDO_TEST_ARG").value_or("") == "my_arg_value");
-
-    std::filesystem::remove(shPath);
 }
 
 TEST_CASE("shell.builtin.source_env_bat_rejected_on_posix", "[source-env][posix]")
 {
     TestShell shell;
 
-    auto const tempDir = std::filesystem::temp_directory_path();
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_source_env" };
+    auto const& tempDir = tempDirGuard.path();
     auto const batPath = tempDir / "endo_test_rejected.bat";
     {
         std::ofstream ofs(batPath);
@@ -4749,8 +4700,6 @@ TEST_CASE("shell.builtin.source_env_bat_rejected_on_posix", "[source-env][posix]
     auto const cmd = std::format("source-env \"{}\"", batPath.string());
     shell(cmd);
     CHECK(shell.exitCode == 1);
-
-    std::filesystem::remove(batPath);
 }
 #endif
 
@@ -4765,7 +4714,8 @@ TEST_CASE("shell.builtin.source_env_unknown_extension", "[source-env]")
 {
     TestShell shell;
 
-    auto const tempDir = std::filesystem::temp_directory_path();
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_source_env" };
+    auto const& tempDir = tempDirGuard.path();
     auto const unknownPath = tempDir / "endo_test_source_env.xyz";
     {
         std::ofstream ofs(unknownPath);
@@ -4775,8 +4725,6 @@ TEST_CASE("shell.builtin.source_env_unknown_extension", "[source-env]")
     auto const cmd = std::format("source-env \"{}\"", unknownPath.string());
     shell(cmd);
     CHECK(shell.exitCode == 1);
-
-    std::filesystem::remove(unknownPath);
 }
 
 TEST_CASE("shell.builtin.source_env_preserves_unchanged", "[source-env]")
@@ -4785,7 +4733,8 @@ TEST_CASE("shell.builtin.source_env_preserves_unchanged", "[source-env]")
     shell.env.set("ENDO_TEST_EXISTING", "original_value");
 
 #if defined(_WIN32)
-    auto const tempDir = std::filesystem::temp_directory_path();
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_source_env" };
+    auto const& tempDir = tempDirGuard.path();
     auto const scriptPath = tempDir / "endo_test_source_env_noop.bat";
     {
         std::ofstream ofs(scriptPath);
@@ -4794,7 +4743,8 @@ TEST_CASE("shell.builtin.source_env_preserves_unchanged", "[source-env]")
         ofs << "set ENDO_TEST_NEW=new_value\r\n";
     }
 #else
-    auto const tempDir = std::filesystem::temp_directory_path();
+    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_source_env" };
+    auto const& tempDir = tempDirGuard.path();
     auto const scriptPath = tempDir / "endo_test_source_env_noop.sh";
     {
         std::ofstream ofs(scriptPath);
@@ -4810,8 +4760,6 @@ TEST_CASE("shell.builtin.source_env_preserves_unchanged", "[source-env]")
     CHECK(shell.env.get("ENDO_TEST_EXISTING").value_or("") == "original_value");
     // New variable should be imported
     CHECK(shell.env.get("ENDO_TEST_NEW").value_or("") == "new_value");
-
-    std::filesystem::remove(scriptPath);
 }
 
 // ============================================================================
@@ -4961,12 +4909,17 @@ TEST_CASE("shell.completion.executeCompleterFunction_with_CompletionEntry")
 
 namespace
 {
-/// @brief Writes @p content to a uniquely named file and returns its path.
-auto writeMarkdownFixture(std::string_view name, std::string_view content) -> std::filesystem::path
+/// @brief Writes @p content into @p dir under @p name and returns the file's path.
+///
+/// The directory is the caller's, so its lifetime is visible at the call site: a guard
+/// created here would delete the file before the caller could read it.
+/// @param dir     Directory to write into; must outlive the returned path's use.
+/// @param name    File name to create inside @p dir.
+/// @param content Bytes to write.
+/// @return The path of the written file.
+auto writeMarkdownFixture(std::filesystem::path const& dir, std::string_view name, std::string_view content)
+    -> std::filesystem::path
 {
-    namespace fs = std::filesystem;
-    auto const dir = fs::temp_directory_path() / "endo_cat_markdown";
-    fs::create_directories(dir);
     auto const path = dir / name;
     auto stream = std::ofstream(path, std::ios::binary);
     stream.write(content.data(), static_cast<std::streamsize>(content.size()));
@@ -4978,7 +4931,8 @@ constexpr auto MarkdownFixture = "# Title\n\nSee [Docs](https://endo-lang.org/).
 
 TEST_CASE("shell.builtin.cat_markdown_renders_on_tty")
 {
-    auto const path = writeMarkdownFixture("render.md", MarkdownFixture);
+    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
+    auto const path = writeMarkdownFixture(markdownDir.path(), "render.md", MarkdownFixture);
 
     TestShell shell;
     shell(std::format("cat {}", path.string()));
@@ -5001,7 +4955,8 @@ TEST_CASE("shell.builtin.cat_markdown_renders_on_tty")
 
 TEST_CASE("shell.builtin.cat_markdown_is_indented_by_default")
 {
-    auto const path = writeMarkdownFixture("indent_default.md", "Hello\n"sv);
+    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
+    auto const path = writeMarkdownFixture(markdownDir.path(), "indent_default.md", "Hello\n"sv);
 
     TestShell shell;
     shell(std::format("cat {}", path.string()));
@@ -5015,7 +4970,8 @@ TEST_CASE("shell.builtin.cat_markdown_is_indented_by_default")
 
 TEST_CASE("shell.builtin.cat_markdown_indent_flag_overrides_the_default")
 {
-    auto const path = writeMarkdownFixture("indent_flag.md", "Hello\n"sv);
+    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
+    auto const path = writeMarkdownFixture(markdownDir.path(), "indent_flag.md", "Hello\n"sv);
 
     TestShell shell;
     shell(std::format("cat --indent 5 {}", path.string()));
@@ -5029,7 +4985,8 @@ TEST_CASE("shell.builtin.cat_markdown_indent_flag_overrides_the_default")
 
 TEST_CASE("shell.builtin.cat_markdown_indent_zero_hugs_the_left_edge")
 {
-    auto const path = writeMarkdownFixture("indent_zero.md", "Hello\n"sv);
+    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
+    auto const path = writeMarkdownFixture(markdownDir.path(), "indent_zero.md", "Hello\n"sv);
 
     TestShell shell;
     shell(std::format("cat --indent=0 {}", path.string()));
@@ -5044,7 +5001,8 @@ TEST_CASE("shell.builtin.cat_markdown_indent_zero_hugs_the_left_edge")
 
 TEST_CASE("shell.builtin.cat_indent_rejects_invalid_values")
 {
-    auto const path = writeMarkdownFixture("indent_bad.md", "Hello\n"sv);
+    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
+    auto const path = writeMarkdownFixture(markdownDir.path(), "indent_bad.md", "Hello\n"sv);
 
     TestShell bad;
     bad(std::format("cat --indent abc {}", path.string()));
@@ -5061,7 +5019,8 @@ TEST_CASE("shell.builtin.cat_indent_rejects_invalid_values")
 
 TEST_CASE("shell.builtin.cat_indent_does_not_affect_raw_output")
 {
-    auto const path = writeMarkdownFixture("indent_raw.md", "Hello\n"sv);
+    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
+    auto const path = writeMarkdownFixture(markdownDir.path(), "indent_raw.md", "Hello\n"sv);
 
     TestShell shell;
     shell(std::format("cat --raw --indent 5 {}", path.string()));
@@ -5072,7 +5031,8 @@ TEST_CASE("shell.builtin.cat_indent_does_not_affect_raw_output")
 
 TEST_CASE("shell.builtin.cat_markdown_raw_flag_emits_source_bytes")
 {
-    auto const path = writeMarkdownFixture("raw.md", MarkdownFixture);
+    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
+    auto const path = writeMarkdownFixture(markdownDir.path(), "raw.md", MarkdownFixture);
 
     TestShell shell;
     shell(std::format("cat --raw {}", path.string()));
@@ -5086,7 +5046,8 @@ TEST_CASE("shell.builtin.cat_markdown_raw_flag_emits_source_bytes")
 
 TEST_CASE("shell.builtin.cat_markdown_piped_is_not_rendered")
 {
-    auto const path = writeMarkdownFixture("piped.md", MarkdownFixture);
+    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
+    auto const path = writeMarkdownFixture(markdownDir.path(), "piped.md", MarkdownFixture);
 
     // The first `cat` writes into a pipe, so its output handle is not a terminal.
     TestShell shell;
@@ -5100,7 +5061,8 @@ TEST_CASE("shell.builtin.cat_markdown_piped_is_not_rendered")
 
 TEST_CASE("shell.builtin.cat_markdown_number_flag_shows_source")
 {
-    auto const path = writeMarkdownFixture("numbered.md", MarkdownFixture);
+    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
+    auto const path = writeMarkdownFixture(markdownDir.path(), "numbered.md", MarkdownFixture);
 
     // -n asks for a literal view of the source, so rendering is suppressed.
     TestShell shell;
@@ -5116,7 +5078,8 @@ TEST_CASE("shell.builtin.cat_markdown_number_flag_shows_source")
 TEST_CASE("shell.builtin.cat_markdown_redirect_writes_source_bytes")
 {
     namespace fs = std::filesystem;
-    auto const path = writeMarkdownFixture("redirect.md", MarkdownFixture);
+    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
+    auto const path = writeMarkdownFixture(markdownDir.path(), "redirect.md", MarkdownFixture);
     auto const target = path.parent_path() / "redirect.out";
     fs::remove(target);
 
@@ -5131,7 +5094,8 @@ TEST_CASE("shell.builtin.cat_markdown_redirect_writes_source_bytes")
 
 TEST_CASE("shell.builtin.cat_non_markdown_is_unaffected")
 {
-    auto const path = writeMarkdownFixture("plain.txt", "hello world\n"sv);
+    auto const markdownDir = endo::testing::ScopedTempDir { "endo_cat_markdown" };
+    auto const path = writeMarkdownFixture(markdownDir.path(), "plain.txt", "hello world\n"sv);
 
     TestShell shell;
     shell(std::format("cat {}", path.string()));
@@ -5147,16 +5111,15 @@ TEST_CASE("shell.builtin.cat_non_markdown_is_unaffected")
 namespace
 {
 
-/// @brief Creates a directory with known entries and returns its path.
+/// @brief Populates @p dir with the entries the ls link tests inspect, and returns it.
 ///
 /// `structured_ls` reads the real filesystem (it constructs the platform provider directly
 /// rather than taking the injected FileSystem), so an ls test needs real files.
-auto writeLsFixture(std::string_view caseName) -> std::filesystem::path
+/// @param dir Directory to populate; must outlive the returned path's use.
+/// @return @p dir, so call sites can chain.
+auto writeLsFixture(std::filesystem::path const& dir) -> std::filesystem::path
 {
     namespace fs = std::filesystem;
-    // Per-case directory so the three ls cases cannot observe each other's entries.
-    auto const dir = fs::temp_directory_path() / std::format("endo_ls_links_{}", caseName);
-    fs::remove_all(dir);
     fs::create_directories(dir / "subdir");
     auto plain = std::ofstream(dir / "plain.txt", std::ios::binary);
     plain << "x";
@@ -5169,7 +5132,8 @@ auto writeLsFixture(std::string_view caseName) -> std::filesystem::path
 
 TEST_CASE("shell.builtin.ls_emits_osc8_hyperlinks_on_tty")
 {
-    auto const dir = writeLsFixture("emits");
+    auto const lsDir = endo::testing::ScopedTempDir { "endo_ls_links_emits" };
+    auto const dir = writeLsFixture(lsDir.path());
 
     TestShell shell;
     shell(std::format("ls {}", dir.string()));
@@ -5191,7 +5155,8 @@ TEST_CASE("shell.builtin.ls_emits_osc8_hyperlinks_on_tty")
 
 TEST_CASE("shell.builtin.ls_hyperlinks_can_be_disabled")
 {
-    auto const dir = writeLsFixture("disabled");
+    auto const lsDir = endo::testing::ScopedTempDir { "endo_ls_links_disabled" };
+    auto const dir = writeLsFixture(lsDir.path());
 
     TestShell shell;
     shell("shell_hyperlinks <- false");
@@ -5209,7 +5174,8 @@ TEST_CASE("shell.builtin.ls_hyperlinks_can_be_disabled")
 TEST_CASE("shell.builtin.ls_hyperlinks_survive_a_filtered_pipeline")
 {
     // The URI comes from each record, so it stays correct after the listing is reshaped.
-    auto const dir = writeLsFixture("filtered");
+    auto const lsDir = endo::testing::ScopedTempDir { "endo_ls_links_filtered" };
+    auto const dir = writeLsFixture(lsDir.path());
 
     TestShell shell;
     shell(std::format("ls {} |> filter _.isDir", dir.string()));

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -34,6 +34,7 @@ using crispy::escape;
 #include "TTY.hpp"
 #include <platform/InstallPaths.hpp>
 #include <platform/NativeFileSystem.hpp>
+#include <platform/testing/InMemoryFileSystem.hpp>
 #include <platform/testing/TestEnvironmentProvider.hpp>
 
 namespace
@@ -70,6 +71,65 @@ struct TestShell
         return *this;
     }
 };
+
+/// @brief A shell whose filesystem is private to the test case.
+///
+/// Builtins reach the filesystem through Shell's injected FileSystem, so pointing that at
+/// an in-memory implementation gives each test a private tree with nothing to clean up.
+/// This mirrors the wiring endo-test uses for `# mode: shell` tests
+/// (src/endo-test/TestExecutor.cpp).
+///
+/// Not usable by every test. A builtin whose output travels through a real file descriptor
+/// -- a redirection target, or anything inherited by a forked child -- cannot see this
+/// filesystem, because a child process cannot read an in-memory file through an fd. Those
+/// tests keep using TestShell and the real filesystem.
+///
+/// The in-memory model is also deliberately shallow in places: lastWriteTime() always
+/// reports "now", weaklyCanonical() never resolves symlinks, symlinks are metadata only,
+/// and permissions are not enforced beyond denyAccess(). A test whose assertion depends on
+/// any of those would pass vacuously here and belongs on TestShell.
+struct InMemoryShell
+{
+    endo::TestPTY pty;
+    endo::InMemoryFileSystem fs;
+    endo::TestEnvironment env { "/test" };
+    int exitCode = -1;
+
+    endo::Shell shell { pty, env, fs };
+
+    std::string output() const { return pty.output(); }
+
+    InMemoryShell()
+    {
+        fs.addDirectory("/test");
+        // Keep the filesystem's idea of the working directory in step with the
+        // environment's, so a relative path resolves the same way through both.
+        fs.setCurrentPath("/test");
+        env.set("HOME", "/test/home");
+        env.set("PWD", "/test");
+        shell.addModuleSearchPath("/test");
+        // Never probe the test PTY for Sixel support: the query would leak escape bytes
+        // into the captured output and stall on timeout.
+        shell.setSixelCapability(std::make_unique<endo::StaticSixelCapability>(false));
+    }
+
+    InMemoryShell& operator()(std::string_view cmd)
+    {
+        exitCode = shell.execute(std::string(cmd));
+        return *this;
+    }
+
+    /// @brief Returns a file's entire contents, or an empty string if it cannot be read.
+    ///
+    /// Whole contents rather than the first line: the fixtures these assertions replaced
+    /// used std::getline only because std::ifstream made that the easy call, so truncating
+    /// here would let a copy that dropped everything after the first newline pass.
+    [[nodiscard]] std::string content(std::filesystem::path const& path) const
+    {
+        return fs.readFile(path).value_or(std::string {});
+    }
+};
+
 } // namespace
 
 // ============================================================================
@@ -1086,22 +1146,16 @@ TEST_CASE("shell.builtin.rm_help")
 
 TEST_CASE("shell.builtin.rm_file")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_rm_test_file";
-    fs::create_directories(testDir);
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/rm_file");
+    shell.fs.addDirectory(testDir);
     auto const filePath = testDir / "testfile.txt";
-    {
-        std::ofstream ofs(filePath);
-        ofs << "hello";
-    }
-    REQUIRE(fs::exists(filePath));
+    shell.fs.addFile(filePath, "hello");
+    REQUIRE(shell.fs.exists(filePath));
 
-    TestShell shell;
     shell(std::format("rm {}", filePath.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(!fs::exists(filePath));
-
-    fs::remove_all(testDir);
+    CHECK(!shell.fs.exists(filePath));
 }
 
 TEST_CASE("shell.builtin.rm_nonexistent")
@@ -1120,84 +1174,64 @@ TEST_CASE("shell.builtin.rm_force_nonexistent")
 
 TEST_CASE("shell.builtin.rm_directory_without_recursive")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_rm_test_dir_norec";
-    fs::create_directories(testDir);
-    REQUIRE(fs::exists(testDir));
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/rm_dir_norec");
+    shell.fs.addDirectory(testDir);
+    REQUIRE(shell.fs.exists(testDir));
 
-    TestShell shell;
     shell(std::format("rm {}", testDir.string()));
     CHECK(shell.exitCode == 1);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.rm_recursive")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_rm_test_recursive";
-    fs::create_directories(testDir / "subdir");
-    {
-        std::ofstream ofs(testDir / "subdir" / "file.txt");
-        ofs << "data";
-    }
-    REQUIRE(fs::exists(testDir / "subdir" / "file.txt"));
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/rm_recursive");
+    shell.fs.addFile(testDir / "subdir" / "file.txt", "data");
+    REQUIRE(shell.fs.exists(testDir / "subdir" / "file.txt"));
 
-    TestShell shell;
     shell(std::format("rm -r {}", testDir.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(!fs::exists(testDir));
+    CHECK(!shell.fs.exists(testDir));
 }
 
 TEST_CASE("shell.builtin.rm_dir_flag")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_rm_test_emptydir";
-    fs::create_directories(testDir);
-    REQUIRE(fs::exists(testDir));
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/rm_emptydir");
+    shell.fs.addDirectory(testDir);
+    REQUIRE(shell.fs.exists(testDir));
 
-    TestShell shell;
     shell(std::format("rm -d {}", testDir.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(!fs::exists(testDir));
+    CHECK(!shell.fs.exists(testDir));
 }
 
 TEST_CASE("shell.builtin.rm_verbose")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_rm_test_verbose";
-    fs::create_directories(testDir);
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/rm_verbose");
+    shell.fs.addDirectory(testDir);
     auto const filePath = testDir / "verbose_file.txt";
-    {
-        std::ofstream ofs(filePath);
-        ofs << "data";
-    }
-    REQUIRE(fs::exists(filePath));
+    shell.fs.addFile(filePath, "data");
+    REQUIRE(shell.fs.exists(filePath));
 
-    TestShell shell;
     auto output = shell(std::format("rm -v {}", filePath.string())).output();
     CHECK(shell.exitCode == 0);
     CHECK(output.find("removed") != std::string::npos);
-    CHECK(!fs::exists(filePath));
-
-    fs::remove_all(testDir);
+    CHECK(!shell.fs.exists(filePath));
 }
 
 TEST_CASE("shell.builtin.rm_verbose_recursive")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_rm_test_verbose_recursive";
-    fs::create_directories(testDir / "subdir");
-    {
-        std::ofstream ofs(testDir / "subdir" / "file.txt");
-        ofs << "data";
-    }
-    REQUIRE(fs::exists(testDir / "subdir" / "file.txt"));
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/rm_verbose_recursive");
+    shell.fs.addFile(testDir / "subdir" / "file.txt", "data");
+    REQUIRE(shell.fs.exists(testDir / "subdir" / "file.txt"));
 
-    TestShell shell;
     auto output = shell(std::format("rm -vr {}", testDir.string())).output();
     CHECK(shell.exitCode == 0);
-    CHECK(!fs::exists(testDir));
+    CHECK(!shell.fs.exists(testDir));
 
     // Should list each removed entry (file, subdir, top-level dir)
     auto const lines = std::count(output.begin(), output.end(), '\n');
@@ -1208,39 +1242,28 @@ TEST_CASE("shell.builtin.rm_verbose_recursive")
 
 TEST_CASE("shell.builtin.rm_combined_flags")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_rm_test_combined";
-    fs::create_directories(testDir / "inner");
-    {
-        std::ofstream ofs(testDir / "inner" / "f.txt");
-        ofs << "x";
-    }
-    REQUIRE(fs::exists(testDir / "inner" / "f.txt"));
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/rm_combined");
+    shell.fs.addFile(testDir / "inner" / "f.txt", "x");
+    REQUIRE(shell.fs.exists(testDir / "inner" / "f.txt"));
 
-    TestShell shell;
     shell(std::format("rm -rf {}", testDir.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(!fs::exists(testDir));
+    CHECK(!shell.fs.exists(testDir));
 }
 
 TEST_CASE("shell.builtin.rm_double_dash")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_rm_test_ddash";
-    fs::create_directories(testDir);
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/rm_ddash");
+    shell.fs.addDirectory(testDir);
     auto const filePath = testDir / "-weirdname";
-    {
-        std::ofstream ofs(filePath);
-        ofs << "data";
-    }
-    REQUIRE(fs::exists(filePath));
+    shell.fs.addFile(filePath, "data");
+    REQUIRE(shell.fs.exists(filePath));
 
-    TestShell shell;
     shell(std::format("rm -- {}", filePath.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(!fs::exists(filePath));
-
-    fs::remove_all(testDir);
+    CHECK(!shell.fs.exists(filePath));
 }
 
 TEST_CASE("shell.builtin.rm_preserve_root")
@@ -1279,72 +1302,54 @@ TEST_CASE("shell.builtin.mkdir_help")
 
 TEST_CASE("shell.builtin.mkdir_basic")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_mkdir_test_basic";
-    fs::remove_all(testDir); // ensure clean state
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/mkdir_basic");
 
-    TestShell shell;
     shell(std::format("mkdir {}", testDir.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(fs::is_directory(testDir));
-
-    fs::remove_all(testDir);
+    CHECK(shell.fs.isDirectory(testDir));
 }
 
 TEST_CASE("shell.builtin.mkdir_already_exists")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_mkdir_test_exists";
-    fs::create_directories(testDir);
-    REQUIRE(fs::exists(testDir));
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/mkdir_exists");
+    shell.fs.addDirectory(testDir);
+    REQUIRE(shell.fs.exists(testDir));
 
-    TestShell shell;
     shell(std::format("mkdir {}", testDir.string()));
     CHECK(shell.exitCode == 1);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.mkdir_parents")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_mkdir_test_parents" / "a" / "b" / "c";
-    fs::remove_all(fs::temp_directory_path() / "endo_mkdir_test_parents");
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/mkdir_parents") / "a" / "b" / "c";
 
-    TestShell shell;
     shell(std::format("mkdir -p {}", testDir.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(fs::is_directory(testDir));
-
-    fs::remove_all(fs::temp_directory_path() / "endo_mkdir_test_parents");
+    CHECK(shell.fs.isDirectory(testDir));
 }
 
 TEST_CASE("shell.builtin.mkdir_parents_long")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_mkdir_test_parents_long" / "x" / "y";
-    fs::remove_all(fs::temp_directory_path() / "endo_mkdir_test_parents_long");
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/mkdir_parents_long") / "x" / "y";
 
-    TestShell shell;
     shell(std::format("mkdir --parents {}", testDir.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(fs::is_directory(testDir));
-
-    fs::remove_all(fs::temp_directory_path() / "endo_mkdir_test_parents_long");
+    CHECK(shell.fs.isDirectory(testDir));
 }
 
 TEST_CASE("shell.builtin.mkdir_parents_existing")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_mkdir_test_parents_exist";
-    fs::create_directories(testDir);
-    REQUIRE(fs::exists(testDir));
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/mkdir_parents_exist");
+    shell.fs.addDirectory(testDir);
+    REQUIRE(shell.fs.exists(testDir));
 
-    TestShell shell;
     shell(std::format("mkdir -p {}", testDir.string()));
     CHECK(shell.exitCode == 0);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.mkdir_no_operand")
@@ -1356,67 +1361,51 @@ TEST_CASE("shell.builtin.mkdir_no_operand")
 
 TEST_CASE("shell.builtin.mkdir_verbose")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_mkdir_test_verbose";
-    fs::remove_all(testDir);
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/mkdir_verbose");
 
-    TestShell shell;
     auto output = shell(std::format("mkdir -v {}", testDir.string())).output();
     CHECK(shell.exitCode == 0);
     CHECK(output.find("created directory") != std::string::npos);
-    CHECK(fs::is_directory(testDir));
-
-    fs::remove_all(testDir);
+    CHECK(shell.fs.isDirectory(testDir));
 }
 
 TEST_CASE("shell.builtin.mkdir_combined_flags")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_mkdir_test_combined" / "sub";
-    fs::remove_all(fs::temp_directory_path() / "endo_mkdir_test_combined");
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/mkdir_combined") / "sub";
 
-    TestShell shell;
     auto output = shell(std::format("mkdir -pv {}", testDir.string())).output();
     CHECK(shell.exitCode == 0);
-    CHECK(fs::is_directory(testDir));
+    CHECK(shell.fs.isDirectory(testDir));
     CHECK(output.find("created directory") != std::string::npos);
-
-    fs::remove_all(fs::temp_directory_path() / "endo_mkdir_test_combined");
 }
 
 TEST_CASE("shell.builtin.mkdir_double_dash")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_mkdir_test_ddash" / "-weirdname";
-    fs::remove_all(fs::temp_directory_path() / "endo_mkdir_test_ddash");
-    fs::create_directories(fs::temp_directory_path() / "endo_mkdir_test_ddash");
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/mkdir_ddash") / "-weirdname";
+    shell.fs.addDirectory(std::filesystem::path("/test/mkdir_ddash"));
 
-    TestShell shell;
     shell(std::format("mkdir -- {}", testDir.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(fs::is_directory(testDir));
-
-    fs::remove_all(fs::temp_directory_path() / "endo_mkdir_test_ddash");
+    CHECK(shell.fs.isDirectory(testDir));
 }
 
 TEST_CASE("shell.builtin.mkdir_multiple_dirs")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mkdir_test_multi";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/mkdir_multi");
+    shell.fs.addDirectory(base);
     auto const dir1 = base / "dir1";
     auto const dir2 = base / "dir2";
     auto const dir3 = base / "dir3";
 
-    TestShell shell;
     shell(std::format("mkdir {} {} {}", dir1.string(), dir2.string(), dir3.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(fs::is_directory(dir1));
-    CHECK(fs::is_directory(dir2));
-    CHECK(fs::is_directory(dir3));
-
-    fs::remove_all(base);
+    CHECK(shell.fs.isDirectory(dir1));
+    CHECK(shell.fs.isDirectory(dir2));
+    CHECK(shell.fs.isDirectory(dir3));
 }
 
 // ============================================================================
@@ -1434,312 +1423,186 @@ TEST_CASE("shell.builtin.cp_help")
 
 TEST_CASE("shell.builtin.cp_single_file")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_single";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_single");
+    shell.fs.addDirectory(base);
     auto const src = base / "source.txt";
     auto const dst = base / "dest.txt";
 
     // Create source file with content
-    {
-        std::ofstream ofs(src);
-        ofs << "hello world";
-    }
+    shell.fs.addFile(src, "hello world");
 
-    TestShell shell;
     shell(std::format("cp {} {}", src.string(), dst.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(fs::exists(dst));
+    CHECK(shell.fs.exists(dst));
 
     // Verify content
-    {
-        std::ifstream ifs(dst);
-        std::string content;
-        std::getline(ifs, content);
-        CHECK(content == "hello world");
-    }
-
-    fs::remove_all(base);
+    CHECK(shell.content(dst) == "hello world");
 }
 
 TEST_CASE("shell.builtin.cp_nonexistent_source")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_noexist";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_noexist");
+    shell.fs.addDirectory(base);
 
-    TestShell shell;
     shell(std::format("cp {}/nosuchfile {}/dest", base.string(), base.string()));
     CHECK(shell.exitCode == 1);
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("shell.builtin.cp_overwrite_default")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_overwrite";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_overwrite");
+    shell.fs.addDirectory(base);
     auto const src = base / "source.txt";
     auto const dst = base / "dest.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "new content";
-    }
-    {
-        std::ofstream ofs(dst);
-        ofs << "old content";
-    }
+    shell.fs.addFile(src, "new content");
+    shell.fs.addFile(dst, "old content");
 
-    TestShell shell;
     shell(std::format("cp {} {}", src.string(), dst.string()));
     CHECK(shell.exitCode == 0);
 
-    {
-        std::ifstream ifs(dst);
-        std::string content;
-        std::getline(ifs, content);
-        CHECK(content == "new content");
-    }
-
-    fs::remove_all(base);
+    CHECK(shell.content(dst) == "new content");
 }
 
 TEST_CASE("shell.builtin.cp_no_clobber")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_noclobber";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_noclobber");
+    shell.fs.addDirectory(base);
     auto const src = base / "source.txt";
     auto const dst = base / "dest.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "new content";
-    }
-    {
-        std::ofstream ofs(dst);
-        ofs << "old content";
-    }
+    shell.fs.addFile(src, "new content");
+    shell.fs.addFile(dst, "old content");
 
-    TestShell shell;
     shell(std::format("cp -n {} {}", src.string(), dst.string()));
     CHECK(shell.exitCode == 0);
 
     // Original content preserved
-    {
-        std::ifstream ifs(dst);
-        std::string content;
-        std::getline(ifs, content);
-        CHECK(content == "old content");
-    }
-
-    fs::remove_all(base);
+    CHECK(shell.content(dst) == "old content");
 }
 
 TEST_CASE("shell.builtin.cp_force")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_force";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_force");
+    shell.fs.addDirectory(base);
     auto const src = base / "source.txt";
     auto const dst = base / "dest.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "forced content";
-    }
-    {
-        std::ofstream ofs(dst);
-        ofs << "old content";
-    }
+    shell.fs.addFile(src, "forced content");
+    shell.fs.addFile(dst, "old content");
 
-    TestShell shell;
     shell(std::format("cp -f {} {}", src.string(), dst.string()));
     CHECK(shell.exitCode == 0);
 
-    {
-        std::ifstream ifs(dst);
-        std::string content;
-        std::getline(ifs, content);
-        CHECK(content == "forced content");
-    }
-
-    fs::remove_all(base);
+    CHECK(shell.content(dst) == "forced content");
 }
 
 TEST_CASE("shell.builtin.cp_directory_without_recursive")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_dir_norec";
-    fs::remove_all(base);
-    fs::create_directories(base / "srcdir");
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_dir_norec");
+    shell.fs.addDirectory(base / "srcdir");
 
-    TestShell shell;
     shell(std::format("cp {} {}", (base / "srcdir").string(), (base / "dstdir").string()));
     CHECK(shell.exitCode == 1);
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("shell.builtin.cp_recursive")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_recursive";
-    fs::remove_all(base);
-    fs::create_directories(base / "srcdir" / "sub");
-    {
-        std::ofstream ofs(base / "srcdir" / "file.txt");
-        ofs << "data";
-    }
-    {
-        std::ofstream ofs(base / "srcdir" / "sub" / "nested.txt");
-        ofs << "nested";
-    }
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_recursive");
+    shell.fs.addFile(base / "srcdir" / "file.txt", "data");
+    shell.fs.addFile(base / "srcdir" / "sub" / "nested.txt", "nested");
 
-    TestShell shell;
     shell(std::format("cp -r {} {}", (base / "srcdir").string(), (base / "dstdir").string()));
     CHECK(shell.exitCode == 0);
-    CHECK(fs::exists(base / "dstdir" / "file.txt"));
-    CHECK(fs::exists(base / "dstdir" / "sub" / "nested.txt"));
+    CHECK(shell.fs.exists(base / "dstdir" / "file.txt"));
+    CHECK(shell.fs.exists(base / "dstdir" / "sub" / "nested.txt"));
 
-    {
-        std::ifstream ifs(base / "dstdir" / "sub" / "nested.txt");
-        std::string c;
-        std::getline(ifs, c);
-        CHECK(c == "nested");
-    }
-
-    fs::remove_all(base);
+    CHECK(shell.content(base / "dstdir" / "sub" / "nested.txt") == "nested");
 }
 
 TEST_CASE("shell.builtin.cp_verbose")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_verbose";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_verbose");
+    shell.fs.addDirectory(base);
     auto const src = base / "source.txt";
     auto const dst = base / "dest.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "hello";
-    }
+    shell.fs.addFile(src, "hello");
 
-    TestShell shell;
     auto output = shell(std::format("cp -v {} {}", src.string(), dst.string())).output();
     CHECK(shell.exitCode == 0);
     CHECK(output.find("->") != std::string::npos);
-    CHECK(fs::exists(dst));
-
-    fs::remove_all(base);
+    CHECK(shell.fs.exists(dst));
 }
 
 TEST_CASE("shell.builtin.cp_combined_flags")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_combined";
-    fs::remove_all(base);
-    fs::create_directories(base / "srcdir");
-    {
-        std::ofstream ofs(base / "srcdir" / "file.txt");
-        ofs << "data";
-    }
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_combined");
+    shell.fs.addFile(base / "srcdir" / "file.txt", "data");
 
-    TestShell shell;
     auto output =
         shell(std::format("cp -rv {} {}", (base / "srcdir").string(), (base / "dstdir").string())).output();
     CHECK(shell.exitCode == 0);
-    CHECK(fs::exists(base / "dstdir" / "file.txt"));
+    CHECK(shell.fs.exists(base / "dstdir" / "file.txt"));
     CHECK(output.find("->") != std::string::npos);
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("shell.builtin.cp_double_dash")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_ddash";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_ddash");
+    shell.fs.addDirectory(base);
     auto const src = base / "-weirdname.txt";
     auto const dst = base / "dest.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "content";
-    }
+    shell.fs.addFile(src, "content");
 
-    TestShell shell;
     shell(std::format("cp -- {} {}", src.string(), dst.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(fs::exists(dst));
-
-    fs::remove_all(base);
+    CHECK(shell.fs.exists(dst));
 }
 
 TEST_CASE("shell.builtin.cp_multiple_sources_to_dir")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_multi";
-    fs::remove_all(base);
-    fs::create_directories(base / "destdir");
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_multi");
+    shell.fs.addDirectory(base / "destdir");
     auto const src1 = base / "a.txt";
     auto const src2 = base / "b.txt";
 
-    {
-        std::ofstream ofs(src1);
-        ofs << "aaa";
-    }
-    {
-        std::ofstream ofs(src2);
-        ofs << "bbb";
-    }
+    shell.fs.addFile(src1, "aaa");
+    shell.fs.addFile(src2, "bbb");
 
-    TestShell shell;
     shell(std::format("cp {} {} {}", src1.string(), src2.string(), (base / "destdir").string()));
     CHECK(shell.exitCode == 0);
-    CHECK(fs::exists(base / "destdir" / "a.txt"));
-    CHECK(fs::exists(base / "destdir" / "b.txt"));
-
-    fs::remove_all(base);
+    CHECK(shell.fs.exists(base / "destdir" / "a.txt"));
+    CHECK(shell.fs.exists(base / "destdir" / "b.txt"));
 }
 
 TEST_CASE("shell.builtin.cp_multiple_sources_to_file")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_multi_fail";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_multi_fail");
+    shell.fs.addDirectory(base);
     auto const src1 = base / "a.txt";
     auto const src2 = base / "b.txt";
     auto const dst = base / "dest.txt";
 
-    {
-        std::ofstream ofs(src1);
-        ofs << "aaa";
-    }
-    {
-        std::ofstream ofs(src2);
-        ofs << "bbb";
-    }
-    {
-        std::ofstream ofs(dst);
-        ofs << "xxx";
-    }
+    shell.fs.addFile(src1, "aaa");
+    shell.fs.addFile(src2, "bbb");
+    shell.fs.addFile(dst, "xxx");
 
-    TestShell shell;
     shell(std::format("cp {} {} {}", src1.string(), src2.string(), dst.string()));
     CHECK(shell.exitCode == 1);
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("shell.builtin.cp_no_operand")
@@ -1751,22 +1614,15 @@ TEST_CASE("shell.builtin.cp_no_operand")
 
 TEST_CASE("shell.builtin.cp_missing_destination")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_cp_test_missdest";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/cp_missdest");
+    shell.fs.addDirectory(base);
     auto const src = base / "source.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "data";
-    }
+    shell.fs.addFile(src, "data");
 
-    TestShell shell;
     shell(std::format("cp {}", src.string()));
     CHECK(shell.exitCode == 1);
-
-    fs::remove_all(base);
 }
 
 // ============================================================================
@@ -1784,68 +1640,45 @@ TEST_CASE("shell.builtin.mv_help")
 
 TEST_CASE("shell.builtin.mv_single_file")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_single";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/mv_single");
+    shell.fs.addDirectory(base);
     auto const src = base / "source.txt";
     auto const dst = base / "dest.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "hello world";
-    }
+    shell.fs.addFile(src, "hello world");
 
-    TestShell shell;
     shell(std::format("mv {} {}", src.string(), dst.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(!fs::exists(src));
-    CHECK(fs::exists(dst));
+    CHECK(!shell.fs.exists(src));
+    CHECK(shell.fs.exists(dst));
 
-    {
-        std::ifstream ifs(dst);
-        std::string content;
-        std::getline(ifs, content);
-        CHECK(content == "hello world");
-    }
-
-    fs::remove_all(base);
+    CHECK(shell.content(dst) == "hello world");
 }
 
 TEST_CASE("shell.builtin.mv_to_directory")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_todir";
-    fs::remove_all(base);
-    fs::create_directories(base / "subdir");
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/mv_todir");
+    shell.fs.addDirectory(base / "subdir");
     auto const src = base / "file.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "data";
-    }
+    shell.fs.addFile(src, "data");
 
-    TestShell shell;
     shell(std::format("mv {} {}", src.string(), (base / "subdir").string()));
     CHECK(shell.exitCode == 0);
-    CHECK(!fs::exists(src));
-    CHECK(fs::exists(base / "subdir" / "file.txt"));
-
-    fs::remove_all(base);
+    CHECK(!shell.fs.exists(src));
+    CHECK(shell.fs.exists(base / "subdir" / "file.txt"));
 }
 
 TEST_CASE("shell.builtin.mv_nonexistent")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_noexist";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/mv_noexist");
+    shell.fs.addDirectory(base);
 
-    TestShell shell;
     shell(std::format("mv {}/nosuchfile {}/dest", base.string(), base.string()));
     CHECK(shell.exitCode == 1);
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("shell.builtin.mv_no_operand")
@@ -1857,103 +1690,67 @@ TEST_CASE("shell.builtin.mv_no_operand")
 
 TEST_CASE("shell.builtin.mv_missing_destination")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_missdest";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/mv_missdest");
+    shell.fs.addDirectory(base);
     auto const src = base / "source.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "data";
-    }
+    shell.fs.addFile(src, "data");
 
-    TestShell shell;
     shell(std::format("mv {}", src.string()));
     CHECK(shell.exitCode == 1);
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("shell.builtin.mv_no_clobber")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_noclobber";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/mv_noclobber");
+    shell.fs.addDirectory(base);
     auto const src = base / "source.txt";
     auto const dst = base / "dest.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "source content";
-    }
-    {
-        std::ofstream ofs(dst);
-        ofs << "existing content";
-    }
+    shell.fs.addFile(src, "source content");
+    shell.fs.addFile(dst, "existing content");
 
-    TestShell shell;
     shell(std::format("mv -n {} {}", src.string(), dst.string()));
     CHECK(shell.exitCode == 0);
     // Source should still exist (move was skipped)
-    CHECK(fs::exists(src));
+    CHECK(shell.fs.exists(src));
     // Destination should retain original content
-    {
-        std::ifstream ifs(dst);
-        std::string content;
-        std::getline(ifs, content);
-        CHECK(content == "existing content");
-    }
-
-    fs::remove_all(base);
+    CHECK(shell.content(dst) == "existing content");
 }
 
 TEST_CASE("shell.builtin.mv_verbose")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_verbose";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/mv_verbose");
+    shell.fs.addDirectory(base);
     auto const src = base / "source.txt";
     auto const dst = base / "dest.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "data";
-    }
+    shell.fs.addFile(src, "data");
 
-    TestShell shell;
     auto output = shell(std::format("mv -v {} {}", src.string(), dst.string())).output();
     CHECK(shell.exitCode == 0);
     CHECK(output.find("->") != std::string::npos);
-    CHECK(!fs::exists(src));
-    CHECK(fs::exists(dst));
-
-    fs::remove_all(base);
+    CHECK(!shell.fs.exists(src));
+    CHECK(shell.fs.exists(dst));
 }
 
 TEST_CASE("shell.builtin.mv_double_dash")
 {
-    namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_mv_test_ddash";
-    fs::remove_all(base);
-    fs::create_directories(base);
+    InMemoryShell shell;
+    auto const base = std::filesystem::path("/test/mv_ddash");
+    shell.fs.addDirectory(base);
     auto const src = base / "-dashfile.txt";
     auto const dst = base / "dest.txt";
 
-    {
-        std::ofstream ofs(src);
-        ofs << "data";
-    }
+    shell.fs.addFile(src, "data");
 
-    TestShell shell;
     shell(std::format("mv -- {} {}", src.string(), dst.string()));
     CHECK(shell.exitCode == 0);
-    CHECK(!fs::exists(src));
-    CHECK(fs::exists(dst));
-
-    fs::remove_all(base);
+    CHECK(!shell.fs.exists(src));
+    CHECK(shell.fs.exists(dst));
 }
 
 TEST_CASE("shell.builtin.mv_multiple_to_dir")
@@ -4308,21 +4105,11 @@ TEST_CASE("module.shell_level.shows_correct_level")
 
 TEST_CASE("shell.builtin.find_basic")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_find_test_basic";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
-    fs::create_directories(testDir / "sub");
-    {
-        std::ofstream ofs(testDir / "a.txt");
-        ofs << "hello";
-    }
-    {
-        std::ofstream ofs(testDir / "sub" / "b.txt");
-        ofs << "world";
-    }
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/find_basic");
+    shell.fs.addFile(testDir / "a.txt", "hello");
+    shell.fs.addFile(testDir / "sub" / "b.txt", "world");
 
-    TestShell shell;
     shell(std::format("find {}", testDir.string()));
     CHECK(shell.exitCode == 0);
     auto const out = std::string(shell.output());
@@ -4330,52 +4117,31 @@ TEST_CASE("shell.builtin.find_basic")
     CHECK(out.find("a.txt") != std::string::npos);
     CHECK(out.find("b.txt") != std::string::npos);
     CHECK(out.find("sub") != std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.find_name_pattern")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_find_test_name";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
-    {
-        std::ofstream ofs(testDir / "hello.cpp");
-        ofs << "x";
-    }
-    {
-        std::ofstream ofs(testDir / "world.hpp");
-        ofs << "x";
-    }
-    {
-        std::ofstream ofs(testDir / "other.txt");
-        ofs << "x";
-    }
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/find_name");
+    shell.fs.addFile(testDir / "hello.cpp", "x");
+    shell.fs.addFile(testDir / "world.hpp", "x");
+    shell.fs.addFile(testDir / "other.txt", "x");
 
-    TestShell shell;
     shell(std::format("find {} -name '*.cpp'", testDir.string()));
     CHECK(shell.exitCode == 0);
     auto const out = std::string(shell.output());
     CHECK(out.find("hello.cpp") != std::string::npos);
     CHECK(out.find("world.hpp") == std::string::npos);
     CHECK(out.find("other.txt") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.find_type_file")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_find_test_type";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir / "subdir");
-    {
-        std::ofstream ofs(testDir / "file.txt");
-        ofs << "x";
-    }
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/find_type");
+    shell.fs.addDirectory(testDir / "subdir");
+    shell.fs.addFile(testDir / "file.txt", "x");
 
-    TestShell shell;
     shell(std::format("find {} -type f", testDir.string()));
     CHECK(shell.exitCode == 0);
     auto const out = std::string(shell.output());
@@ -4388,107 +4154,61 @@ TEST_CASE("shell.builtin.find_type_file")
 
 TEST_CASE("shell.builtin.find_type_directory")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_find_test_typed";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir / "subdir");
-    {
-        std::ofstream ofs(testDir / "file.txt");
-        ofs << "x";
-    }
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/find_typed");
+    shell.fs.addDirectory(testDir / "subdir");
+    shell.fs.addFile(testDir / "file.txt", "x");
 
-    TestShell shell;
     shell(std::format("find {} -type d", testDir.string()));
     CHECK(shell.exitCode == 0);
     auto const out = std::string(shell.output());
     CHECK(out.find("subdir") != std::string::npos);
     CHECK(out.find("file.txt") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.find_maxdepth")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_find_test_maxdepth";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir / "a" / "b");
-    {
-        std::ofstream ofs(testDir / "top.txt");
-        ofs << "x";
-    }
-    {
-        std::ofstream ofs(testDir / "a" / "mid.txt");
-        ofs << "x";
-    }
-    {
-        std::ofstream ofs(testDir / "a" / "b" / "deep.txt");
-        ofs << "x";
-    }
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/find_maxdepth");
+    shell.fs.addFile(testDir / "top.txt", "x");
+    shell.fs.addFile(testDir / "a" / "mid.txt", "x");
+    shell.fs.addFile(testDir / "a" / "b" / "deep.txt", "x");
 
-    TestShell shell;
     shell(std::format("find {} -maxdepth 1", testDir.string()));
     CHECK(shell.exitCode == 0);
     auto const out = std::string(shell.output());
     CHECK(out.find("top.txt") != std::string::npos);
     CHECK(out.find("deep.txt") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.find_or_grouping")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_find_test_or";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
-    {
-        std::ofstream ofs(testDir / "a.cpp");
-        ofs << "x";
-    }
-    {
-        std::ofstream ofs(testDir / "b.hpp");
-        ofs << "x";
-    }
-    {
-        std::ofstream ofs(testDir / "c.txt");
-        ofs << "x";
-    }
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/find_or");
+    shell.fs.addFile(testDir / "a.cpp", "x");
+    shell.fs.addFile(testDir / "b.hpp", "x");
+    shell.fs.addFile(testDir / "c.txt", "x");
 
-    TestShell shell;
     shell(std::format("find {} '(' -name '*.cpp' -o -name '*.hpp' ')'", testDir.string()));
     CHECK(shell.exitCode == 0);
     auto const out = std::string(shell.output());
     CHECK(out.find("a.cpp") != std::string::npos);
     CHECK(out.find("b.hpp") != std::string::npos);
     CHECK(out.find("c.txt") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.find_not")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_find_test_not";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
-    {
-        std::ofstream ofs(testDir / "keep.cpp");
-        ofs << "x";
-    }
-    {
-        std::ofstream ofs(testDir / "remove.o");
-        ofs << "x";
-    }
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/find_not");
+    shell.fs.addFile(testDir / "keep.cpp", "x");
+    shell.fs.addFile(testDir / "remove.o", "x");
 
-    TestShell shell;
     shell(std::format("find {} -type f -not -name '*.o'", testDir.string()));
     CHECK(shell.exitCode == 0);
     auto const out = std::string(shell.output());
     CHECK(out.find("keep.cpp") != std::string::npos);
     CHECK(out.find("remove.o") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.find_empty")
@@ -4518,45 +4238,29 @@ TEST_CASE("shell.builtin.find_empty")
 
 TEST_CASE("shell.builtin.find_print0")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_find_test_print0";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
-    {
-        std::ofstream ofs(testDir / "file.txt");
-        ofs << "x";
-    }
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/find_print0");
+    shell.fs.addFile(testDir / "file.txt", "x");
 
-    TestShell shell;
     shell(std::format("find {} -name '*.txt' -print0", testDir.string()));
     CHECK(shell.exitCode == 0);
     auto const out = std::string(shell.output());
     // Output should contain null byte instead of newline
     CHECK(out.find('\0') != std::string::npos);
     CHECK(out.find("file.txt") != std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.find_no_results")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_find_test_noresult";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
-    {
-        std::ofstream ofs(testDir / "file.txt");
-        ofs << "x";
-    }
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/find_noresult");
+    shell.fs.addFile(testDir / "file.txt", "x");
 
-    TestShell shell;
     shell(std::format("find {} -name '*.nonexistent'", testDir.string()));
     CHECK(shell.exitCode == 0);
     // Output should be empty (no matches, no error)
     auto const out = std::string(shell.output());
     CHECK(out.find("file.txt") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 // ============================================================================
@@ -4660,44 +4364,30 @@ TEST_CASE("shell.builtin.grep_pipe_multiple_e")
 
 TEST_CASE("shell.builtin.grep_file_basic")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_grep_test_file";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/grep_file");
+    shell.fs.addDirectory(testDir);
     auto const file1 = testDir / "test.txt";
-    {
-        std::ofstream ofs(file1);
-        ofs << "hello world\ngoodbye world\nhello again\n";
-    }
+    shell.fs.addFile(file1, "hello world\ngoodbye world\nhello again\n");
 
-    TestShell shell;
     shell(std::format("grep --color=never hello {}", file1.string()));
     CHECK(shell.exitCode == 0);
     auto const out = std::string(shell.output());
     CHECK(out.find("hello world") != std::string::npos);
     CHECK(out.find("hello again") != std::string::npos);
     CHECK(out.find("goodbye") == std::string::npos);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.grep_file_no_match_exit_code")
 {
-    namespace fs = std::filesystem;
-    auto const testDir = fs::temp_directory_path() / "endo_grep_test_nomatch";
-    fs::remove_all(testDir);
-    fs::create_directories(testDir);
+    InMemoryShell shell;
+    auto const testDir = std::filesystem::path("/test/grep_nomatch");
+    shell.fs.addDirectory(testDir);
     auto const file1 = testDir / "test.txt";
-    {
-        std::ofstream ofs(file1);
-        ofs << "hello world\n";
-    }
+    shell.fs.addFile(file1, "hello world\n");
 
-    TestShell shell;
     shell(std::format("grep --color=never xyz {}", file1.string()));
     CHECK(shell.exitCode == 1);
-
-    fs::remove_all(testDir);
 }
 
 TEST_CASE("shell.builtin.grep_file_multiple_files")

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -5101,6 +5101,19 @@ TEST_CASE("shell.builtin.grep_reports_an_unreadable_file_with_or_without_binary_
     CHECK(shell("grep -I needle /test/locked.txt").output().find("Permission denied") != std::string::npos);
 }
 
+TEST_CASE("shell.builtin.cat_follows_a_symlink_inside_the_injected_filesystem")
+{
+    // A symlink must classify as whatever it points at, exactly as std::filesystem does.
+    // Reporting it as neither file nor directory would send cat down the descriptor path
+    // meant for FIFOs and devices -- and straight onto the host's disk.
+    InMemoryShell shell;
+    shell.fs.addFile("/test/target.txt", "through the link\n");
+    shell.fs.addSymlink("/test/link.txt", "/test/target.txt");
+
+    CHECK(shell("cat /test/link.txt").output().find("through the link") != std::string::npos);
+    CHECK(shell.exitCode == 0);
+}
+
 TEST_CASE("shell.builtin.cat_never_falls_back_to_the_host_filesystem")
 {
     // A path absent from the injected filesystem must be reported as absent, never opened

--- a/src/shell/Shell_test.cpp
+++ b/src/shell/Shell_test.cpp
@@ -33,6 +33,7 @@ using crispy::escape;
 #include "Shell.hpp"
 #include "TTY.hpp"
 #include <platform/InstallPaths.hpp>
+#include <platform/NativeFileSystem.hpp>
 #include <platform/testing/InMemoryFileSystem.hpp>
 #include <platform/testing/TestEnvironmentProvider.hpp>
 #include <testing/ScopedTempDir.hpp>
@@ -1292,6 +1293,43 @@ TEST_CASE("shell.builtin.rm_dot_rejection")
 // ============================================================================
 // mkdir builtin
 // ============================================================================
+
+TEST_CASE("shell.expand.glob_expands_against_the_injected_filesystem")
+{
+    // Glob expansion used to enumerate the real disk while the builtin it fed then acted on
+    // the injected filesystem -- so `rm *.txt` listed one set of files and deleted another.
+    InMemoryShell shell;
+    shell.fs.addFile("/test/globbed/a.txt", "a");
+    shell.fs.addFile("/test/globbed/b.txt", "b");
+    shell.fs.addFile("/test/globbed/c.log", "c");
+
+    auto const listed = shell("echo /test/globbed/*.txt").output();
+    CHECK(listed.find("a.txt") != std::string::npos);
+    CHECK(listed.find("b.txt") != std::string::npos);
+    CHECK(listed.find("c.log") == std::string::npos);
+
+    // And what it expanded is what it removes.
+    shell("rm /test/globbed/*.txt");
+    CHECK(shell.exitCode == 0);
+    CHECK(!shell.fs.exists("/test/globbed/a.txt"));
+    CHECK(!shell.fs.exists("/test/globbed/b.txt"));
+    CHECK(shell.fs.exists("/test/globbed/c.log"));
+}
+
+TEST_CASE("shell.builtin.head_and_wc_read_through_the_injected_filesystem")
+{
+    // head/tail/wc/sort/uniq/cut/tr share readLinesFromInput, which now opens files through
+    // Shell's FileSystem rather than an ifstream. Without that these could only be tested
+    // against a real directory.
+    InMemoryShell shell;
+    shell.fs.addFile("/test/lines.txt", "one\ntwo\nthree\n");
+
+    CHECK(shell("head -n 2 /test/lines.txt").output() == "one\ntwo\n");
+    CHECK(shell.exitCode == 0);
+
+    auto const counted = shell("wc -l /test/lines.txt").output();
+    CHECK(counted.find('3') != std::string::npos);
+}
 
 TEST_CASE("shell.builtin.mkdir_help")
 {
@@ -2974,16 +3012,13 @@ TEST_CASE("shell.jobs.wait_with_job_id")
 TEST_CASE("FileCompleter.prefix_match_scores_higher_than_fuzzy")
 {
     // Create a temporary directory with "src" and "scripts" subdirectories
-    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_test_completion" };
-    auto const& tempDir = tempDirGuard.path();
-    std::filesystem::create_directories(tempDir / "src");
-    std::filesystem::create_directories(tempDir / "scripts");
-
-    // Change to the temp directory for testing
-    auto const scopedCwd = endo::testing::ScopedWorkingDirectory { tempDir };
+    auto fs = endo::InMemoryFileSystem {};
+    fs.addDirectory("/test/src");
+    fs.addDirectory("/test/scripts");
+    fs.setCurrentPath("/test");
 
     endo::TestEnvironment env;
-    endo::FileCompleter completer(env);
+    endo::FileCompleter completer(env, fs);
 
     // Complete "sr" - should match both "src" (prefix) and "scripts" (fuzzy)
     endo::CompletionContext context {
@@ -3018,17 +3053,12 @@ TEST_CASE("FileCompleter.relative_prefix_stays_relative")
     // Regression: a relative nested prefix (e.g. "sub/it") must keep its relative
     // form in the completion. On Windows, canonicalizing the parent directory would
     // resolve it to an absolute path and rewrite the user's typed relative prefix.
-    auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_rel_completion" };
-    auto const& tempDir = tempDirGuard.path();
-    std::filesystem::create_directories(tempDir / "sub");
-    {
-        std::ofstream(tempDir / "sub" / "item.txt");
-    }
-
-    auto const scopedCwd = endo::testing::ScopedWorkingDirectory { tempDir };
+    auto fs = endo::InMemoryFileSystem {};
+    fs.addFile("/test/sub/item.txt", "");
+    fs.setCurrentPath("/test");
 
     endo::TestEnvironment env;
-    endo::FileCompleter completer(env);
+    endo::FileCompleter completer(env, fs);
 
     endo::CompletionContext context {
         .type = endo::CompletionContextType::FilePath,
@@ -3048,12 +3078,14 @@ TEST_CASE("FileCompleter.absolute_directory_corrects_case")
     // On case-insensitive filesystems, completing an absolute directory typed in the
     // wrong case must echo the on-disk capitalization (".../foo" -> ".../Foo/") rather
     // than the case the user typed.
+    // Stays on the real filesystem: InMemoryFileSystem does not model case-insensitive
+    // lookup, so an injected one would make this pass without testing anything.
     auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_case_completion" };
     auto const& tempDir = tempDirGuard.path();
     std::filesystem::create_directories(tempDir / "Foo");
 
     endo::TestEnvironment env;
-    endo::FileCompleter completer(env);
+    endo::FileCompleter completer(env, endo::NativeFileSystem::instance());
 
     // Type the directory in lower-case; it resolves case-insensitively to "Foo".
     auto const typed = endo::platform::normalizePath((tempDir / "foo").string());
@@ -3076,12 +3108,13 @@ TEST_CASE("FileCompleter.partial_prefix_corrects_case")
     // A partial directory name typed in the wrong case (even with leading upper-case,
     // which would otherwise trigger smart-case) must still match and recase on a
     // case-insensitive filesystem (e.g. "Lastrada-to" -> "lastrada-tools/").
+    // Real filesystem, for the same reason as the test above.
     auto const tempDirGuard = endo::testing::ScopedTempDir { "endo_partial_case_completion" };
     auto const& tempDir = tempDirGuard.path();
     std::filesystem::create_directories(tempDir / "lastrada-tools");
 
     endo::TestEnvironment env;
-    endo::FileCompleter completer(env);
+    endo::FileCompleter completer(env, endo::NativeFileSystem::instance());
 
     auto const typed = endo::platform::normalizePath((tempDir / "Lastrada-to").string());
     endo::CompletionContext context {

--- a/src/shell/builtins/Expansion.cpp
+++ b/src/shell/builtins/Expansion.cpp
@@ -56,7 +56,7 @@ void Shell::builtinExpandGlob(CoreVM::Params& context)
 {
     auto const& pattern = context.getString(1);
 
-    auto matches = expandGlobPattern(pattern);
+    auto matches = expandGlobPattern(_fs, pattern);
     if (matches.empty())
     {
         cmdBuilderArgs().push_back(pattern);

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -1127,13 +1127,6 @@ int Shell::executeInlineCat(CoreVM::CoreStringArray const& args, NativeHandle ou
                 continue;
             }
 
-            // openRead() collapses every failure into a null or failed stream, so the reason
-            // is established separately -- otherwise an unreadable file gets reported as a
-            // missing one. FileSystem offers no error channel here.
-            auto const openFailure = [&] {
-                return _fs.exists(resolvedFile) ? "Permission denied" : "No such file or directory";
-            };
-
             std::string content;
             int exitCode = 0;
 
@@ -1144,13 +1137,13 @@ int Shell::executeInlineCat(CoreVM::CoreStringArray const& args, NativeHandle ou
                 // file is always ready, so the stream loop's SIGINT check between chunks is
                 // enough to stay interruptible.
                 auto stream = _fs.openRead(resolvedFile);
-                if (!stream || !*stream)
+                if (!stream)
                 {
-                    error("cat: {}: {}", file, openFailure());
+                    error("cat: {}: {}", file, stream.error());
                     success = false;
                     continue;
                 }
-                std::tie(content, exitCode) = interruptibleReadAll(*stream);
+                std::tie(content, exitCode) = interruptibleReadAll(**stream);
             }
             // A path that resolveDevicePath() rewrote is a device by construction ("/dev/null"
             // becomes "NUL" on Windows), which the filesystem abstraction does not model and
@@ -2662,10 +2655,10 @@ int Shell::executeInlineGrep(CoreVM::CoreStringArray const& args, NativeHandle o
 
             // Read file
             auto fileStream = _fs.openRead(filePath);
-            if (!fileStream || !fileStream->good())
+            if (!fileStream)
             {
                 if (!opts.suppressErrors)
-                    error("grep: {}: Permission denied", platform::normalizePath(filePath));
+                    error("grep: {}: {}", platform::normalizePath(filePath), fileStream.error());
                 hasError = true;
                 continue;
             }
@@ -2675,7 +2668,7 @@ int Shell::executeInlineGrep(CoreVM::CoreStringArray const& args, NativeHandle o
             // buffer to avoid a per-line copy.
             std::vector<std::string> lines;
             std::string line;
-            while (std::getline(*fileStream, line))
+            while (std::getline(**fileStream, line))
             {
                 if (throttle.pending())
                     return 130;
@@ -4777,19 +4770,13 @@ namespace
                 else
                 {
                     auto stream = fs.openRead(platform::resolveDevicePath(file));
-                    if (!stream || !*stream)
+                    if (!stream)
                     {
-                        // Same inference as cat: openRead() cannot say why it failed, and
-                        // reporting an unreadable file as a missing one is worse than
-                        // guessing between the two cases that actually occur.
-                        errorFn(
-                            std::format("{}: {}",
-                                        file,
-                                        fs.exists(file) ? "Permission denied" : "No such file or directory"));
+                        errorFn(std::format("{}: {}", file, stream.error()));
                         result.hadError = true;
                         continue;
                     }
-                    readFromStream(*stream);
+                    readFromStream(**stream);
                 }
             }
         }
@@ -4932,14 +4919,12 @@ int Shell::executeInlineTail(CoreVM::CoreStringArray const& args, NativeHandle o
         // observes no further appends there -- but it reads the file the rest of the shell
         // would read, instead of a same-named one on the host's disk.
         auto const stream = _fs.openRead(platform::resolveDevicePath(filePath));
-        if (!stream || !*stream)
+        if (!stream)
         {
-            error("tail: cannot open '{}': {}",
-                  filePath,
-                  _fs.exists(filePath) ? "Permission denied" : "No such file or directory");
+            error("tail: cannot open '{}': {}", filePath, stream.error());
             return 1;
         }
-        auto& ifs = *stream;
+        auto& ifs = **stream;
 
         // Read and output last N lines using a sliding window
         std::deque<std::string> lastLines;

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -1023,7 +1023,18 @@ int Shell::executeInlineCat(CoreVM::CoreStringArray const& args, NativeHandle ou
 
             if (renderMode == CatRenderMode::SixelImage)
             {
-                auto imageResult = tui::loadImage(file);
+                // Through the injected filesystem, like the text path below: loadImage()
+                // takes a path and would read the host's disk, so the bytes are fetched
+                // here and decoded from memory instead.
+                auto const imageBytes = _fs.readFile(file);
+                if (!imageBytes.has_value())
+                {
+                    error("cat: {}: {}", file, imageBytes.error());
+                    success = false;
+                    continue;
+                }
+                auto imageResult = tui::loadImageFromMemory(std::span<std::uint8_t const> {
+                    reinterpret_cast<std::uint8_t const*>(imageBytes->data()), imageBytes->size() });
                 if (!imageResult.has_value())
                 {
                     error("cat: {}: {}", file, imageResult.error());
@@ -1141,24 +1152,36 @@ int Shell::executeInlineCat(CoreVM::CoreStringArray const& args, NativeHandle ou
                 }
                 std::tie(content, exitCode) = interruptibleReadAll(*stream);
             }
-            else
+            // A path that resolveDevicePath() rewrote is a device by construction ("/dev/null"
+            // becomes "NUL" on Windows), which the filesystem abstraction does not model and
+            // cannot be asked about.
+            else if (resolvedFile != std::filesystem::path(file) || _fs.exists(resolvedFile))
             {
                 // A FIFO, a character device or a process-substitution descriptor
                 // (`cat <(...)`) is not always ready, and SIGINT arrives over a signalfd
                 // rather than as EINTR -- so a blocking stream read would sit through Ctrl+C
                 // until the writer produced data. Those keep the polling descriptor path.
-                // Nothing an injected filesystem models is one of them, so this branch is
-                // reached only against a real filesystem, or for a path that is simply absent.
+                //
+                // Reached only for something the injected filesystem says is really there but
+                // is not a regular file. Falling through to here for a path it does not have
+                // would read the host's disk and defeat the injection entirely.
                 auto const result = _processManager.openFile(resolvedFile, O_RDONLY);
                 if (!result.has_value())
                 {
-                    error("cat: {}: {}", file, openFailure());
+                    // Unlike openRead(), this reports why.
+                    error("cat: {}: {}", file, toString(result.error()));
                     success = false;
                     continue;
                 }
                 auto const fd = result.value();
                 std::tie(content, exitCode) = interruptibleReadAll(fd);
                 _processManager.closeHandle(fd);
+            }
+            else
+            {
+                error("cat: {}: No such file or directory", file);
+                success = false;
+                continue;
             }
 
             if (exitCode != 0)
@@ -4756,7 +4779,13 @@ namespace
                     auto stream = fs.openRead(platform::resolveDevicePath(file));
                     if (!stream || !*stream)
                     {
-                        errorFn(std::format("{}: No such file or directory", file));
+                        // Same inference as cat: openRead() cannot say why it failed, and
+                        // reporting an unreadable file as a missing one is worse than
+                        // guessing between the two cases that actually occur.
+                        errorFn(
+                            std::format("{}: {}",
+                                        file,
+                                        fs.exists(file) ? "Permission denied" : "No such file or directory"));
                         result.hadError = true;
                         continue;
                     }
@@ -4898,12 +4927,19 @@ int Shell::executeInlineTail(CoreVM::CoreStringArray const& args, NativeHandle o
     {
         // Follow mode: open file once, stream last N lines via bounded deque, then follow
         auto const& filePath = files.back();
-        std::ifstream ifs(platform::resolveDevicePath(filePath));
-        if (!ifs)
+        // Through the injected filesystem, like the non-follow path below: an injected
+        // filesystem hands back a snapshot rather than a growing file, so follow mode
+        // observes no further appends there -- but it reads the file the rest of the shell
+        // would read, instead of a same-named one on the host's disk.
+        auto const stream = _fs.openRead(platform::resolveDevicePath(filePath));
+        if (!stream || !*stream)
         {
-            error("tail: cannot open '{}': No such file or directory", filePath);
+            error("tail: cannot open '{}': {}",
+                  filePath,
+                  _fs.exists(filePath) ? "Permission denied" : "No such file or directory");
             return 1;
         }
+        auto& ifs = *stream;
 
         // Read and output last N lines using a sliding window
         std::deque<std::string> lastLines;

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -1021,20 +1021,29 @@ int Shell::executeInlineCat(CoreVM::CoreStringArray const& args, NativeHandle ou
                                    .language = tui::detectLanguageFromPath(file) };
             auto const renderMode = chooseCatRenderMode(renderContext);
 
+            // Resolved once, and every probe below asks about the same path: on Windows
+            // "/dev/null" resolves to "NUL", and querying the unresolved spelling would
+            // describe a path that was never opened.
+            auto const resolvedFile = platform::resolveDevicePath(file);
+
             if (renderMode == CatRenderMode::SixelImage)
             {
                 // Through the injected filesystem, like the text path below: loadImage()
                 // takes a path and would read the host's disk, so the bytes are fetched
-                // here and decoded from memory instead.
-                auto const imageBytes = _fs.readFile(file);
-                if (!imageBytes.has_value())
+                // here and decoded from memory instead. openRead() rather than readFile()
+                // so the reason reads the same as it does for a text file.
+                auto const imageStream = _fs.openRead(resolvedFile);
+                if (!imageStream.has_value())
                 {
-                    error("cat: {}: {}", file, imageBytes.error());
+                    error("cat: {}: {}", file, imageStream.error());
                     success = false;
                     continue;
                 }
+                auto imageBuffer = std::ostringstream {};
+                imageBuffer << (*imageStream)->rdbuf();
+                auto const imageBytes = std::move(imageBuffer).str();
                 auto imageResult = tui::loadImageFromMemory(std::span<std::uint8_t const> {
-                    reinterpret_cast<std::uint8_t const*>(imageBytes->data()), imageBytes->size() });
+                    reinterpret_cast<std::uint8_t const*>(imageBytes.data()), imageBytes.size() });
                 if (!imageResult.has_value())
                 {
                     error("cat: {}: {}", file, imageResult.error());
@@ -1112,11 +1121,6 @@ int Shell::executeInlineCat(CoreVM::CoreStringArray const& args, NativeHandle ou
                 writeOutput("\n");
                 continue;
             }
-
-            // Resolved once, and every probe below asks about the same path: on Windows
-            // "/dev/null" resolves to "NUL", and querying the unresolved spelling would
-            // describe a path that was never opened.
-            auto const resolvedFile = platform::resolveDevicePath(file);
 
             // A directory has to be rejected before the open, not after: opening one
             // succeeds on some platforms and then reads as nothing at all.

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -4609,7 +4609,13 @@ namespace
         int exitCode = 0;
     };
 
-    ReadLinesResult readLinesFromInput(endo::NativeHandle stdinFd,
+    /// @brief Reads every line from stdin or from @p files.
+    ///
+    /// Takes the filesystem rather than opening an ifstream directly, so the six builtins
+    /// sharing this helper -- head, tail, wc, sort, uniq and cut -- read through the same
+    /// injected filesystem as the rest of the shell instead of going straight to disk.
+    ReadLinesResult readLinesFromInput(endo::platform::FileSystem const& fs,
+                                       endo::NativeHandle stdinFd,
                                        std::span<std::string const> files,
                                        auto const& errorFn)
     {
@@ -4661,14 +4667,14 @@ namespace
                 }
                 else
                 {
-                    std::ifstream ifs(platform::resolveDevicePath(file));
-                    if (!ifs)
+                    auto stream = fs.openRead(platform::resolveDevicePath(file));
+                    if (!stream || !*stream)
                     {
                         errorFn(std::format("{}: No such file or directory", file));
                         result.hadError = true;
                         continue;
                     }
-                    readFromStream(ifs);
+                    readFromStream(*stream);
                 }
             }
         }
@@ -4727,7 +4733,7 @@ int Shell::executeInlineHead(CoreVM::CoreStringArray const& args, NativeHandle o
     auto const errorFn = [this](std::string const& msg) {
         error("head: {}", msg);
     };
-    auto const result = readLinesFromInput(stdinFd, files, errorFn);
+    auto const result = readLinesFromInput(_fs, stdinFd, files, errorFn);
     if (result.exitCode != 0)
         return result.exitCode;
     if (result.hadError)
@@ -4857,7 +4863,7 @@ int Shell::executeInlineTail(CoreVM::CoreStringArray const& args, NativeHandle o
         auto const errorFn = [this](std::string const& msg) {
             error("tail: {}", msg);
         };
-        auto const result = readLinesFromInput(stdinFd, files, errorFn);
+        auto const result = readLinesFromInput(_fs, stdinFd, files, errorFn);
         if (result.exitCode != 0)
             return result.exitCode;
         auto const& lines = result.lines;
@@ -4905,7 +4911,7 @@ int Shell::executeInlineTail(CoreVM::CoreStringArray const& args, NativeHandle o
     auto const errorFn = [this](std::string const& msg) {
         error("tail: {}", msg);
     };
-    auto const result = readLinesFromInput(stdinFd, files, errorFn);
+    auto const result = readLinesFromInput(_fs, stdinFd, files, errorFn);
     if (result.exitCode != 0)
         return result.exitCode;
     if (result.hadError)
@@ -5195,7 +5201,7 @@ int Shell::executeInlineWc(CoreVM::CoreStringArray const& args, NativeHandle out
     auto const errorFn = [this](std::string const& msg) {
         error("wc: {}", msg);
     };
-    auto const result = readLinesFromInput(stdinFd, files, errorFn);
+    auto const result = readLinesFromInput(_fs, stdinFd, files, errorFn);
     if (result.exitCode != 0)
         return result.exitCode;
     if (result.hadError)
@@ -5316,7 +5322,7 @@ int Shell::executeInlineSort(CoreVM::CoreStringArray const& args, NativeHandle o
     auto const errorFn = [this](std::string const& msg) {
         error("sort: {}", msg);
     };
-    auto result = readLinesFromInput(stdinFd, files, errorFn);
+    auto result = readLinesFromInput(_fs, stdinFd, files, errorFn);
     if (result.exitCode != 0)
         return result.exitCode;
     if (result.hadError)
@@ -5431,7 +5437,7 @@ int Shell::executeInlineUniq(CoreVM::CoreStringArray const& args, NativeHandle o
     auto const errorFn = [this](std::string const& msg) {
         error("uniq: {}", msg);
     };
-    auto const result = readLinesFromInput(stdinFd, files, errorFn);
+    auto const result = readLinesFromInput(_fs, stdinFd, files, errorFn);
     if (result.exitCode != 0)
         return result.exitCode;
     if (result.hadError)
@@ -5584,7 +5590,7 @@ int Shell::executeInlineCut(CoreVM::CoreStringArray const& args, NativeHandle ou
     auto const errorFn = [this](std::string const& msg) {
         error("cut: {}", msg);
     };
-    auto const result = readLinesFromInput(stdinFd, files, errorFn);
+    auto const result = readLinesFromInput(_fs, stdinFd, files, errorFn);
     if (result.exitCode != 0)
         return result.exitCode;
     if (result.hadError)

--- a/src/shell/builtins/InlineCommands.cpp
+++ b/src/shell/builtins/InlineCommands.cpp
@@ -270,6 +270,43 @@ std::pair<std::string, int> interruptibleReadAll(endo::NativeHandle fd)
     return { std::move(data), exitCode };
 }
 
+/// Reads all data from a stream interruptibly.
+///
+/// The descriptor-based overload polls because its source may be a pipe or a terminal that
+/// trickles data in. A stream from FileSystem::openRead() is a file, which is always ready,
+/// so a poll would be a no-op -- what carries over is the SIGINT check between chunks, which
+/// is what keeps `cat` of a very large file interruptible.
+///
+/// @param stream The stream to drain.
+/// @return {data, exitCode} where exitCode is 0 on EOF, 1 on I/O error, 130 on SIGINT.
+std::pair<std::string, int> interruptibleReadAll(std::istream& stream)
+{
+    using namespace endo::platform;
+
+    std::string data;
+    std::array<char, 4096> buffer {};
+
+    while (true)
+    {
+        SignalHandler::processSignalFd();
+        if (SignalHandler::hasPendingSigint())
+        {
+            SignalHandler::clearPendingSigint();
+            return { std::move(data), 130 };
+        }
+
+        stream.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        auto const bytesRead = stream.gcount();
+        if (bytesRead > 0)
+            data.append(buffer.data(), static_cast<size_t>(bytesRead));
+        if (stream.bad())
+            return { std::move(data), 1 };
+        if (bytesRead == 0 || stream.eof())
+            break;
+    }
+    return { std::move(data), 0 };
+}
+
 /// @brief A TerminalOutput that writes to a caller-supplied file descriptor.
 ///
 /// tui::TerminalOutput composes escape sequences into an internal buffer and, by
@@ -1065,16 +1102,65 @@ int Shell::executeInlineCat(CoreVM::CoreStringArray const& args, NativeHandle ou
                 continue;
             }
 
-            auto const result = _processManager.openFile(file, O_RDONLY);
-            if (!result.has_value())
+            // Resolved once, and every probe below asks about the same path: on Windows
+            // "/dev/null" resolves to "NUL", and querying the unresolved spelling would
+            // describe a path that was never opened.
+            auto const resolvedFile = platform::resolveDevicePath(file);
+
+            // A directory has to be rejected before the open, not after: opening one
+            // succeeds on some platforms and then reads as nothing at all.
+            if (_fs.isDirectory(resolvedFile))
             {
-                error("cat: {}: {}", file, strerror(errno));
+                error("cat: {}: Is a directory", file);
                 success = false;
                 continue;
             }
-            auto const fd = result.value();
-            auto [content, exitCode] = interruptibleReadAll(fd);
-            _processManager.closeHandle(fd);
+
+            // openRead() collapses every failure into a null or failed stream, so the reason
+            // is established separately -- otherwise an unreadable file gets reported as a
+            // missing one. FileSystem offers no error channel here.
+            auto const openFailure = [&] {
+                return _fs.exists(resolvedFile) ? "Permission denied" : "No such file or directory";
+            };
+
+            std::string content;
+            int exitCode = 0;
+
+            if (_fs.isRegularFile(resolvedFile))
+            {
+                // Read through the injected filesystem: cat consumes the bytes itself and
+                // hands no descriptor to a child, so a regular file needs no real fd. Such a
+                // file is always ready, so the stream loop's SIGINT check between chunks is
+                // enough to stay interruptible.
+                auto stream = _fs.openRead(resolvedFile);
+                if (!stream || !*stream)
+                {
+                    error("cat: {}: {}", file, openFailure());
+                    success = false;
+                    continue;
+                }
+                std::tie(content, exitCode) = interruptibleReadAll(*stream);
+            }
+            else
+            {
+                // A FIFO, a character device or a process-substitution descriptor
+                // (`cat <(...)`) is not always ready, and SIGINT arrives over a signalfd
+                // rather than as EINTR -- so a blocking stream read would sit through Ctrl+C
+                // until the writer produced data. Those keep the polling descriptor path.
+                // Nothing an injected filesystem models is one of them, so this branch is
+                // reached only against a real filesystem, or for a path that is simply absent.
+                auto const result = _processManager.openFile(resolvedFile, O_RDONLY);
+                if (!result.has_value())
+                {
+                    error("cat: {}: {}", file, openFailure());
+                    success = false;
+                    continue;
+                }
+                auto const fd = result.value();
+                std::tie(content, exitCode) = interruptibleReadAll(fd);
+                _processManager.closeHandle(fd);
+            }
+
             if (exitCode != 0)
                 return exitCode;
 

--- a/src/shell/commands/GrepCommand.cpp
+++ b/src/shell/commands/GrepCommand.cpp
@@ -455,10 +455,12 @@ bool isBinaryFile(platform::FileSystem const& fs, std::filesystem::path const& p
     // Open through the injected FileSystem so binary detection works against any
     // backend (e.g. InMemoryFileSystem in tests), consistent with collectFiles.
     auto stream = fs.openRead(path);
-    // Unreadable counts as binary, so the caller skips the file: classifying it means
-    // reading it, and that has already failed.
+    // Not binary -- unreadable, which is a different thing. Reporting it as binary makes
+    // the caller skip the file silently, so `grep -I pattern unreadable.txt` said nothing at
+    // all while the same command without -I reported the reason. Saying "not binary" lets
+    // the caller's own open fail and explain itself.
     if (!stream)
-        return true;
+        return false;
 
     auto& in = **stream;
     auto buffer = std::array<char, BinaryCheckSize> {};

--- a/src/shell/commands/GrepCommand.cpp
+++ b/src/shell/commands/GrepCommand.cpp
@@ -455,12 +455,15 @@ bool isBinaryFile(platform::FileSystem const& fs, std::filesystem::path const& p
     // Open through the injected FileSystem so binary detection works against any
     // backend (e.g. InMemoryFileSystem in tests), consistent with collectFiles.
     auto stream = fs.openRead(path);
-    if (!stream || !stream->good())
+    // Unreadable counts as binary, so the caller skips the file: classifying it means
+    // reading it, and that has already failed.
+    if (!stream)
         return true;
 
+    auto& in = **stream;
     auto buffer = std::array<char, BinaryCheckSize> {};
-    stream->read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
-    auto const bytesRead = static_cast<size_t>(stream->gcount());
+    in.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    auto const bytesRead = static_cast<size_t>(in.gcount());
 
     return std::any_of(buffer.begin(), buffer.begin() + static_cast<std::ptrdiff_t>(bytesRead), [](char c) {
         return c == '\0';

--- a/src/shell/commands/GrepCommand.hpp
+++ b/src/shell/commands/GrepCommand.hpp
@@ -147,10 +147,15 @@ using ErrorWriter = std::function<void(std::string_view)>;
 [[nodiscard]] std::expected<std::regex, std::string> buildRegex(GrepOptions const& opts);
 
 /// Checks if a file appears to be binary by scanning for null bytes.
+///
+/// A file that cannot be opened is reported as *not* binary: unreadable is a different
+/// thing, and answering "binary" would make `-I` skip it without a word, where the caller's
+/// own open fails and explains why.
+///
 /// @param fs FileSystem abstraction used to open the file (so it works against
 ///           any injected backend, not just the real on-disk filesystem).
 /// @param path Path to the file to check.
-/// @return true if the file appears to be binary (or cannot be opened).
+/// @return true if the file appears to be binary; false if it does not, or cannot be opened.
 [[nodiscard]] bool isBinaryFile(platform::FileSystem const& fs, std::filesystem::path const& path);
 
 /// Collects the list of files to search based on options.

--- a/src/shell/commands/GrepCommand_test.cpp
+++ b/src/shell/commands/GrepCommand_test.cpp
@@ -608,6 +608,17 @@ TEST_CASE("grep.binary.null_bytes", "[grep]")
     CHECK(isBinaryFile(fs, "/test/binary.bin"));
 }
 
+TEST_CASE("grep.binary.unreadable_is_not_binary", "[grep]")
+{
+    // An unreadable file must not be classified as binary: that would make -I skip it
+    // silently, where the caller's own open reports why.
+    auto fs = endo::InMemoryFileSystem {};
+    fs.addFile("/test/locked.txt", "hello world\n");
+    fs.denyAccess("/test/locked.txt");
+
+    CHECK_FALSE(isBinaryFile(fs, "/test/locked.txt"));
+}
+
 // ============================================================================
 // OSC 8 hyperlinks on filename prefixes
 // ============================================================================

--- a/src/shell/commands/GrepCommand_test.cpp
+++ b/src/shell/commands/GrepCommand_test.cpp
@@ -3,12 +3,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include <filesystem>
-#include <fstream>
 #include <vector>
 
 #include <platform/InterruptThrottle.hpp>
-#include <platform/NativeFileSystem.hpp>
 #include <platform/SignalHandler.hpp>
 #include <platform/testing/InMemoryFileSystem.hpp>
 
@@ -599,32 +596,16 @@ TEST_CASE("grep.search.context_overlap", "[grep]")
 
 TEST_CASE("grep.binary.text_file", "[grep]")
 {
-    namespace fs = std::filesystem;
-    auto const tmpDir = fs::temp_directory_path() / "endo_grep_test_binary";
-    fs::create_directories(tmpDir);
-    auto const textFile = tmpDir / "text.txt";
-    {
-        std::ofstream f(textFile);
-        f << "hello world\nthis is text\n";
-    }
-    CHECK_FALSE(isBinaryFile(endo::platform::NativeFileSystem::instance(), textFile));
-    fs::remove_all(tmpDir);
+    auto const fs =
+        endo::InMemoryFileSystem { { .path = "/test/text.txt", .content = "hello world\nthis is text\n" } };
+    CHECK_FALSE(isBinaryFile(fs, "/test/text.txt"));
 }
 
 TEST_CASE("grep.binary.null_bytes", "[grep]")
 {
-    namespace fs = std::filesystem;
-    auto const tmpDir = fs::temp_directory_path() / "endo_grep_test_binary";
-    fs::create_directories(tmpDir);
-    auto const binFile = tmpDir / "binary.bin";
-    {
-        std::ofstream f(binFile, std::ios::binary);
-        f << "hello";
-        f.put('\0');
-        f << "world";
-    }
-    CHECK(isBinaryFile(endo::platform::NativeFileSystem::instance(), binFile));
-    fs::remove_all(tmpDir);
+    auto const fs = endo::InMemoryFileSystem { { .path = "/test/binary.bin",
+                                                 .content = std::string("hello\0world", 11) } };
+    CHECK(isBinaryFile(fs, "/test/binary.bin"));
 }
 
 // ============================================================================

--- a/src/shell/completion/Completer.cpp
+++ b/src/shell/completion/Completer.cpp
@@ -62,7 +62,7 @@ Completer::Completer(EnvironmentProvider const& env,
 
     _providers.push_back(std::make_unique<LetBindingCompleter>(fsharpState));
     _providers.push_back(std::make_unique<VariableCompleter>(env));
-    _providers.push_back(std::make_unique<FileCompleter>(env));
+    _providers.push_back(std::make_unique<FileCompleter>(env, fs));
     _providers.push_back(std::make_unique<HistoryCompleter>(history, env, fs));
 
     // Sort by priority (highest first)

--- a/src/shell/completion/FileCompleter.cpp
+++ b/src/shell/completion/FileCompleter.cpp
@@ -17,7 +17,7 @@
 namespace endo
 {
 
-FileCompleter::FileCompleter(EnvironmentProvider const& env): _env(env)
+FileCompleter::FileCompleter(EnvironmentProvider const& env, FileSystem const& fs): _env(env), _fs(fs)
 {
 }
 
@@ -60,6 +60,10 @@ std::vector<CompletionItem> FileCompleter::complete(CompletionContext const& con
 
     // Returns the on-disk capitalization of an existing absolute path so completions
     // echo the real case rather than the case the user typed (e.g. "D:/foo" -> "D:/Foo").
+    // This deliberately bypasses _fs: FileSystem models no case-canonicalization, and
+    // canonicalCasePath() is a Windows-only on-disk query (identity on POSIX). An injected
+    // filesystem addressed by a drive-letter path would therefore be asked about the real
+    // drive's casing -- add a FileSystem::canonicalCase() before writing such a test.
     // Relative and tilde-prefixed paths are left exactly as typed: canonicalCasePath()
     // resolves to an absolute path and would otherwise rewrite "foo/" into an absolute
     // path or expand "~/foo" into the literal home directory.
@@ -75,11 +79,10 @@ std::vector<CompletionItem> FileCompleter::complete(CompletionContext const& con
             s += '/';
     };
 
-    std::error_code ec;
     std::filesystem::path dir;
     std::string filePrefix;
 
-    if (std::filesystem::is_directory(expandedPath, ec) && !ec)
+    if (_fs.isDirectory(expandedPath))
     {
         // If path is a directory and ends with /, list its contents
         if (!prefix.empty() && prefix.back() == '/')
@@ -133,6 +136,7 @@ std::vector<CompletionItem> FileCompleter::complete(CompletionContext const& con
             {
                 // Use the on-disk capitalization (and upper-case drive letter on Windows)
                 // so the completed prefix matches the real path, not the user's typed case.
+                // Bypasses _fs for the same reason as caseCorrect() above.
                 // Only canonicalize absolute paths: canonicalCasePath() resolves to an
                 // absolute path, which would otherwise rewrite a relative prefix the user
                 // typed (e.g. "foo/") into an absolute one.
@@ -144,7 +148,7 @@ std::vector<CompletionItem> FileCompleter::complete(CompletionContext const& con
     }
 
     // Check if directory exists
-    if (!std::filesystem::exists(dir, ec) || !std::filesystem::is_directory(dir, ec))
+    if (!_fs.isDirectory(dir))
         return {};
 
     return listDirectory(dir, filePrefix, pathPrefix);
@@ -208,10 +212,9 @@ bool FileCompleter::isHidden(std::string_view name)
 
 std::vector<CompletionItem> FileCompleter::listDirectory(std::filesystem::path const& dir,
                                                          std::string_view prefix,
-                                                         std::string_view pathPrefix)
+                                                         std::string_view pathPrefix) const
 {
     std::vector<CompletionItem> results;
-    std::error_code ec;
 
     // Determine if we should show hidden files
     bool showHidden = !prefix.empty() && prefix[0] == '.';
@@ -227,12 +230,13 @@ std::vector<CompletionItem> FileCompleter::listDirectory(std::filesystem::path c
     // smart-case matching is kept there.
     bool const caseInsensitive = platform::FilesystemCaseInsensitive;
 
-    for (auto const& entry: std::filesystem::directory_iterator(dir, ec))
-    {
-        if (ec)
-            break;
+    auto const listing = _fs.listDirectory(dir);
+    if (!listing)
+        return results;
 
-        auto filename = entry.path().filename().string();
+    for (auto const& entry: *listing)
+    {
+        auto filename = entry.path.filename().string();
 
         // Skip hidden files unless prefix starts with dot
         if (isHidden(filename) && !showHidden)
@@ -260,7 +264,7 @@ std::vector<CompletionItem> FileCompleter::listDirectory(std::filesystem::path c
         if (!isPrefixMatch && !isFuzzyMatch)
             continue;
 
-        bool isDir = entry.is_directory(ec);
+        bool const isDir = entry.isDirectory;
         std::string displayName = filename;
         std::string fullPath = std::string(pathPrefix) + filename;
 

--- a/src/shell/completion/FileCompleter.hpp
+++ b/src/shell/completion/FileCompleter.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <platform/EnvironmentProvider.hpp>
+#include <platform/FileSystem.hpp>
 
 namespace endo
 {
@@ -19,7 +20,9 @@ class FileCompleter: public CompletionProvider
     /// @brief Constructs a file completer.
     /// @param env Environment abstraction used to resolve the user's home directory
     ///            for tilde (`~`) expansion.
-    explicit FileCompleter(EnvironmentProvider const& env);
+    /// @param fs  Filesystem to enumerate. Completion must offer what the shell will act
+    ///            on, so it reads the same filesystem the builtins do.
+    FileCompleter(EnvironmentProvider const& env, FileSystem const& fs);
 
     [[nodiscard]] std::vector<CompletionItem> complete(CompletionContext const& context) override;
     [[nodiscard]] bool canHandle(CompletionContextType type) const override;
@@ -28,6 +31,7 @@ class FileCompleter: public CompletionProvider
 
   private:
     EnvironmentProvider const& _env;
+    FileSystem const& _fs;
 
     /// @brief Expands tilde to home directory.
     [[nodiscard]] std::filesystem::path expandTilde(std::string_view path) const;
@@ -35,10 +39,10 @@ class FileCompleter: public CompletionProvider
     /// @brief Checks if a filename is hidden (starts with dot).
     [[nodiscard]] static bool isHidden(std::string_view name);
 
-    /// @brief Lists directory entries matching prefix.
-    [[nodiscard]] static std::vector<CompletionItem> listDirectory(std::filesystem::path const& dir,
-                                                                   std::string_view prefix,
-                                                                   std::string_view pathPrefix);
+    /// @brief Lists entries of @p dir (in @ref _fs) matching @p prefix.
+    [[nodiscard]] std::vector<CompletionItem> listDirectory(std::filesystem::path const& dir,
+                                                            std::string_view prefix,
+                                                            std::string_view pathPrefix) const;
 };
 
 } // namespace endo

--- a/src/shell/history/PersistentHistory_test.cpp
+++ b/src/shell/history/PersistentHistory_test.cpp
@@ -6,7 +6,6 @@
 
 #include "PersistentHistory.hpp"
 #include "RequiredPaths.hpp"
-#include <platform/NativeFileSystem.hpp>
 #include <platform/testing/InMemoryFileSystem.hpp>
 
 using namespace std::string_literals;
@@ -15,39 +14,26 @@ using namespace std::string_view_literals;
 namespace
 {
 
-auto const& testFs()
+/// @brief A history file in a filesystem private to one test case.
+///
+/// PersistentHistory already takes FileSystem const&, so injecting an in-memory one is the
+/// designed seam: each test gets its own tree, with no shared path to collide over and
+/// nothing to clean up.
+struct HistoryFixture
 {
-    return endo::NativeFileSystem::instance();
-}
+    endo::InMemoryFileSystem fs;
+    std::filesystem::path dir { "/test/history" };
+    endo::PersistentHistory history { fs };
 
-/// @brief RAII helper that creates a temporary directory and removes it on destruction.
-struct TempDir
-{
-    std::filesystem::path path;
-
-    TempDir()
-    {
-        path = std::filesystem::temp_directory_path() / "endo_history_test";
-        std::filesystem::create_directories(path);
-    }
-
-    ~TempDir() { std::filesystem::remove_all(path); }
+    HistoryFixture() { history.setFilePath(dir / "history.yml"); }
 };
-
-void writeFile(std::filesystem::path const& path, std::string_view content)
-{
-    std::filesystem::create_directories(path.parent_path());
-    auto const result = testFs().writeFile(path, content);
-    REQUIRE(result.has_value());
-}
 
 } // namespace
 
 TEST_CASE("PersistentHistory.basic_add_and_search", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("git status");
     history.add("git log");
@@ -63,9 +49,8 @@ TEST_CASE("PersistentHistory.basic_add_and_search", "[history]")
 
 TEST_CASE("PersistentHistory.fuzzy_search", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("git status");
     history.add("cmake --build --preset clang-debug");
@@ -78,9 +63,8 @@ TEST_CASE("PersistentHistory.fuzzy_search", "[history]")
 
 TEST_CASE("PersistentHistory.deduplication", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("git status");
     history.add("git log");
@@ -93,9 +77,8 @@ TEST_CASE("PersistentHistory.deduplication", "[history]")
 
 TEST_CASE("PersistentHistory.markLastResult_persists_on_success", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("echo hello");
     CHECK(!history.richEntries().back().persisted);
@@ -104,14 +87,13 @@ TEST_CASE("PersistentHistory.markLastResult_persists_on_success", "[history]")
     CHECK(history.richEntries().back().persisted);
 
     // File should exist after flush
-    CHECK(std::filesystem::exists(dir.path / "history.yml"));
+    CHECK(fixture.fs.exists(fixture.dir / "history.yml"));
 }
 
 TEST_CASE("PersistentHistory.markLastResult_does_not_persist_new_on_failure", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("nonexistent_command");
     CHECK(!history.richEntries().back().persisted);
@@ -120,14 +102,13 @@ TEST_CASE("PersistentHistory.markLastResult_does_not_persist_new_on_failure", "[
     CHECK(!history.richEntries().back().persisted);
 
     // File should NOT exist (no successful command yet)
-    CHECK(!std::filesystem::exists(dir.path / "history.yml"));
+    CHECK(!fixture.fs.exists(fixture.dir / "history.yml"));
 }
 
 TEST_CASE("PersistentHistory.previously_persisted_unpersisted_on_failure", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     // First: add and succeed
     history.add("git status");
@@ -144,12 +125,12 @@ TEST_CASE("PersistentHistory.previously_persisted_unpersisted_on_failure", "[his
 
 TEST_CASE("PersistentHistory.failure_removes_from_disk_on_roundtrip", "[history]")
 {
-    auto dir = TempDir {};
-    auto const filePath = dir.path / "history.yml";
+    auto fixture = HistoryFixture {};
+    auto const filePath = fixture.dir / "history.yml";
 
     // Persist two commands successfully
     {
-        auto history = endo::PersistentHistory { testFs() };
+        auto history = endo::PersistentHistory { fixture.fs };
         history.setFilePath(filePath);
 
         history.add("git status");
@@ -161,7 +142,7 @@ TEST_CASE("PersistentHistory.failure_removes_from_disk_on_roundtrip", "[history]
 
     // Re-run "git status" with failure — should un-persist it
     {
-        auto history = endo::PersistentHistory { testFs() };
+        auto history = endo::PersistentHistory { fixture.fs };
         history.setFilePath(filePath);
         history.load();
         REQUIRE(history.size() == 2);
@@ -172,7 +153,7 @@ TEST_CASE("PersistentHistory.failure_removes_from_disk_on_roundtrip", "[history]
 
     // Reload and verify only "cmake --build" survives
     {
-        auto history = endo::PersistentHistory { testFs() };
+        auto history = endo::PersistentHistory { fixture.fs };
         history.setFilePath(filePath);
         history.load();
 
@@ -183,12 +164,12 @@ TEST_CASE("PersistentHistory.failure_removes_from_disk_on_roundtrip", "[history]
 
 TEST_CASE("PersistentHistory.load_save_roundtrip", "[history]")
 {
-    auto dir = TempDir {};
-    auto const filePath = dir.path / "history.yml";
+    auto fixture = HistoryFixture {};
+    auto const filePath = fixture.dir / "history.yml";
 
     // Create and save
     {
-        auto history = endo::PersistentHistory { testFs() };
+        auto history = endo::PersistentHistory { fixture.fs };
         history.setFilePath(filePath);
 
         history.add("git status");
@@ -203,7 +184,7 @@ TEST_CASE("PersistentHistory.load_save_roundtrip", "[history]")
 
     // Load in a new instance
     {
-        auto history = endo::PersistentHistory { testFs() };
+        auto history = endo::PersistentHistory { fixture.fs };
         history.setFilePath(filePath);
         history.load();
 
@@ -216,9 +197,8 @@ TEST_CASE("PersistentHistory.load_save_roundtrip", "[history]")
 
 TEST_CASE("PersistentHistory.recency_over_frequency", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     // Add "git status" many times to boost frequency
     history.add("git status");
@@ -241,9 +221,8 @@ TEST_CASE("PersistentHistory.recency_over_frequency", "[history]")
 
 TEST_CASE("PersistentHistory.frequency_tiebreaker", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     // Build up frequency for "git status" (executionCount = 20)
     for (auto i = 0; i < 20; ++i)
@@ -276,9 +255,9 @@ TEST_CASE("PersistentHistory.frequency_tiebreaker", "[history]")
 
 TEST_CASE("PersistentHistory.maxSize_eviction", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory(testFs(), 5); // small max
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto history = endo::PersistentHistory { fixture.fs, 5 }; // small max
+    history.setFilePath(fixture.dir / "history.yml");
 
     for (auto i = 0; i < 6; ++i)
     {
@@ -291,18 +270,18 @@ TEST_CASE("PersistentHistory.maxSize_eviction", "[history]")
 
 TEST_CASE("PersistentHistory.import_fish", "[history]")
 {
-    auto dir = TempDir {};
-    auto const fishPath = dir.path / "fish_history";
-    writeFile(fishPath,
-              "- cmd: git status\n"
-              "  when: 1707849600\n"
-              "- cmd: cmake --build\n"
-              "  when: 1707849400\n"
-              "- cmd: ls -la\n"
-              "  when: 1707849200\n");
+    auto fixture = HistoryFixture {};
+    auto const fishPath = fixture.dir / "fish_history";
+    fixture.fs.addFile(fishPath,
+                       "- cmd: git status\n"
+                       "  when: 1707849600\n"
+                       "- cmd: cmake --build\n"
+                       "  when: 1707849400\n"
+                       "- cmd: ls -la\n"
+                       "  when: 1707849200\n");
 
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto history = endo::PersistentHistory { fixture.fs };
+    history.setFilePath(fixture.dir / "history.yml");
     auto const imported = history.importFish(fishPath);
     CHECK(imported == 3);
 
@@ -315,15 +294,15 @@ TEST_CASE("PersistentHistory.import_fish", "[history]")
 
 TEST_CASE("PersistentHistory.import_zsh_extended", "[history]")
 {
-    auto dir = TempDir {};
-    auto const zshPath = dir.path / "zsh_history";
-    writeFile(zshPath,
-              ": 1707849600:0;git status\n"
-              ": 1707849400:0;cmake --build\n"
-              ": 1707849200:0;ls -la\n");
+    auto fixture = HistoryFixture {};
+    auto const zshPath = fixture.dir / "zsh_history";
+    fixture.fs.addFile(zshPath,
+                       ": 1707849600:0;git status\n"
+                       ": 1707849400:0;cmake --build\n"
+                       ": 1707849200:0;ls -la\n");
 
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto history = endo::PersistentHistory { fixture.fs };
+    history.setFilePath(fixture.dir / "history.yml");
     auto const imported = history.importZsh(zshPath);
     CHECK(imported == 3);
 
@@ -334,15 +313,15 @@ TEST_CASE("PersistentHistory.import_zsh_extended", "[history]")
 
 TEST_CASE("PersistentHistory.import_bash", "[history]")
 {
-    auto dir = TempDir {};
-    auto const bashPath = dir.path / "bash_history";
-    writeFile(bashPath,
-              "git status\n"
-              "cmake --build\n"
-              "ls -la\n");
+    auto fixture = HistoryFixture {};
+    auto const bashPath = fixture.dir / "bash_history";
+    fixture.fs.addFile(bashPath,
+                       "git status\n"
+                       "cmake --build\n"
+                       "ls -la\n");
 
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto history = endo::PersistentHistory { fixture.fs };
+    history.setFilePath(fixture.dir / "history.yml");
     auto const imported = history.importBash(bashPath);
     CHECK(imported == 3);
 
@@ -353,9 +332,9 @@ TEST_CASE("PersistentHistory.import_bash", "[history]")
 
 TEST_CASE("PersistentHistory.nonexistent_file_loads_empty", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "does_not_exist.yml");
+    auto fixture = HistoryFixture {};
+    auto history = endo::PersistentHistory { fixture.fs };
+    history.setFilePath(fixture.dir / "does_not_exist.yml");
     history.load();
 
     CHECK(history.size() == 0);
@@ -364,11 +343,11 @@ TEST_CASE("PersistentHistory.nonexistent_file_loads_empty", "[history]")
 
 TEST_CASE("PersistentHistory.corrupt_yaml_loads_empty", "[history]")
 {
-    auto dir = TempDir {};
-    auto const filePath = dir.path / "history.yml";
-    writeFile(filePath, "{{{{not valid yaml at all!!!!}}}}");
+    auto fixture = HistoryFixture {};
+    auto const filePath = fixture.dir / "history.yml";
+    fixture.fs.addFile(filePath, "{{{{not valid yaml at all!!!!}}}}");
 
-    auto history = endo::PersistentHistory { testFs() };
+    auto history = endo::PersistentHistory { fixture.fs };
     history.setFilePath(filePath);
     history.load();
 
@@ -377,9 +356,8 @@ TEST_CASE("PersistentHistory.corrupt_yaml_loads_empty", "[history]")
 
 TEST_CASE("PersistentHistory.entries_returns_unique_set", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("git status");
     history.add("git log");
@@ -397,9 +375,8 @@ TEST_CASE("PersistentHistory.entries_returns_unique_set", "[history]")
 
 TEST_CASE("PersistentHistory.trim_whitespace", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("  git status  ");
     REQUIRE(history.size() == 1);
@@ -412,9 +389,8 @@ TEST_CASE("PersistentHistory.trim_whitespace", "[history]")
 
 TEST_CASE("PersistentHistory.whitespace_only_not_added", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("   ");
     history.add("\t\n\r");
@@ -425,9 +401,8 @@ TEST_CASE("PersistentHistory.whitespace_only_not_added", "[history]")
 
 TEST_CASE("PersistentHistory.trimmed_duplicates_detected", "[history]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("git status");
     history.add("  git status  "); // duplicate after trimming
@@ -439,18 +414,18 @@ TEST_CASE("PersistentHistory.trimmed_duplicates_detected", "[history]")
 
 TEST_CASE("PersistentHistory.atomic_flush_uses_tmp", "[history]")
 {
-    auto dir = TempDir {};
-    auto const filePath = dir.path / "history.yml";
-    auto history = endo::PersistentHistory { testFs() };
+    auto fixture = HistoryFixture {};
+    auto const filePath = fixture.dir / "history.yml";
+    auto history = endo::PersistentHistory { fixture.fs };
     history.setFilePath(filePath);
 
     history.add("test command");
     history.markLastResult(0);
 
     // The .tmp file should not remain after flush
-    CHECK(!std::filesystem::exists(filePath.string() + ".tmp"));
+    CHECK(!fixture.fs.exists(filePath.string() + ".tmp"));
     // The actual file should exist
-    CHECK(std::filesystem::exists(filePath));
+    CHECK(fixture.fs.exists(filePath));
 }
 
 // ---------------------------------------------------------------------------
@@ -459,10 +434,10 @@ TEST_CASE("PersistentHistory.atomic_flush_uses_tmp", "[history]")
 
 TEST_CASE("PersistentHistory.cwd_and_paths_yaml_roundtrip", "[history][cwd]")
 {
-    auto dir = TempDir {};
-    auto const filePath = dir.path / "history.yml";
+    auto fixture = HistoryFixture {};
+    auto const filePath = fixture.dir / "history.yml";
     {
-        auto history = endo::PersistentHistory { testFs() };
+        auto history = endo::PersistentHistory { fixture.fs };
         history.setFilePath(filePath);
         history.add("vim ~/notes/plan.md",
                     endo::HistoryAddContext {
@@ -472,7 +447,7 @@ TEST_CASE("PersistentHistory.cwd_and_paths_yaml_roundtrip", "[history][cwd]")
         history.markLastResult(0);
     }
 
-    auto history = endo::PersistentHistory { testFs() };
+    auto history = endo::PersistentHistory { fixture.fs };
     history.setFilePath(filePath);
     history.load();
 
@@ -486,17 +461,17 @@ TEST_CASE("PersistentHistory.cwd_and_paths_yaml_roundtrip", "[history][cwd]")
 
 TEST_CASE("PersistentHistory.legacy_v1_yaml_loads_without_cwd", "[history][cwd]")
 {
-    auto dir = TempDir {};
-    auto const filePath = dir.path / "history.yml";
+    auto fixture = HistoryFixture {};
+    auto const filePath = fixture.dir / "history.yml";
     // Hand-craft a legacy v1 file (no cwd, no paths).
-    writeFile(filePath,
-              "version: 1\n"
-              "entries:\n"
-              "  - cmd: legacy command\n"
-              "    ts: 1000\n"
-              "    count: 2\n");
+    fixture.fs.addFile(filePath,
+                       "version: 1\n"
+                       "entries:\n"
+                       "  - cmd: legacy command\n"
+                       "    ts: 1000\n"
+                       "    count: 2\n");
 
-    auto history = endo::PersistentHistory { testFs() };
+    auto history = endo::PersistentHistory { fixture.fs };
     history.setFilePath(filePath);
     history.load();
 
@@ -518,9 +493,8 @@ TEST_CASE("PersistentHistory.legacy_v1_yaml_loads_without_cwd", "[history][cwd]"
 
 TEST_CASE("PersistentHistory.exact_cwd_match_boosts_rank", "[history][cwd]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("make build", endo::HistoryAddContext { .cwd = "~/projects/other", .requiredPaths = {} });
     history.add("make build", endo::HistoryAddContext { .cwd = "~/projects/endo", .requiredPaths = {} });
@@ -541,9 +515,8 @@ TEST_CASE("PersistentHistory.exact_cwd_match_boosts_rank", "[history][cwd]")
 
 TEST_CASE("PersistentHistory.ancestor_cwd_match_weaker_than_exact", "[history][cwd]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     // Entry stored with cwd = ~/projects ; current CWD is ~/projects/endo (descendant).
     history.add("scan project", endo::HistoryAddContext { .cwd = "~/projects", .requiredPaths = {} });
@@ -563,9 +536,8 @@ TEST_CASE("PersistentHistory.ancestor_cwd_match_weaker_than_exact", "[history][c
 
 TEST_CASE("PersistentHistory.required_paths_filtered_when_missing", "[history][required-paths]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("cat ~/notes/plan.md",
                 endo::HistoryAddContext { .cwd = "~", .requiredPaths = { "~/notes/plan.md" } });
@@ -588,9 +560,8 @@ TEST_CASE("PersistentHistory.required_paths_filtered_when_missing", "[history][r
 
 TEST_CASE("PersistentHistory.required_paths_kept_when_file_exists", "[history][required-paths]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("cat ~/notes/plan.md",
                 endo::HistoryAddContext { .cwd = "~", .requiredPaths = { "~/notes/plan.md" } });
@@ -611,9 +582,8 @@ TEST_CASE("PersistentHistory.required_paths_kept_when_file_exists", "[history][r
 
 TEST_CASE("PersistentHistory.required_paths_validation_disabled", "[history][required-paths]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("cat ~/missing.txt",
                 endo::HistoryAddContext { .cwd = "~", .requiredPaths = { "~/missing.txt" } });
@@ -638,9 +608,8 @@ TEST_CASE("PersistentHistory.fuzzy_finds_substring_after_repeated_grapheme", "[h
     // earlier in the command (the greedy matcher scattered the match and the
     // long entry fell below the fuzzy quality threshold). The command has no
     // path arguments, so required-paths validation is not involved here.
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add("./build/clangcl-debug/src/shell/endo.exe",
                 endo::HistoryAddContext { .cwd = "~/projects/endo", .requiredPaths = {} });
@@ -656,9 +625,8 @@ TEST_CASE("PersistentHistory.fuzzy_finds_substring_after_repeated_grapheme", "[h
 
 TEST_CASE("PersistentHistory.readd_updates_cwd_and_paths", "[history][cwd]")
 {
-    auto dir = TempDir {};
-    auto history = endo::PersistentHistory { testFs() };
-    history.setFilePath(dir.path / "history.yml");
+    auto fixture = HistoryFixture {};
+    auto& history = fixture.history;
 
     history.add(
         "make build",

--- a/src/shell/testing/InjectedShell.hpp
+++ b/src/shell/testing/InjectedShell.hpp
@@ -2,8 +2,10 @@
 #pragma once
 
 #include <shell/Shell.hpp>
+#include <shell/SixelCapability.hpp>
 #include <shell/TTY.hpp>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -45,10 +47,10 @@ inline void seedInjectedShell(endo::InMemoryFileSystem& fs, endo::TestEnvironmen
 /// child inherits descriptors, and there is no descriptor for an in-memory file. Those keep
 /// using a real filesystem.
 ///
-/// The in-memory model is also deliberately shallow in places: lastWriteTime() always
-/// reports "now", weaklyCanonical() never resolves symlinks, symlinks are metadata only,
-/// and permissions are not enforced beyond denyAccess(). A test whose assertion depends on
-/// any of those would pass vacuously here and belongs on a real filesystem.
+/// The in-memory model is also deliberately shallow in places: lastWriteTime() always reports
+/// "now", weaklyCanonical() never resolves symlinks (the type queries and the stream opens do
+/// follow them), and permissions are not enforced beyond denyAccess(). A test whose assertion
+/// depends on any of those would pass vacuously here and belongs on a real filesystem.
 struct InMemoryShell
 {
     endo::TestPTY pty;

--- a/src/shell/testing/InjectedShell.hpp
+++ b/src/shell/testing/InjectedShell.hpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <shell/Shell.hpp>
+#include <shell/TTY.hpp>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include <platform/testing/InMemoryFileSystem.hpp>
+#include <platform/testing/TestEnvironmentProvider.hpp>
+
+namespace endo::testing
+{
+
+/// @brief Seeds the "/test" convention every injected-filesystem fixture shares.
+///
+/// Kept in one place because a fixture that seeds it differently is not a variant, it is a
+/// bug: the shell resolves a relative path through the filesystem and the environment both,
+/// so the two views of the working directory have to agree. $HOME matters for the same
+/// reason -- it decides where per-user state such as the trust store lives, and pointing it
+/// at the host's would put every test back on one shared real file.
+///
+/// @param fs    The injected filesystem to seed.
+/// @param env   The injected environment to keep in step with it.
+/// @param shell The shell owning them.
+inline void seedInjectedShell(endo::InMemoryFileSystem& fs, endo::TestEnvironment& env, endo::Shell& shell)
+{
+    fs.addDirectory("/test");
+    fs.setCurrentPath("/test");
+    env.set("HOME", "/test/home");
+    env.set("PWD", "/test");
+    shell.addModuleSearchPath("/test");
+    // Never probe the test PTY for Sixel support: the query would leak escape bytes into
+    // the captured output and stall on timeout.
+    shell.setSixelCapability(std::make_unique<endo::StaticSixelCapability>(false));
+}
+
+/// @brief A shell whose filesystem is private to the test case.
+///
+/// Nothing it reads or writes touches the host's disk, so concurrent instances cannot
+/// collide and no fixture has to be cleaned up. Tests that need a real descriptor -- a
+/// redirect target, an external program, process substitution -- cannot use this: a forked
+/// child inherits descriptors, and there is no descriptor for an in-memory file. Those keep
+/// using a real filesystem.
+///
+/// The in-memory model is also deliberately shallow in places: lastWriteTime() always
+/// reports "now", weaklyCanonical() never resolves symlinks, symlinks are metadata only,
+/// and permissions are not enforced beyond denyAccess(). A test whose assertion depends on
+/// any of those would pass vacuously here and belongs on a real filesystem.
+struct InMemoryShell
+{
+    endo::TestPTY pty;
+    endo::InMemoryFileSystem fs;
+    endo::TestEnvironment env { "/test" };
+    int exitCode = -1;
+
+    endo::Shell shell { pty, env, fs };
+
+    [[nodiscard]] std::string output() const { return pty.output(); }
+
+    /// @param path Path within the injected filesystem.
+    /// @return The file's content, or an empty string when it does not exist.
+    [[nodiscard]] std::string content(std::filesystem::path const& path) const
+    {
+        return fs.readFile(path).value_or(std::string {});
+    }
+
+    InMemoryShell() { seedInjectedShell(fs, env, shell); }
+
+    InMemoryShell& operator()(std::string_view cmd)
+    {
+        exitCode = shell.execute(std::string(cmd));
+        return *this;
+    }
+};
+
+} // namespace endo::testing

--- a/src/shell/ui/PromptComponent_test.cpp
+++ b/src/shell/ui/PromptComponent_test.cpp
@@ -15,8 +15,8 @@
 #include <thread>
 
 #include "PromptComponent.hpp"
+#include <platform/NativeFileSystem.hpp>
 #include <platform/PathUtils.hpp>
-#include <platform/testing/InMemoryFileSystem.hpp>
 #include <platform/testing/TestEnvironmentProvider.hpp>
 #include <testing/ScopedTempDir.hpp>
 
@@ -119,7 +119,9 @@ TEST_CASE("PromptComponent.tab_inserts_common_prefix_before_popup", "[prompt]")
     endo::InMemoryHistory history;
     endo::TestEnvironment env;
     endo::FSharpPersistentState fsharpState;
-    endo::InMemoryFileSystem fileSystem;
+    // Real filesystem: these complete against directories created on disk above,
+    // and assert the on-disk capitalisation that only a real lookup can supply.
+    auto const& fileSystem = endo::NativeFileSystem::instance();
     endo::Completer completer(env, history, fsharpState, fileSystem);
 
     // Use an absolute path so only file-path completion applies (mirrors `cd D:/last`).
@@ -156,7 +158,9 @@ TEST_CASE("PromptComponent.tab_quotes_path_with_space", "[prompt]")
     endo::InMemoryHistory history;
     endo::TestEnvironment env;
     endo::FSharpPersistentState fsharpState;
-    endo::InMemoryFileSystem fileSystem;
+    // Real filesystem: these complete against directories created on disk above,
+    // and assert the on-disk capitalisation that only a real lookup can supply.
+    auto const& fileSystem = endo::NativeFileSystem::instance();
     endo::Completer completer(env, history, fsharpState, fileSystem);
 
     auto const typed = "cd " + endo::platform::normalizePath((base / "space").string());

--- a/src/shell/ui/PromptComponent_test.cpp
+++ b/src/shell/ui/PromptComponent_test.cpp
@@ -18,6 +18,7 @@
 #include <platform/PathUtils.hpp>
 #include <platform/testing/InMemoryFileSystem.hpp>
 #include <platform/testing/TestEnvironmentProvider.hpp>
+#include <testing/ScopedTempDir.hpp>
 
 using namespace endo;
 
@@ -110,8 +111,8 @@ TEST_CASE("PromptComponent.tab_inserts_common_prefix_before_popup", "[prompt]")
     // all candidates (e.g. "last" -> "lastrada-") without showing the popup; only the
     // next Tab opens the popup to disambiguate.
     namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_prompt_common_prefix";
-    fs::remove_all(base);
+    auto const baseGuard = endo::testing::ScopedTempDir { "endo_prompt_common_prefix" };
+    auto const& base = baseGuard.path();
     fs::create_directories(base / "lastrada-tools");
     fs::create_directories(base / "lastrada-config");
 
@@ -140,8 +141,6 @@ TEST_CASE("PromptComponent.tab_inserts_common_prefix_before_popup", "[prompt]")
     // Second Tab: the common prefix no longer extends the word, so show the popup.
     (void) comp.processInput(tabEvent());
     CHECK(comp.completionVisible());
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("PromptComponent.tab_quotes_path_with_space", "[prompt]")
@@ -150,8 +149,8 @@ TEST_CASE("PromptComponent.tab_quotes_path_with_space", "[prompt]")
     // double quote so it stays a single argument. A directory candidate leaves the
     // quote open so completion can continue inside it.
     namespace fs = std::filesystem;
-    auto const base = fs::temp_directory_path() / "endo_prompt_quote_space";
-    fs::remove_all(base);
+    auto const baseGuard = endo::testing::ScopedTempDir { "endo_prompt_quote_space" };
+    auto const& base = baseGuard.path();
     fs::create_directories(base / "space dir");
 
     endo::InMemoryHistory history;
@@ -169,8 +168,6 @@ TEST_CASE("PromptComponent.tab_quotes_path_with_space", "[prompt]")
 
     (void) comp.processInput(tabEvent());
     CHECK(comp.text() == expected);
-
-    fs::remove_all(base);
 }
 
 TEST_CASE("PromptComponent.ctrl_d_after_timeout_shows_hint_again", "[prompt]")

--- a/src/shell/util/CommandResolver_test.cpp
+++ b/src/shell/util/CommandResolver_test.cpp
@@ -5,10 +5,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <filesystem>
-#include <fstream>
 #include <string>
 
-#include <platform/NativeFileSystem.hpp>
 #include <platform/testing/InMemoryFileSystem.hpp>
 #include <platform/testing/TestEnvironmentProvider.hpp>
 
@@ -17,50 +15,33 @@ using namespace endo;
 namespace
 {
 
-/// @brief RAII helper that creates a temporary directory and removes it on destruction.
-struct TempDir
+/// @brief A $PATH directory populated inside a filesystem private to one test.
+///
+/// CommandResolver already takes FileSystem const&, so injecting an in-memory one is the
+/// designed seam: each test gets its own tree, with no shared path to collide over.
+struct PathDir
 {
-    std::filesystem::path path;
+    endo::InMemoryFileSystem fs;
+    std::filesystem::path path { "/test/bin" };
 
-    TempDir()
-    {
-        path = std::filesystem::temp_directory_path() / "endo_test_cmdresolver";
-        std::filesystem::create_directories(path);
-    }
+    PathDir() { fs.addDirectory(path); }
 
-    ~TempDir() { std::filesystem::remove_all(path); }
+    /// @brief Creates an executable file with the given name in the directory.
+    void createExecutable(std::string const& name) { fs.addExecutable(path / name); }
 
-    /// @brief Creates a zero-byte file with the given name inside the temp directory.
-    /// On POSIX, sets owner-execute permission.
-    [[nodiscard]] std::filesystem::path createExecutable(std::string const& name) const
-    {
-        auto const filePath = path / name;
-        std::ofstream { filePath }.flush();
-#if !defined(_WIN32)
-        std::filesystem::permissions(
-            filePath, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
-#endif
-        return filePath;
-    }
-
-    /// @brief Creates a zero-byte file without execute permission (POSIX only distinction).
-    [[nodiscard]] std::filesystem::path createNonExecutable(std::string const& name) const
-    {
-        auto const filePath = path / name;
-        std::ofstream { filePath }.flush();
-        return filePath;
-    }
+    /// @brief Creates a file without the execute bit.
+    void createNonExecutable(std::string const& name) { fs.addFile(path / name, ""); }
 };
 
 } // namespace
 
 TEST_CASE("CommandResolver.findInPath.bare_name_found")
 {
-    TempDir dir;
+    PathDir dir;
 #if defined(_WIN32)
-    (void) dir.createExecutable("testcmd.exe");
+    dir.createExecutable("testcmd.exe");
 #else
-    (void) dir.createExecutable("testcmd");
+    dir.createExecutable("testcmd");
 #endif
 
     platform::TestEnvironmentProvider env;
@@ -69,7 +50,7 @@ TEST_CASE("CommandResolver.findInPath.bare_name_found")
     env.set("PATHEXT", ".exe;.cmd;.bat");
 #endif
 
-    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
+    auto const resolver = CommandResolver(env, dir.fs);
     auto const result = resolver.findInPath("testcmd");
     REQUIRE(!result.empty());
     CHECK(std::filesystem::path(result).filename().string().starts_with("testcmd"));
@@ -77,7 +58,7 @@ TEST_CASE("CommandResolver.findInPath.bare_name_found")
 
 TEST_CASE("CommandResolver.findInPath.not_found")
 {
-    TempDir dir;
+    PathDir dir;
 
     platform::TestEnvironmentProvider env;
     env.set("PATH", dir.path.string());
@@ -85,7 +66,7 @@ TEST_CASE("CommandResolver.findInPath.not_found")
     env.set("PATHEXT", ".exe");
 #endif
 
-    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
+    auto const resolver = CommandResolver(env, dir.fs);
     auto const result = resolver.findInPath("nonexistent");
     CHECK(result.empty());
 }
@@ -95,28 +76,29 @@ TEST_CASE("CommandResolver.findInPath.missing_PATH")
     platform::TestEnvironmentProvider env;
     // No PATH set at all.
 
-    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
+    auto const fs = endo::InMemoryFileSystem {};
+    auto const resolver = CommandResolver(env, fs);
     auto const result = resolver.findInPath("anything");
     CHECK(result.empty());
 }
 
 TEST_CASE("CommandResolver.findInPath.skips_nonexistent_directory")
 {
-    TempDir dir;
+    PathDir dir;
 #if defined(_WIN32)
-    (void) dir.createExecutable("mycmd.exe");
+    dir.createExecutable("mycmd.exe");
     auto const pathValue = std::string("C:\\no_such_dir_12345") + ";" + dir.path.string();
     platform::TestEnvironmentProvider env;
     env.set("PATH", pathValue);
     env.set("PATHEXT", ".exe");
 #else
-    (void) dir.createExecutable("mycmd");
+    dir.createExecutable("mycmd");
     auto const pathValue = std::string("/no_such_dir_12345") + ":" + dir.path.string();
     platform::TestEnvironmentProvider env;
     env.set("PATH", pathValue);
 #endif
 
-    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
+    auto const resolver = CommandResolver(env, dir.fs);
     auto const result = resolver.findInPath("mycmd");
     REQUIRE(!result.empty());
     CHECK(std::filesystem::path(result).filename().string().starts_with("mycmd"));
@@ -125,15 +107,15 @@ TEST_CASE("CommandResolver.findInPath.skips_nonexistent_directory")
 #if defined(_WIN32)
 TEST_CASE("CommandResolver.findInPath.PATHEXT_resolution")
 {
-    TempDir dir;
+    PathDir dir;
     // Create testapp.cmd — should be found when searching for "testapp"
-    (void) dir.createExecutable("testapp.cmd");
+    dir.createExecutable("testapp.cmd");
 
     platform::TestEnvironmentProvider env;
     env.set("PATH", dir.path.string());
     env.set("PATHEXT", ".exe;.cmd;.bat");
 
-    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
+    auto const resolver = CommandResolver(env, dir.fs);
     auto const result = resolver.findInPath("testapp");
     REQUIRE(!result.empty());
     CHECK(result.ends_with(".cmd"));
@@ -308,14 +290,20 @@ TEST_CASE("CommandResolver.resolve.invalidates_cache_on_PATHEXT_change")
 #if !defined(_WIN32)
 TEST_CASE("CommandResolver.findInPath.skips_non_executable")
 {
-    TempDir dir;
+    // POSIX-only, even though the in-memory model carries an execute bit everywhere:
+    // on Windows candidateNames() never probes the extensionless name (it expands "noexec"
+    // to noexec.exe/.cmd/.bat/.com/.ps1), so the search would come back empty whatever the
+    // execute bit says — and NativeFileSystem on Windows deliberately treats any existing
+    // non-directory entry as executable, so the assertion would not describe the real
+    // platform behaviour either.
+    PathDir dir;
     // Create a file without execute permission — should not be found.
-    (void) dir.createNonExecutable("noexec");
+    dir.createNonExecutable("noexec");
 
     platform::TestEnvironmentProvider env;
     env.set("PATH", dir.path.string());
 
-    auto const resolver = CommandResolver(env, platform::NativeFileSystem::instance());
+    auto const resolver = CommandResolver(env, dir.fs);
     auto const result = resolver.findInPath("noexec");
     CHECK(result.empty());
 }

--- a/src/shell/util/GlobMatcher.cpp
+++ b/src/shell/util/GlobMatcher.cpp
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "GlobMatcher.hpp"
 
-#include <platform/PathUtils.hpp>
-
 #include <algorithm>
 #include <filesystem>
 #include <ranges>
 #include <string>
 
+#include <platform/PathUtils.hpp>
+
 namespace endo
 {
 
-std::vector<std::string> expandGlobPattern(std::string_view pattern)
+std::vector<std::string> expandGlobPattern(platform::FileSystem const& fileSystem, std::string_view pattern)
 {
     namespace fs = std::filesystem;
     std::vector<std::string> results;
@@ -20,7 +20,7 @@ std::vector<std::string> expandGlobPattern(std::string_view pattern)
     auto const starstarPos = patternStr.find("**");
     if (starstarPos != std::string::npos)
     {
-        return expandRecursiveGlob(patternStr);
+        return expandRecursiveGlob(fileSystem, patternStr);
     }
 
     fs::path patternPath(patternStr);
@@ -38,24 +38,21 @@ std::vector<std::string> expandGlobPattern(std::string_view pattern)
         return {};
     }
 
-    std::error_code ec;
-    if (!fs::exists(dirPath, ec) || ec)
+    auto const listing = fileSystem.listDirectory(dirPath);
+    if (!listing)
     {
         return {};
     }
 
-    for (auto const& entry: fs::directory_iterator(dirPath, ec))
+    for (auto const& entry: *listing)
     {
-        if (ec)
-            break;
-
-        std::string filename = entry.path().filename().string();
+        std::string filename = entry.path.filename().string();
         if (globMatchFilename(filename, filePattern))
         {
             if (dirPath == ".")
                 results.push_back(filename);
             else
-                results.push_back(platform::normalizePath(entry.path()));
+                results.push_back(platform::normalizePath(entry.path));
         }
     }
 
@@ -64,9 +61,8 @@ std::vector<std::string> expandGlobPattern(std::string_view pattern)
     return results;
 }
 
-std::vector<std::string> expandRecursiveGlob(std::string_view pattern)
+std::vector<std::string> expandRecursiveGlob(platform::FileSystem const& fileSystem, std::string_view pattern)
 {
-    namespace fs = std::filesystem;
     std::vector<std::string> results;
     std::string patternStr(pattern);
 
@@ -84,20 +80,16 @@ std::vector<std::string> expandRecursiveGlob(std::string_view pattern)
     while (!suffixPattern.empty() && (suffixPattern.front() == '/' || suffixPattern.front() == '\\'))
         suffixPattern.erase(0, 1);
 
-    std::error_code ec;
-    if (!fs::exists(basePath, ec) || ec)
+    if (!fileSystem.isDirectory(basePath))
         return {};
 
-    for (auto const& entry: fs::recursive_directory_iterator(basePath, ec))
+    for (auto const& entry: fileSystem.walkDirectoryRecursive(basePath))
     {
-        if (ec)
-            break;
-
-        if (!entry.is_regular_file())
+        if (!entry.isRegularFile)
             continue;
 
-        std::string filePath = platform::normalizePath(entry.path());
-        std::string filename = entry.path().filename().string();
+        std::string filePath = platform::normalizePath(entry.path);
+        std::string filename = entry.path.filename().string();
 
         if (!suffixPattern.empty())
         {

--- a/src/shell/util/GlobMatcher.cpp
+++ b/src/shell/util/GlobMatcher.cpp
@@ -61,28 +61,41 @@ std::vector<std::string> expandGlobPattern(platform::FileSystem const& fileSyste
     return results;
 }
 
-/// @brief Spells a walked path relative to the base the walk started from.
-///
-/// walkDirectoryRecursive() yields whatever the filesystem considers the entry's path, and an
-/// injected filesystem resolves a relative base such as "." to an absolute one. Re-anchoring
-/// keeps `**` results in the same shape as `*` results regardless of the backend.
-///
-/// @param fileSystem The filesystem being walked; its working directory is the anchor.
-/// @param entryPath   The path as reported by the walk.
-/// @param basePath    The base the walk started from.
-/// @return The entry path relative to @p basePath when the base was ".", else normalized.
-std::string relativizeToBase(platform::FileSystem const& fileSystem,
-                             std::filesystem::path const& entryPath,
-                             std::string_view basePath)
+namespace
 {
-    if (basePath != ".")
-        return platform::normalizePath(entryPath);
+    /// @brief Spells a walked path relative to the base the walk started from.
+    ///
+    /// walkDirectoryRecursive() yields whatever the filesystem considers the entry's path, and
+    /// the two backends disagree about what that is for a base of ".": an injected filesystem
+    /// resolves it to its own working directory and reports absolute paths, while the real one
+    /// hands back "./sub/file". Re-anchoring the first and normalizing the second away leaves
+    /// both spelled the way expandGlobPattern() spells a match in ".", i.e. with no "./"
+    /// prefix, so `**` and `*` agree with each other and across backends.
+    ///
+    /// @param fileSystem The filesystem being walked; its working directory is the anchor.
+    /// @param entryPath   The path as reported by the walk.
+    /// @param basePath    The base the walk started from.
+    /// @return The entry path relative to @p basePath when the base was ".", else normalized.
+    [[nodiscard]] std::string relativizeToBase(platform::FileSystem const& fileSystem,
+                                               std::filesystem::path const& entryPath,
+                                               std::string_view basePath)
+    {
+        if (basePath != ".")
+            return platform::normalizePath(entryPath);
 
-    // The filesystem's working directory, never the process's: they are different views
-    // whenever the filesystem is injected, which is the whole reason this exists.
-    auto const relative = entryPath.lexically_relative(fileSystem.currentPath());
-    return platform::normalizePath(relative.empty() ? entryPath : relative);
-}
+        // The filesystem's working directory, never the process's: they are different views
+        // whenever the filesystem is injected, which is the whole reason this exists.
+        auto const relative = entryPath.lexically_relative(fileSystem.currentPath());
+        if (!relative.empty())
+            return platform::normalizePath(relative);
+
+        // lexically_relative() gives up whenever the entry is relative and the working
+        // directory absolute -- which is every entry the real filesystem yields for a walk
+        // rooted at ".". Those already are relative to the base; only the leading "." the
+        // iterator prepended has to go.
+        return platform::normalizePath(entryPath.lexically_normal());
+    }
+} // namespace
 
 std::vector<std::string> expandRecursiveGlob(platform::FileSystem const& fileSystem, std::string_view pattern)
 {

--- a/src/shell/util/GlobMatcher.cpp
+++ b/src/shell/util/GlobMatcher.cpp
@@ -61,6 +61,29 @@ std::vector<std::string> expandGlobPattern(platform::FileSystem const& fileSyste
     return results;
 }
 
+/// @brief Spells a walked path relative to the base the walk started from.
+///
+/// walkDirectoryRecursive() yields whatever the filesystem considers the entry's path, and an
+/// injected filesystem resolves a relative base such as "." to an absolute one. Re-anchoring
+/// keeps `**` results in the same shape as `*` results regardless of the backend.
+///
+/// @param fileSystem The filesystem being walked; its working directory is the anchor.
+/// @param entryPath   The path as reported by the walk.
+/// @param basePath    The base the walk started from.
+/// @return The entry path relative to @p basePath when the base was ".", else normalized.
+std::string relativizeToBase(platform::FileSystem const& fileSystem,
+                             std::filesystem::path const& entryPath,
+                             std::string_view basePath)
+{
+    if (basePath != ".")
+        return platform::normalizePath(entryPath);
+
+    // The filesystem's working directory, never the process's: they are different views
+    // whenever the filesystem is injected, which is the whole reason this exists.
+    auto const relative = entryPath.lexically_relative(fileSystem.currentPath());
+    return platform::normalizePath(relative.empty() ? entryPath : relative);
+}
+
 std::vector<std::string> expandRecursiveGlob(platform::FileSystem const& fileSystem, std::string_view pattern)
 {
     std::vector<std::string> results;
@@ -88,7 +111,11 @@ std::vector<std::string> expandRecursiveGlob(platform::FileSystem const& fileSys
         if (!entry.isRegularFile)
             continue;
 
-        std::string filePath = platform::normalizePath(entry.path);
+        // Spelled the way expandGlobPattern() spells its results: relative to the walk root
+        // when the pattern was relative. An injected filesystem resolves "." to an absolute
+        // path, so without this the same pattern yields absolute paths in a test and
+        // "./"-relative ones in the real shell.
+        std::string filePath = relativizeToBase(fileSystem, entry.path, basePath);
         std::string filename = entry.path.filename().string();
 
         if (!suffixPattern.empty())

--- a/src/shell/util/GlobMatcher.hpp
+++ b/src/shell/util/GlobMatcher.hpp
@@ -6,16 +6,30 @@
 #include <string_view>
 #include <vector>
 
+#include <platform/FileSystem.hpp>
 #include <platform/GlobMatch.hpp>
 
 namespace endo
 {
 
 /// Expands a glob pattern to matching file paths. Returns empty if no matches.
-[[nodiscard]] std::vector<std::string> expandGlobPattern(std::string_view pattern);
+///
+/// Enumerates @p fileSystem rather than the real filesystem: a shell told to operate on an injected
+/// filesystem must expand `*.txt` against the same one it will then act on, or it deletes
+/// files it never listed.
+///
+/// @param fileSystem Filesystem to enumerate.
+/// @param pattern The glob pattern.
+/// @return Matching paths, or empty when nothing matches.
+[[nodiscard]] std::vector<std::string> expandGlobPattern(platform::FileSystem const& fileSystem,
+                                                         std::string_view pattern);
 
 /// Expands a recursive glob pattern (containing **) to matching file paths.
-[[nodiscard]] std::vector<std::string> expandRecursiveGlob(std::string_view pattern);
+/// @param fileSystem Filesystem to enumerate.
+/// @param pattern The glob pattern.
+/// @return Matching paths, or empty when nothing matches.
+[[nodiscard]] std::vector<std::string> expandRecursiveGlob(platform::FileSystem const& fileSystem,
+                                                           std::string_view pattern);
 
 /// Matches text against a shell glob pattern (for parameter expansion).
 [[nodiscard]] inline bool globMatch(std::string_view text, std::string_view pattern)

--- a/src/shell/util/GlobMatcher_test.cpp
+++ b/src/shell/util/GlobMatcher_test.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "GlobMatcher.hpp"
+#include <platform/NativeFileSystem.hpp>
+#include <platform/testing/InMemoryFileSystem.hpp>
+#include <testing/ScopedTempDir.hpp>
+#include <testing/ScopedWorkingDirectory.hpp>
+
+using endo::expandGlobPattern;
+using endo::expandRecursiveGlob;
+using endo::platform::testing::InMemoryFileSystem;
+
+// ============================================================================
+// Recursive globs must be spelled the same way whichever filesystem answers
+// ============================================================================
+
+TEST_CASE("expandRecursiveGlob spells matches relative to the walk root", "[glob]")
+{
+    // The injected filesystem resolves "." to its own working directory and reports absolute
+    // paths; a relative pattern must not pick that up, or an in-memory test would exercise
+    // argument strings the real shell never produces.
+    auto fs = InMemoryFileSystem {};
+    fs.addFile("/test/sub/deep/a.txt", "a");
+    fs.addFile("/test/sub/b.txt", "b");
+    fs.addFile("/test/sub/c.log", "c");
+    fs.setCurrentPath("/test");
+
+    auto matches = expandRecursiveGlob(fs, "**/*.txt");
+    std::ranges::sort(matches);
+
+    CHECK(matches == std::vector<std::string> { "sub/b.txt", "sub/deep/a.txt" });
+}
+
+#if !defined(_WIN32)
+TEST_CASE("expandRecursiveGlob agrees with the real filesystem", "[glob]")
+{
+    // The real walk yields "./sub/a.txt" for a root of "." -- relative, where the injected one
+    // yields an absolute path. Both must arrive at the same spelling, which is the one
+    // expandGlobPattern() already produces for a match in ".": no leading "./".
+    auto const dir = endo::testing::ScopedTempDir { "endo_glob_shape" };
+    std::filesystem::create_directories(dir / "sub" / "deep");
+    {
+        std::ofstream { dir / "sub" / "b.txt" } << "b";
+    }
+    {
+        std::ofstream { dir / "sub" / "deep" / "a.txt" } << "a";
+    }
+    {
+        std::ofstream { dir / "sub" / "c.log" } << "c";
+    }
+
+    auto const guard = endo::testing::ScopedWorkingDirectory { dir.path() };
+
+    auto matches = expandRecursiveGlob(endo::platform::NativeFileSystem::instance(), "**/*.txt");
+    std::ranges::sort(matches);
+
+    CHECK(matches == std::vector<std::string> { "sub/b.txt", "sub/deep/a.txt" });
+}
+#endif
+
+TEST_CASE("expandGlobPattern spells a match in the working directory as a bare name", "[glob]")
+{
+    // The shape expandRecursiveGlob() above is required to agree with.
+    auto fs = InMemoryFileSystem {};
+    fs.addFile("/test/a.txt", "a");
+    fs.addFile("/test/b.log", "b");
+    fs.setCurrentPath("/test");
+
+    CHECK(expandGlobPattern(fs, "*.txt") == std::vector<std::string> { "a.txt" });
+}

--- a/src/testing/EnvHelper.hpp
+++ b/src/testing/EnvHelper.hpp
@@ -2,6 +2,9 @@
 #pragma once
 
 #include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
 #ifdef _WIN32
     #include <stdlib.h> // _putenv_s
 #endif
@@ -31,5 +34,42 @@ inline void unsetTestEnv(char const* name)
     unsetenv(name);
 #endif
 }
+
+/// @brief Sets an environment variable for a scope, restoring the previous value after.
+///
+/// The environment is process-global, so a test that sets a variable and restores it at the
+/// end of the test body leaks that change whenever an assertion throws first. $HOME is the
+/// one that bites here: other fixtures read it while constructing a shell, so a leaked
+/// value silently redirects a later test's history or config to the wrong place.
+class ScopedEnv
+{
+  public:
+    /// @brief Sets @p name to @p value until this object goes out of scope.
+    /// @param name  Environment variable name.
+    /// @param value Value to set for the duration of the scope.
+    ScopedEnv(std::string_view name, std::string_view value): _name { name }
+    {
+        if (auto const* previous = std::getenv(_name.c_str()))
+            _previous = std::string { previous };
+        setTestEnv(_name.c_str(), std::string { value }.c_str());
+    }
+
+    ~ScopedEnv()
+    {
+        if (_previous)
+            setTestEnv(_name.c_str(), _previous->c_str());
+        else
+            unsetTestEnv(_name.c_str());
+    }
+
+    ScopedEnv(ScopedEnv const&) = delete;
+    ScopedEnv& operator=(ScopedEnv const&) = delete;
+    ScopedEnv(ScopedEnv&&) = delete;
+    ScopedEnv& operator=(ScopedEnv&&) = delete;
+
+  private:
+    std::string _name;
+    std::optional<std::string> _previous;
+};
 
 } // namespace endo::testing

--- a/src/testing/ScopedTempDir.hpp
+++ b/src/testing/ScopedTempDir.hpp
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file ScopedTempDir.hpp
+/// @brief A uniquely-named temporary directory that removes itself.
+
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#if defined(_WIN32)
+    #include <atomic>
+    #include <format>
+    #include <ranges>
+
+    #include <process.h>
+#else
+
+    #include <unistd.h>
+#endif
+
+namespace endo::testing
+{
+
+/// @brief A temporary directory unique to this instance, removed on destruction.
+///
+/// Tests that need a real filesystem must not build fixtures at a fixed path such as
+/// `std::filesystem::temp_directory_path() / "endo_cp_test"`: that is one shared location
+/// for every process on the machine, so two runs of the same binary -- `ctest -j`, a
+/// developer alongside CI, a sanitizer build alongside a normal one -- overwrite and delete
+/// each other's fixtures. Several tests also wipe the directory *before* creating it, which
+/// makes a collision destructive rather than merely flaky.
+///
+/// Uniqueness comes from the OS (`mkdtemp`), not from the caller choosing a distinctive
+/// name, because a distinctive name is exactly what everyone believed they already had.
+///
+/// Prefer an injected `InMemoryFileSystem` where the code under test accepts one; use this
+/// only where a real filesystem is unavoidable -- a forked child, or a real file descriptor.
+class ScopedTempDir
+{
+  public:
+    /// @brief Creates a uniquely-named directory under the system temp directory.
+    /// @param prefix Human-readable prefix, to make stray directories identifiable.
+    /// @throws std::runtime_error if the directory cannot be created.
+    ///
+    /// Throwing rather than degrading: an empty path would make operator/ return a relative
+    /// path, so the test would quietly build its fixtures in the current working directory
+    /// -- which, with ScopedWorkingDirectory in play, may be another test's temp directory.
+    /// Catch2 reports a constructor throw as a failing test, which is what should happen.
+    explicit ScopedTempDir(std::string_view prefix)
+    {
+#if defined(_WIN32)
+        // No mkdtemp on Windows; the pid plus a per-process counter is unique, and
+        // create_directory fails rather than silently reusing an existing directory.
+        static std::atomic<unsigned> counter { 0 };
+        for ([[maybe_unused]] auto const attempt: std::views::iota(0, 128))
+        {
+            auto candidate = std::filesystem::temp_directory_path()
+                             / std::format("{}_{}_{}", prefix, _getpid(), counter.fetch_add(1));
+            auto ec = std::error_code {};
+            if (std::filesystem::create_directory(candidate, ec))
+            {
+                _path = std::move(candidate);
+                return;
+            }
+        }
+#else
+        auto pattern = (std::filesystem::temp_directory_path() / std::string(prefix)).string() + "_XXXXXX";
+        if (char const* const created = ::mkdtemp(pattern.data()))
+        {
+            _path = created;
+            return;
+        }
+#endif
+        throw std::runtime_error("ScopedTempDir: could not create a temporary directory");
+    }
+
+    ~ScopedTempDir()
+    {
+        if (_path.empty())
+            return;
+        auto ec = std::error_code {};
+        std::filesystem::remove_all(_path, ec);
+    }
+
+    ScopedTempDir(ScopedTempDir const&) = delete;
+    ScopedTempDir& operator=(ScopedTempDir const&) = delete;
+    ScopedTempDir(ScopedTempDir&&) = delete;
+    ScopedTempDir& operator=(ScopedTempDir&&) = delete;
+
+    /// @brief The directory's path. Never empty: construction throws instead.
+    [[nodiscard]] std::filesystem::path const& path() const noexcept { return _path; }
+
+    /// @brief Builds a path inside the directory.
+    [[nodiscard]] std::filesystem::path operator/(std::string_view name) const
+    {
+        return _path / std::filesystem::path(name);
+    }
+
+    /// @brief The directory's path as a string, for interpolating into shell commands.
+    ///
+    /// Generic (forward-slash) form on purpose: the shell under test treats a backslash as
+    /// an escape, so a native Windows path would be mangled -- and inside a glob pattern it
+    /// would silently escape the character that follows it instead of separating a
+    /// directory. Forward slashes are accepted by the Windows APIs the shell calls.
+    [[nodiscard]] std::string string() const { return _path.generic_string(); }
+
+  private:
+    std::filesystem::path _path;
+};
+
+} // namespace endo::testing

--- a/src/testing/ScopedTempDir.hpp
+++ b/src/testing/ScopedTempDir.hpp
@@ -18,6 +18,8 @@
     #include <process.h>
 #else
 
+    #include <cstdlib> // mkdtemp
+
     #include <unistd.h>
 #endif
 

--- a/src/testing/ScopedTempDir_test.cpp
+++ b/src/testing/ScopedTempDir_test.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <fstream>
+
+#include <testing/ScopedTempDir.hpp>
+
+TEST_CASE("ScopedTempDir hands out a distinct directory each time", "[FileSystem]")
+{
+    // The property the helper exists for. Fixed fixture names looked distinctive too --
+    // "endo_cp_test_recursive" reads unique until a second process picks the same one --
+    // so uniqueness has to come from the OS and be asserted, not assumed.
+    auto const first = endo::testing::ScopedTempDir { "endo_scoped_test" };
+    auto const second = endo::testing::ScopedTempDir { "endo_scoped_test" };
+
+    REQUIRE(!first.path().empty());
+    REQUIRE(!second.path().empty());
+    CHECK(first.path() != second.path());
+    CHECK(std::filesystem::is_directory(first.path()));
+    CHECK(std::filesystem::is_directory(second.path()));
+}
+
+TEST_CASE("ScopedTempDir removes its directory on destruction", "[FileSystem]")
+{
+    auto captured = std::filesystem::path {};
+    {
+        auto const dir = endo::testing::ScopedTempDir { "endo_scoped_test" };
+        captured = dir.path();
+        REQUIRE(std::filesystem::is_directory(captured));
+        std::ofstream { dir / "leftover.txt" } << "content";
+    }
+    CHECK(!std::filesystem::exists(captured));
+}

--- a/src/testing/ScopedWorkingDirectory.hpp
+++ b/src/testing/ScopedWorkingDirectory.hpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file ScopedWorkingDirectory.hpp
+/// @brief Changes the process working directory and restores it on destruction.
+
+#include <filesystem>
+#include <system_error>
+
+namespace endo::testing
+{
+
+/// @brief Sets the process working directory for a scope, restoring the previous one.
+///
+/// The working directory is process-global, so a test that changes it and restores it at
+/// the end of the test body leaks that change whenever an assertion fails first -- and if
+/// the directory it moved into is then deleted, every later test resolving a relative path
+/// runs from a deleted inode. Restoring from a destructor makes that impossible.
+class ScopedWorkingDirectory
+{
+  public:
+    /// @brief Changes the working directory to @p path.
+    /// @param path Directory to switch to.
+    /// @throws std::filesystem::filesystem_error if the directory cannot be changed.
+    ///
+    /// Deliberately not error-swallowing: a test that believes it moved but did not would
+    /// run its body against the wrong directory and report a confusing failure elsewhere.
+    explicit ScopedWorkingDirectory(std::filesystem::path const& path):
+        _previous { std::filesystem::current_path() }
+    {
+        std::filesystem::current_path(path);
+    }
+
+    ~ScopedWorkingDirectory()
+    {
+        if (_previous.empty())
+            return;
+        auto ec = std::error_code {};
+        std::filesystem::current_path(_previous, ec);
+    }
+
+    ScopedWorkingDirectory(ScopedWorkingDirectory const&) = delete;
+    ScopedWorkingDirectory& operator=(ScopedWorkingDirectory const&) = delete;
+    ScopedWorkingDirectory(ScopedWorkingDirectory&&) = delete;
+    ScopedWorkingDirectory& operator=(ScopedWorkingDirectory&&) = delete;
+
+  private:
+    std::filesystem::path _previous;
+};
+
+} // namespace endo::testing


### PR DESCRIPTION
The shell suites built fixtures at fixed absolute paths — 133 distinct ones, since
`temp_directory_path()` is just `/tmp` — so two concurrent runs of `test-endo-shell` shared
them. Many tests `remove_all()` the directory *before* creating it, which turns a collision
from flaky into destructive: one process deletes the fixture another is still using.

Measured on this machine with six instances running concurrently: **9 failures in 24 runs**,
with errors like `cat: /tmp/endo_test_procsubst.txt: No such file or directory`. It was
latent only because nothing set `ctest -j`.

Now **0 failures in 30 runs**, and `ctest` runs 4-way parallel by default (37s → 11s), so the
property is exercised on every run rather than resting on nobody trying.

## Changes

**Tests read through an injected filesystem.** `Shell` already took `FileSystem&`, and
`PersistentHistory`, `DirectoryConfigTrustStore` and `CommandResolver` already took
`FileSystem const&` — those seams simply were not wired up. Roughly 110 tests now touch no
disk at all. This is the wiring `endo-test` has used for `# mode: shell` tests all along.

**Production code that ignored the injected filesystem now uses it.** The sharp edge was
`rm *.txt`: glob expansion enumerated the *real* directory and the removal then ran against
the *injected* one. `expandGlobPattern`, `FileCompleter`, the shared line reader behind
`head`/`tail`/`wc`/`sort`/`uniq`/`cut`, and `cat` all read through `FileSystem` now.

**`ProcessManager` is injectable.** A shell could inject a filesystem and an environment but
never the thing that spawns processes. With a `MockProcessManager` it records what it *would*
have spawned instead of forking.

**`FileSystem::openRead` and friends report why they failed.** They returned a bare
`unique_ptr`, so missing, denied, is-a-directory and EIO all arrived as the same null, and
callers inferred the reason from a follow-up `exists()` probe — which could only guess between
two causes and raced with the open. They now return `std::expected<..., std::string>`, matching
`readFile` on the same interface.

**What remains on the real filesystem, deliberately.** A forked child inherits descriptors and
cannot read an in-memory file through one, so redirect targets, external programs and process
substitution keep real fds — as does `cat` of a FIFO or a process-substitution descriptor,
because those block and need `poll()` to stay interruptible under Ctrl+C. Every remaining
fixture gets a unique `mkdtemp` directory instead, and a lint (`scripts/check-test-isolation.py`,
wired into ctest) fails the build if a fixed path comes back.

## Defects found along the way

Each is covered by a test:

- `cat` in an in-memory shell read the **host's** disk for any path the injected filesystem
  did not hold as a regular file — `cat /etc/hostname` printed the real file.
- `head somedir` printed nothing and exited **0**: opening a directory succeeds on POSIX and
  fails only on the first read. Both backends refuse it now.
- `grep -I pattern unreadable.txt` skipped the file in silence, while the same command without
  `-I` reported "Permission denied" — `isBinaryFile` conflated unreadable with binary.
- `NativeFileSystem::listDirectory` advanced through the throwing `operator++`, so a mid-walk
  readdir failure escaped an `std::expected`-returning function as a `filesystem_error`.
- `InMemoryFileSystem::normalize` could not resolve `"."` at all: `lexically_normal()` keeps a
  trailing separator for a final `.`, so `/test/.` never matched the stored `/test`.
- A `Wakeup` test raced on a flag the worker set after signalling — pre-existing, exposed once
  the suites ran in parallel.

## Notes for review

- The in-memory model is shallow in places — `lastWriteTime()` always reports "now", symlinks
  are metadata-only, permissions unenforced beyond `denyAccess()`. A test relying on any of
  those would pass *vacuously*, so that is documented on the fixture and such tests stay on a
  real filesystem, each saying why at the point of use.
- `FileCompleter`'s case-correction still queries the real filesystem: `FileSystem` models no
  case-canonicalization, and it is a Windows-only on-disk operation. Both call sites say so,
  including the drive-letter path a future test could trip on.
- `tail -f` against an injected filesystem follows a snapshot rather than a growing file. It
  reads the right file now, but will not observe appends.
