### PR TITLE
Make the experimental AI agent features opt-in at configure time

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,10 +9,16 @@
 # It is therefore disabled tree-wide, matching contour (the upstream source of
 # src/coro and src/net). Endo cannot keep a directory-local .clang-tidy inside
 # those vendored directories, since they are overwritten on every fetch.
+# Note on -bugprone-chained-comparison below: Catch2 decomposes an assertion into
+# `Decomposer() <= lhs == rhs`, so every CHECK/REQUIRE holding a comparison reads to
+# that check as a chained comparison. It fires on essentially every assertion in every
+# *_test.cpp, is not something endo's own code can fix, and cannot be scoped to a
+# directory either, since the tests sit next to the sources they cover.
 Checks: >-
   -*,
   bugprone-*,
   -bugprone-branch-clone,
+  -bugprone-chained-comparison,
   -bugprone-command-processor,
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,11 +83,11 @@ jobs:
 
     - name: Configure CMake (Linux)
       if: runner.os == 'Linux'
-      run: cmake --preset clang-release -DCMAKE_C_COMPILER=clang-${{ env.LLVM_VERSION }} -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }}
+      run: cmake --preset clang-release -DCMAKE_C_COMPILER=clang-${{ env.LLVM_VERSION }} -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }} -DENDO_ENABLE_AGENT=ON
 
     - name: Configure CMake (macOS)
       if: runner.os == 'macOS'
-      run: cmake --preset clang-release
+      run: cmake --preset clang-release -DENDO_ENABLE_AGENT=ON
 
     # ── Build & Test ──
 
@@ -120,6 +120,79 @@ jobs:
         name: endo-macos-arm64-dmg
         path: ${{ matrix.build_dir }}/endo-*.dmg
         retention-days: 30
+
+  # The AI agent features are opt-in (ENDO_ENABLE_AGENT, default OFF), so the build
+  # without them is the one most people get. Nothing else in CI compiles that
+  # configuration, and it is a genuinely different program: src/agent is dropped
+  # entirely and the shell registers no-op stubs for every agent_* property so that
+  # existing init.endo scripts keep loading. This job is what keeps that path honest.
+  linux-no-agent:
+    runs-on: ubuntu-latest
+    name: "Linux x86_64 (no AI features)"
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # full history + tags so the version is derived correctly
+
+    - name: Install clang
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh ${{ env.LLVM_VERSION }}
+        sudo apt-get install -y clang-tidy-${{ env.LLVM_VERSION }}
+        # The clang-debug preset enables clang-tidy, and cmake/ClangTidy.cmake looks for
+        # an unversioned binary, which apt.llvm.org does not provide.
+        sudo ln -sf /usr/bin/clang-tidy-${{ env.LLVM_VERSION }} /usr/local/bin/clang-tidy
+
+    # OpenSSL backs the TLS transport in the vendored net library and curl backs the
+    # `fetch` builtin; neither is agent-only, so both are still needed here.
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libssl-dev
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-linux-no-agent
+        max-size: 256M
+
+    - name: Install CMake
+      uses: ssrobins/install-cmake@v1
+
+    - name: Install Ninja
+      uses: seanmiddleditch/gha-setup-ninja@master
+
+    - name: "Get vendored contour sources"
+      run: python3 scripts/get_contour_dirs.py
+
+    # clang-debug brings ASAN, UBSAN and clang-tidy, so the stub path is not merely
+    # compiled but exercised. ENDO_ENABLE_AGENT=OFF is the default; it is spelled out
+    # so the job's purpose survives a future change of that default.
+    - name: Configure CMake
+      run: >
+        cmake --preset clang-debug
+        -DCMAKE_C_COMPILER=clang-${{ env.LLVM_VERSION }}
+        -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }}
+        -DENDO_ENABLE_AGENT=OFF
+
+    - name: Build
+      run: cmake --build --preset clang-debug
+
+    - name: Test
+      run: ctest --preset clang-debug
+      timeout-minutes: 30
+
+    # A build that silently re-enabled the agent would pass everything above, so
+    # assert the feature really is gone from the binary.
+    - name: Verify AI features are absent
+      run: |
+        set -e
+        endo=build/clang-debug/src/shell/endo
+        ! "$endo" agent status
+        "$endo" agent status 2>&1 | grep -q "not available in this build"
+        ! "$endo" --help | grep -q "AGENT COMMANDS"
 
   static-build:
     runs-on: ubuntu-latest
@@ -156,6 +229,7 @@ jobs:
         -DCMAKE_C_COMPILER=clang-${{ env.LLVM_VERSION }}
         -DCMAKE_BUILD_TYPE=Release
         -DENABLE_STATIC_LINKING=ON
+        -DENDO_ENABLE_AGENT=ON
         -GNinja
         -S ${{ github.workspace }}
 
@@ -209,7 +283,7 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Configure CMake
-      run: cmake --preset clangcl-release
+      run: cmake --preset clangcl-release -DENDO_ENABLE_AGENT=ON
 
     - name: Build
       run: cmake --build build/clangcl-release --config Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
         sudo ./llvm.sh ${{ env.LLVM_VERSION }}
         sudo apt-get install -y clang-tidy-${{ env.LLVM_VERSION }}
         # The clang-debug preset enables clang-tidy, and cmake/ClangTidy.cmake looks for
-        # an unversioned binary, which apt.llvm.org does not provide.
+        # an unversioned binary, which apt.llvm.org does not install.
         sudo ln -sf /usr/bin/clang-tidy-${{ env.LLVM_VERSION }} /usr/local/bin/clang-tidy
 
     # OpenSSL backs the TLS transport in the vendored net library and curl backs the
@@ -168,8 +168,8 @@ jobs:
       run: python3 scripts/get_contour_dirs.py
 
     # clang-debug brings ASAN, UBSAN and clang-tidy, so the stub path is not merely
-    # compiled but exercised. ENDO_ENABLE_AGENT=OFF is the default; it is spelled out
-    # so the job's purpose survives a future change of that default.
+    # compiled but exercised and linted. ENDO_ENABLE_AGENT=OFF is the default; it is
+    # spelled out so the job's purpose survives a future change of that default.
     - name: Configure CMake
       run: >
         cmake --preset clang-debug

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -50,12 +50,15 @@ jobs:
     - name: Setup clang-tidy problem matcher
       run: echo "::add-matcher::.github/clang-tidy-matcher.json"
 
+    # ENDO_ENABLE_AGENT is opt-in and off by default, but src/agent must stay in the
+    # compile database or a PR touching it would silently go untidied.
     - name: Configure CMake
       run: >
         cmake -B build
         -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }}
         -DCMAKE_C_COMPILER=clang-${{ env.LLVM_VERSION }}
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -DENDO_ENABLE_AGENT=ON
         -GNinja
         -S ${{ github.workspace }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Configure
         run: >
           cmake --preset clang-release-static
+          -DENDO_ENABLE_AGENT=ON
           -DCMAKE_C_COMPILER=clang-${{ env.LLVM_VERSION }}
           -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }}
           -DCMAKE_C_COMPILER_LAUNCHER=ccache
@@ -150,7 +151,7 @@ jobs:
         run: python3 scripts/get_contour_dirs.py
 
       - name: Configure
-        run: cmake --preset clang-release
+        run: cmake --preset clang-release -DENDO_ENABLE_AGENT=ON
 
       - name: Build
         run: cmake --build --preset clang-release
@@ -201,7 +202,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Configure
-        run: cmake --preset clangcl-release
+        run: cmake --preset clangcl-release -DENDO_ENABLE_AGENT=ON
 
       - name: Build
         run: cmake --build --preset clangcl-release

--- a/AGENT.md
+++ b/AGENT.md
@@ -153,9 +153,20 @@ APIs, not the other way around.
 
 ## Building
 
+The AI agent features (`src/agent/`, agent mode in the shell, MCP) are experimental and
+opt-in: `ENDO_ENABLE_AGENT` defaults to `OFF`. Use the `clang-debug-agent` preset (or pass
+`-DENDO_ENABLE_AGENT=ON`) when working on them. With the option off, `src/agent` is not
+built at all, `AgentModeSession.cpp` is dropped from `endo-shell`, the llama.cpp dependency
+is skipped, and `Shell::registerAgentConfigBuiltins()` registers no-op stubs driven by
+`agentPropertyDescriptors()` so `init.endo` scripts still load. CI covers both
+configurations; changes to shell builtins or `Shell.cpp` should be checked in both.
+
 ```bash
 # Configure (debug with ASAN, UBSAN, clang-tidy)
 cmake --preset clang-debug
+
+# Same, with the experimental AI agent features compiled in
+cmake --preset clang-debug-agent
 
 # Build
 cmake --build --preset clang-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,11 @@ if(WIN32)
 endif()
 
 
-option(ENDO_ENABLE_AGENT "Build with AI agent support (LLM providers, agent mode, MCP)" ON)
+# The AI agent features are experimental, so they are opt-in: a default configure
+# builds no LLM providers, no agent mode and no MCP client, and skips the llama.cpp
+# dependency entirely. Official packages are built with this switched ON.
+option(ENDO_ENABLE_AGENT
+       "Build with experimental AI agent support (LLM providers, agent mode, MCP) [default: OFF]" OFF)
 option(ENDO_ENABLE_WASM "Build the WebAssembly compilation backend (requires binaryen) [default: ON]" ON)
 
 if(NOT DEFINED ENDO_TRACE_VM)
@@ -247,6 +251,7 @@ message(STATUS "endo trace lexer    ${ENDO_TRACE_LEXER}")
 message(STATUS "Testing             ${ENDO_TESTING}")
 message(STATUS "Static linking      ${ENABLE_STATIC_LINKING}")
 message(STATUS "WASM backend        ${ENDO_HAS_WASM}")
+message(STATUS "Agent support       ${ENDO_ENABLE_AGENT}")
 message(STATUS "Built in crashdump  ${ENDO_BUILTIN_CRARHDUMP}")
 if(NOT EMSCRIPTEN)
     message(STATUS "Address Sanitizer   ${ENABLE_ASAN}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,6 +51,14 @@
             }
         },
         {
+            "name": "clang-debug-agent",
+            "inherits": "clang-debug",
+            "displayName": "Clang Debug (with AI agent)",
+            "cacheVariables": {
+                "ENDO_ENABLE_AGENT": "ON"
+            }
+        },
+        {
             "name": "clang-release",
             "inherits": "unix-base",
             "displayName": "Clang Release",
@@ -218,6 +226,10 @@
             "configurePreset": "clang-debug"
         },
         {
+            "name": "clang-debug-agent",
+            "configurePreset": "clang-debug-agent"
+        },
+        {
             "name": "clang-release",
             "configurePreset": "clang-release"
         },
@@ -288,6 +300,11 @@
         {
             "name": "clang-debug",
             "configurePreset": "clang-debug",
+            "inherits": "default-test"
+        },
+        {
+            "name": "clang-debug-agent",
+            "configurePreset": "clang-debug-agent",
             "inherits": "default-test"
         },
         {

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ cmake --build --preset clang-release
 sudo cmake --install build/clang-release
 ```
 
+The experimental AI agent features are off by default in a source build; add
+`-DENDO_ENABLE_AGENT=ON` at configure time to include them. The packages below are built
+with them enabled.
+
 ### Debian / Ubuntu (`.deb`)
 
 Each [release](https://github.com/contour-terminal/endo/releases) ships a `.deb`

--- a/ROADMAP-AGENT.md
+++ b/ROADMAP-AGENT.md
@@ -4,6 +4,10 @@
 > The primary screen (inline rendering) is the main focus — no alt-screen context switch
 > for the core experience. Alt-screen is available on demand for sub-agents or full-screen views.
 
+> **Build status:** these features are experimental and opt-in. `ENDO_ENABLE_AGENT` defaults
+> to `OFF`; configure with `-DENDO_ENABLE_AGENT=ON` (or the `clang-debug-agent` preset) to
+> build them. Official release packages are built with them enabled.
+
 ---
 
 ## Design Principles

--- a/cmake/tests/TestVersionParse.cmake
+++ b/cmake/tests/TestVersionParse.cmake
@@ -7,6 +7,11 @@
 # Data-driven: each row is "<describe>|<expected-numeric>". The sentinel value
 # "FAIL" means parsing is expected to be rejected (out_ok == FALSE).
 
+# Required: a -P script starts with no policy baseline, and with CMP0007 unset the
+# list() commands drop empty elements. The empty-input row below splits to ";FAIL",
+# whose first element is empty, so list(GET _parts 1 ...) would read past the end.
+cmake_minimum_required(VERSION 3.30 FATAL_ERROR)
+
 include("${CMAKE_CURRENT_LIST_DIR}/../VersionParse.cmake")
 
 set(_cases

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -5,6 +5,15 @@ description: Built-in AI agent — setup, providers, and quick start.
 
 # AI Agent Overview
 
+!!! warning "Experimental -- opt-in at build time"
+
+    The agent features are experimental and are **not compiled in by default**. The
+    official packages ship with them enabled, but a build from source needs
+    `-DENDO_ENABLE_AGENT=ON` at configure time (see
+    [Build Options](../getting-started.md#build-options)). Without it, `endo agent`
+    reports that agent features are unavailable, `#` does not enter agent mode, and the
+    `agent_*` configuration properties in `init.endo` are accepted but do nothing.
+
 Endo includes a built-in AI agent that can read and edit files, run commands, search your
 codebase, execute Endo scripts, and connect to external tool servers via
 [MCP](configuration.md#mcp-server-configuration).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,6 +34,18 @@ cmake --build --preset clang-debug
 ctest --preset=clang-debug
 ```
 
+The AI agent features are opt-in and off by default. To work on them, use the
+`clang-debug-agent` preset, which is `clang-debug` plus `ENDO_ENABLE_AGENT=ON`:
+
+```bash
+cmake --preset clang-debug-agent
+cmake --build --preset clang-debug-agent
+ctest --preset=clang-debug-agent
+```
+
+Changes to the shell that touch agent code should be checked in both configurations -- CI
+builds the agent-less one on Linux, and the two register different builtins.
+
 For performance-sensitive changes, also verify with the release preset:
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,6 +47,21 @@ cmake --preset clang-debug
 cmake --build --preset clang-debug
 ```
 
+### Build Options
+
+The AI agent features -- LLM providers, agent mode and the MCP client -- are experimental
+and **off by default**. Enable them at configure time:
+
+```bash
+cmake --preset clang-release -DENDO_ENABLE_AGENT=ON
+cmake --build --preset clang-release
+```
+
+Building with them enabled also pulls in [llama.cpp](https://github.com/ggml-org/llama.cpp)
+for local inference, which noticeably lengthens the first build. The official packages
+(`.deb`, `.msi`, `.dmg` and the static Linux binary) are built with agent support enabled,
+so this only affects builds from source. See the [AI Agent](agent/index.md) documentation.
+
 ### Install (Optional)
 
 ```bash

--- a/packaging/deb/Dockerfile
+++ b/packaging/deb/Dockerfile
@@ -76,6 +76,7 @@ RUN printf '%s\n' "${ENDO_VERSION}" > version.txt \
 RUN cmake --preset clang-deb \
         -DCMAKE_C_COMPILER=clang-21 \
         -DCMAKE_CXX_COMPILER=clang++-21 \
+        -DENDO_ENABLE_AGENT=ON \
     && cmake --build --preset clang-deb \
     && cpack --preset clang-deb
 

--- a/src/shell/builtins/Registration.cpp
+++ b/src/shell/builtins/Registration.cpp
@@ -13,6 +13,7 @@
 
 #include <endo-language/builtins/BuiltinImpls.hpp>
 #include <endo-language/builtins/BuiltinSignatures.hpp>
+#include <endo-language/builtins/PropertyDescriptors.hpp>
 
 #include <CoreVM/types/TypeDescriptor.hpp>
 #include <CoreVM/types/TypedObject.hpp>
@@ -1573,73 +1574,37 @@ void Shell::registerAgentConfigBuiltins()
         .onSet([this](CoreVM::Params& args) { agentConfig.local.chatTemplate = std::string(args.getString(1)); _agentProviderFactory.reset(); });
     // clang-format on
 }
-#else  // !ENDO_ENABLE_AGENT — register no-op stubs so init.endo scripts don't break
+#else  // !ENDO_ENABLE_AGENT
 void Shell::registerAgentConfigBuiltins()
 {
-    // clang-format off
-    auto noopSet = [](CoreVM::Params&) {};
-
-    auto registerStringProp = [&](char const* name) {
-        _runtime.registerProperty(name, CoreVM::LiteralType::String)
-            .onGet([](CoreVM::Params& args) { args.setResult(std::string {}); })
-            .onSet(noopSet);
-    };
-    auto registerNumberProp = [&](char const* name) {
-        _runtime.registerProperty(name, CoreVM::LiteralType::Number)
-            .onGet([](CoreVM::Params& args) { args.setResult(CoreVM::CoreNumber(0)); })
-            .onSet(noopSet);
-    };
-    auto registerBoolProp = [&](char const* name) {
-        _runtime.registerProperty(name, CoreVM::LiteralType::Boolean)
-            .onGet([](CoreVM::Params& args) { args.setResult(false); })
-            .onSet(noopSet);
-    };
-    auto registerObjectProp = [&](char const* name) {
-        _runtime.registerProperty(name, CoreVM::LiteralType::Number)
-            .onGet([](CoreVM::Params& args) { args.setResult(CoreVM::CoreNumber(0)); })
-            .onSet(noopSet);
-    };
-
-    for (auto const* name : {
-        "agent_provider", "agent_prompt_indicator",
-        "agent_claude_api_key", "agent_claude_api_key_env", "agent_claude_model",
-        "agent_claude_thinking_mode", "agent_claude_auth_type",
-        "agent_openai_api_key", "agent_openai_api_key_env", "agent_openai_model",
-        "agent_openai_base_url", "agent_openai_thinking_mode",
-        "agent_openai_compat_api_key", "agent_openai_compat_api_key_env",
-        "agent_openai_compat_model", "agent_openai_compat_base_url",
-        "agent_openai_compat_thinking_mode",
-        "agent_gemini_api_key", "agent_gemini_api_key_env", "agent_gemini_model",
-        "agent_gemini_thinking_mode",
-        "agent_permissions_policy",
-        "agent_web_search_engine", "agent_web_search_api_key", "agent_web_search_cx",
-        "agent_error_recovery_action", "agent_error_recovery_model",
-        "agent_local_model_path", "agent_local_model_dir", "agent_local_chat_template",
-        "agent_trace_default_path",
-    }) registerStringProp(name);
-
-    for (auto const* name : {
-        "agent_max_tool_result_size",
-        "agent_claude_max_tokens", "agent_openai_max_tokens",
-        "agent_openai_compat_max_tokens", "agent_gemini_max_tokens",
-        "agent_plan_mode_max_exploration_turns", "agent_explore_max_turns",
-        "agent_trace_max_files", "agent_web_search_max_results",
-        "agent_local_gpu_layers", "agent_local_context_size",
-        "agent_local_threads", "agent_local_batch_size",
-        "agent_local_temperature", "agent_local_max_tokens",
-    }) registerNumberProp(name);
-
-    for (auto const* name : {
-        "agent_log_tool_uses", "agent_claude_prompt_caching",
-        "agent_plan_mode_enabled", "agent_plan_mode_pause_between_steps",
-        "agent_auto_resume", "agent_session_replay",
-        "agent_trace_enabled", "agent_trace_terminal",
-        "agent_local_flash_attention",
-    }) registerBoolProp(name);
-
-    registerObjectProp("agent_trusted_tool");
-    registerObjectProp("agent_blocked_pattern");
-    // clang-format on
+    // Without agent support there is nothing to configure, but `init.endo` scripts and the
+    // documentation snippets still assign to these properties, and dropping the registrations
+    // would turn every such assignment into a compile error. Register a no-op stub for each
+    // one instead, driven by `agentPropertyDescriptors()` — the same table the LSP, hover and
+    // completion already read — so that name, type and getter/setter shape cannot drift from
+    // the agent-enabled build, and a newly declared property gets its stub for free.
+    for (auto const& descriptor: agentPropertyDescriptors())
+    {
+        auto& property = _runtime.registerProperty(std::string { descriptor.name }, descriptor.type);
+        switch (descriptor.type)
+        {
+            case CoreVM::LiteralType::String:
+                property.onGet([](CoreVM::Params& args) { args.setResult(std::string {}); });
+                break;
+            case CoreVM::LiteralType::Boolean:
+                property.onGet([](CoreVM::Params& args) { args.setResult(false); });
+                break;
+            // Number, and Object — whose agent-enabled getters return a cons-cell chain, of
+            // which the null chain is the empty list — are both a zero CoreNumber at the VM
+            // layer, which is exactly "nothing configured".
+            default:
+                property.onGet(
+                    [](CoreVM::Params& args) { args.setResult(static_cast<CoreVM::CoreNumber>(0)); });
+                break;
+        }
+        if (!descriptor.readOnly)
+            property.onSet([](CoreVM::Params&) {});
+    }
 }
 #endif // ENDO_ENABLE_AGENT
 


### PR DESCRIPTION
The AI agent features are experimental, and building them costs ~37k lines of source plus llama.cpp, the heaviest dependency in the tree. `ENDO_ENABLE_AGENT` already gated all of it, but defaulted to `ON`, so it was an opt-out rather than an opt-in.

This flips the default to `OFF`, keeps every CI and release job building with it `ON` (so published packages are unchanged), and adds one Linux job that builds and tests the configuration nobody was compiling.

## What changed

- **`ENDO_ENABLE_AGENT` now defaults to `OFF`** and is printed in the configure summary next to the other build flags.
- **New `clang-debug-agent` preset** — `clang-debug` plus `ENDO_ENABLE_AGENT=ON`, so working on the agent stays a one-word preset.
- **Every existing job opts in explicitly**: the Linux/macOS matrix, `static-build`, `windows-clangcl`, the three `release.yml` jobs, and `packaging/deb/Dockerfile`. Also `clang-tidy.yml`, whose compile database would otherwise omit `src/agent` and silently leave PRs touching it untidied.
- **New `linux-no-agent` job** on the `clang-debug` preset, so ASAN, UBSAN and clang-tidy all apply to the agent-less build. It ends by asserting the feature really is gone from the binary — without that, a build that quietly re-enabled the agent would still pass.
- **Docs**: a Build Options section in the getting-started guide, a note in the README beside the from-source instructions, the new preset in the contributing guide and `AGENT.md`, and an admonition on the agent docs describing what a build without it actually does.

## Fixes the OFF path needed

Nothing had ever compiled `ENDO_ENABLE_AGENT=OFF`, and it had rotted:

- The no-op stubs for the ~60 `agent_*` properties were a hand-written list kept in parallel with `agentPropertyDescriptors()`, already the single source of truth the LSP, hover and completion read. It had drifted: `agent_trusted_tool` and `agent_blocked_pattern` are `Object` properties, but the stubs registered them as `Number`, which fails `shell.properties.descriptors_and_registrations_agree`. They are now driven from the descriptors, so name, type and getter/setter shape cannot diverge and a newly declared property gets its stub for free.

## Pre-existing issues that blocked the new job

- **`bugprone-chained-comparison`** fires on every Catch2 `CHECK`/`REQUIRE` holding a comparison, because Catch2 decomposes an assertion into `Decomposer() <= lhs == rhs`. Under `WarningsAsErrors: *` that was 179 build errors across five CoreVM test files before the build stopped. It is not fixable in endo's code, and the tests sit next to the sources they cover, so it cannot be scoped to a directory — excluded tree-wide with the rationale above the `Checks` scalar, where this file already keeps such notes.
- **`version-parse`** runs via `cmake -P`, which gives a script no policy baseline. On CMake 3.x, `CMP0007` is then unset and `list()` drops empty elements, so the empty-input row read past the end of its list. CI does not see this (it installs the newest CMake, and 4.x defaults unset policies to NEW), but the project's own floor is 3.30. Given the 3.30 baseline; all ten cases now pass on both 3.31.6 and 4.4.3.

## Verification

Built and tested on a clean checkout with the CI toolchain (clang-22, ninja), in-tree, both ways:

| Configuration | Build | Tests |
|---|---|---|
| Agent off — the new `linux-no-agent` job's exact command line, ASAN + UBSAN + clang-tidy | clean, 0 diagnostics | 19/19 pass |
| Agent on — the new `clang-debug-agent` preset | clean, 0 diagnostics | 20/20 pass |

The verification step passes against the agent-off binary and fails against the agent-on one, so it is not passing vacuously.

## Risk

- **Runtime**: none. Compile-time only; the agent-on build behaves exactly as before.
- **Users of published packages**: unchanged — every release job opts in.
- **Users building from source**: they lose agent mode unless they pass `-DENDO_ENABLE_AGENT=ON`. That is the intended effect, and is why the docs changes are part of this PR rather than a follow-up.
- **Build time**: the agent-off build drops ~37k lines, 62 test files and the llama.cpp fetch and compile.

One gap worth naming: `clang-tidy.yml` builds with the agent on, so code inside `#if !ENDO_ENABLE_AGENT` is preprocessed away there and gets no diff-lint. The new job's whole-tree clang-tidy covers it instead — which is how a `modernize-avoid-c-style-cast` finding in the new stub surfaced.
