### PR TITLE
Embed OS-level version metadata and fix Windows MSI upgrades

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,18 @@ cmake_minimum_required(VERSION 3.30 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(Version)
-GetVersionInformation(ENDO_VERSION ENDO_VERSION_STRING)
 
-project(endo VERSION "${ENDO_VERSION}" LANGUAGES CXX)
+# ENDO_VERSION is the record PREFIX, so the fields below are ENDO_VERSION_NUMERIC
+# (what project()/CPack/MSI use), ENDO_VERSION_QUAD (the four-field form the
+# binary's OS-level metadata reports) and ENDO_VERSION_HUMAN. See
+# ENDO_VERSION_RECORD_FIELDS in cmake/VersionParse.cmake, and docs/releases.md for
+# why the packaged and embedded versions differ.
+endo_get_version_information(ENDO_VERSION)
+
+project(endo VERSION "${ENDO_VERSION_NUMERIC}" LANGUAGES CXX)
 
 include(GNUInstallDirs)
+include(ProjectMetadata)
 
 
 # setting defaults
@@ -150,6 +157,15 @@ include(EndoThirdParties)
 include(PedanticCompiler)
 include(Sanitizers)
 include(ClangTidy)
+
+# OS-level version metadata for the shipped executable: one module per mechanism,
+# each exporting an enable_*(target) that is a no-op off its own platform, and
+# each doing its platform's one-time setup (enabling the RC language, probing the
+# linker) at include time. They are applied to endo-bin in
+# src/shell/CMakeLists.txt alongside enable_sanitizers()/enable_clang_tidy().
+include(WindowsVersionResource)
+include(MacOSInfoPlist)
+include(ElfPackageMetadata)
 
 if(NOT EMSCRIPTEN)
     check_static_system_requirements()

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1392,6 +1392,8 @@ and — as the flagship language consumer — a builtin HTTP server.
 - [x] Set up Windows CI pipeline (`build.yml` has `windows-clangcl` job)
 - [x] Handle Windows-specific dependencies (`vcpkg.json` with 5 packages)
 - [x] Embed OS-level version metadata into the shipped binary (`MAJOR.MINOR.PATCH.COMMITS`): Win32 `VS_VERSION_INFO` resource, macOS `__TEXT,__info_plist` section, Linux `.note.package` ELF note — previously `endo.exe` reported `0.0.0.0` to every OS-level reader
+- [x] Maintain `C:\Program Files\Endo\latest` as a directory junction to the installed version, so a terminal profile has a path that survives upgrades (Windows Terminal does not resolve a bare `endo.exe` through `PATH`)
+- [x] Fix MSI upgrades installing into the previous version's directory: CPack's remembered-install-location search pinned `INSTALL_ROOT` to the old path, so `RemoveExistingProducts` deleted the files the upgrade had just written
 - [x] Fix CoreVM `jump_to` macro for switch-based VM dispatch loop (Windows/MSVC): `break` inside `do { ... } while(0)` wrapper exits the do-while instead of the switch, causing fall-through to the next case handler and VM stack corruption
 - [x] Fix `isInPath()` PATH separator for Windows: use `;` instead of `:`, probe `.exe`/`.cmd`/`.bat` extensions, skip POSIX `owner_exec` permission check
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1391,6 +1391,7 @@ and — as the flagship language consumer — a builtin HTTP server.
 - [x] Configure MSVC and Clang-cl support (`PedanticCompiler.cmake` handles both)
 - [x] Set up Windows CI pipeline (`build.yml` has `windows-clangcl` job)
 - [x] Handle Windows-specific dependencies (`vcpkg.json` with 5 packages)
+- [x] Embed OS-level version metadata into the shipped binary (`MAJOR.MINOR.PATCH.COMMITS`): Win32 `VS_VERSION_INFO` resource, macOS `__TEXT,__info_plist` section, Linux `.note.package` ELF note — previously `endo.exe` reported `0.0.0.0` to every OS-level reader
 - [x] Fix CoreVM `jump_to` macro for switch-based VM dispatch loop (Windows/MSVC): `break` inside `do { ... } while(0)` wrapper exits the do-while instead of the switch, causing fall-through to the next case handler and VM stack corruption
 - [x] Fix `isInPath()` PATH separator for Windows: use `;` instead of `:`, probe `.exe`/`.cmd`/`.bat` extensions, skip POSIX `owner_exec` permission check
 

--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -7,17 +7,21 @@ function(enable_coverage target)
         return()
     endif()
 
+    # Compile options are scoped to CXX: target_compile_options applies to EVERY
+    # language of the target, and endo-bin compiles an RC source on Windows,
+    # where an unknown switch is a fatal RC1106. Link options have no such
+    # per-language split and need no scoping.
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         target_compile_options(${target} PRIVATE
-            -fprofile-instr-generate
-            -fcoverage-mapping
+            $<$<COMPILE_LANGUAGE:CXX>:-fprofile-instr-generate;-fcoverage-mapping>
         )
         target_link_options(${target} PRIVATE
             -fprofile-instr-generate
             -fcoverage-mapping
         )
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(${target} PRIVATE --coverage -fprofile-arcs -ftest-coverage)
+        target_compile_options(${target} PRIVATE
+            $<$<COMPILE_LANGUAGE:CXX>:--coverage;-fprofile-arcs;-ftest-coverage>)
         target_link_options(${target} PRIVATE --coverage)
     endif()
 endfunction()

--- a/cmake/ElfPackageMetadata.cmake
+++ b/cmake/ElfPackageMetadata.cmake
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The systemd ELF Package Metadata note (.note.package), as one concern.
+# Spec: https://systemd.io/ELF_PACKAGE_METADATA/ -- owner "FDO", note type
+# 0xcafe1a7e, description a NUL-terminated compact JSON object.
+#
+# ELF has no VERSIONINFO equivalent; this note is the nearest thing to a
+# standard, and systemd-coredump reads it straight out of a core dump to name
+# the build that produced it. The note is SHF_ALLOC, so it survives `strip` and
+# travels in the stripped .deb rather than disappearing into the .ddeb.
+
+include(CheckLinkerFlag)
+
+set(ENDO_PACKAGE_METADATA_TYPE "cmake" CACHE STRING
+    "'type' field of the .note.package ELF note; a distro build passes deb/rpm/...")
+
+# The note's `architecture` must use the packaging system's own spelling, which is
+# not always uname's: a .deb says amd64 where CMAKE_SYSTEM_PROCESSOR says x86_64.
+# One row per (packaging type, processor) pair that needs translating; anything
+# not listed passes through unchanged, which is already right for rpm and for a
+# plain cmake build.
+set(ENDO_PACKAGE_ARCH_ALIASES
+    "deb/x86_64/amd64"
+    "deb/aarch64/arm64"
+    "deb/armv7l/armhf"
+)
+
+# Translate @p processor into the spelling packaging type @p type uses.
+# @param type      The .note.package `type` field.
+# @param processor CMAKE_SYSTEM_PROCESSOR.
+# @param out_var   Name of the variable to receive the architecture.
+function(endo_package_metadata_architecture type processor out_var)
+    foreach(_alias IN LISTS ENDO_PACKAGE_ARCH_ALIASES)
+        string(REPLACE "/" ";" _parts "${_alias}")
+        list(GET _parts 0 _alias_type)
+        list(GET _parts 1 _alias_processor)
+        list(GET _parts 2 _alias_arch)
+        if(_alias_type STREQUAL "${type}" AND _alias_processor STREQUAL "${processor}")
+            set(${out_var} "${_alias_arch}" PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+    set(${out_var} "${processor}" PARENT_SCOPE)
+endfunction()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # -Xlinker, never -Wl, and never CMake's LINKER: prefix. Both of the latter
+    # split their payload on every comma, and this option's value is JSON --
+    # `-Wl,--package-metadata={"a":1,"b":2}` reaches ld as three arguments, two
+    # of them garbage. -Xlinker passes exactly one argument through untouched.
+    #
+    # A probe rather than a version comparison decides: GNU ld grew this in
+    # binutils 2.39 and LLVM lld in 15, gold never did, and mold at some release
+    # this comment does not claim to know. Asking the linker in front of us is
+    # both shorter and correct.
+    check_linker_flag(CXX
+        "-Xlinker;--package-metadata={\"type\":\"probe\",\"name\":\"probe\",\"version\":\"0\"}"
+        ENDO_HAS_ELF_PACKAGE_METADATA)
+    if(NOT ENDO_HAS_ELF_PACKAGE_METADATA)
+        # Said out loud rather than skipped in silence: a missing .note.package
+        # is invisible until someone tries to identify a core dump with it.
+        message(STATUS
+            "[Version] .note.package will NOT be emitted: this linker does not accept "
+            "--package-metadata (needs GNU ld >= 2.39 or LLVM lld >= 15).")
+    endif()
+endif()
+
+## @brief Emits a systemd ELF package-metadata note into @p target.
+##
+## A no-op off Linux and when the linker does not support the option, so call
+## sites need no guard of their own.
+##
+## @param target The executable to annotate.
+function(enable_elf_package_metadata target)
+    # CMAKE_SYSTEM_NAME rather than UNIX: Emscripten sets UNIX, and wasm-ld has
+    # no ELF notes to emit. This mirrors cmake/Packaging.cmake's own elseif.
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        return()
+    endif()
+    if(NOT ENDO_HAS_ELF_PACKAGE_METADATA)
+        return()
+    endif()
+
+    endo_require_version_record(ENDO_VERSION "enable_elf_package_metadata(${target})")
+
+    endo_package_metadata_architecture(
+        "${ENDO_PACKAGE_METADATA_TYPE}" "${CMAKE_SYSTEM_PROCESSOR}" _arch)
+
+    # Compact -- no spaces anywhere -- so the object stays one shell word however
+    # CMake and Ninja quote it. JSON has no ';' and this object has no '$', so
+    # there is nothing here for CMake's list escaping to mangle either.
+    set(_json "{\"type\":\"${ENDO_PACKAGE_METADATA_TYPE}\"")
+    string(APPEND _json ",\"name\":\"${ENDO_PRODUCT_NAME}\"")
+    string(APPEND _json ",\"version\":\"${ENDO_VERSION_HUMAN}\"")
+    string(APPEND _json ",\"architecture\":\"${_arch}\"}")
+
+    target_link_options(${target} PRIVATE "-Xlinker" "--package-metadata=${_json}")
+    message(STATUS "[Version] ${target}: .note.package = ${_json}")
+endfunction()

--- a/cmake/MacOSInfoPlist.cmake
+++ b/cmake/MacOSInfoPlist.cmake
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The embedded macOS Info.plist, as one concern.
+
+## @brief Embeds the generated Info.plist into @p target's __TEXT,__info_plist.
+##
+## endo is a CLI tool rather than an .app bundle, so MACOSX_BUNDLE and
+## MACOSX_BUNDLE_INFO_PLIST do not apply -- there is no Contents/Info.plist to
+## write. The linker is asked to create the section directly instead, which is
+## the standard mechanism for a command-line tool and is what `otool -P` reads.
+##
+## `-current_version` / `-compatibility_version` are deliberately not used: ld64
+## accepts them only when linking a dylib, and both write into LC_ID_DYLIB, which
+## an executable does not have.
+##
+## The EndoInfo.plist.in template is read from @p target's own source directory,
+## so this works from anywhere. A no-op off Apple platforms, so call sites need no
+## guard of their own.
+##
+## @param target The executable to embed the plist into.
+function(enable_macos_info_plist target)
+    if(NOT APPLE)
+        return()
+    endif()
+    endo_require_version_record(ENDO_VERSION "enable_macos_info_plist(${target})")
+
+    get_target_property(_source_dir ${target} SOURCE_DIR)
+    set(_plist "${CMAKE_CURRENT_BINARY_DIR}/EndoInfo.plist")
+    configure_file("${_source_dir}/EndoInfo.plist.in" "${_plist}" @ONLY)
+
+    # -Wl, splits on every comma, which is exactly how -sectcreate's four
+    # arguments are delivered -- and exactly what a comma in the build path would
+    # break, handing ld64 five garbage arguments. Spaces are fine (CMake
+    # shell-quotes the whole token); commas are not, so refuse up front rather
+    # than emit a link line that fails unreadably.
+    if(_plist MATCHES ",")
+        message(FATAL_ERROR
+            "Endo: the build directory path contains a comma (${_plist}); the "
+            "-Wl,-sectcreate link option cannot carry such a path. Build elsewhere.")
+    endif()
+
+    target_link_options(${target} PRIVATE "-Wl,-sectcreate,__TEXT,__info_plist,${_plist}")
+
+    # A link option is not a dependency: without this, editing the plist (or
+    # reconfiguring onto a new commit) leaves the already-linked executable
+    # carrying the old one and nothing ever relinks. Honoured by the Ninja and
+    # Makefile generators, which is all this project's presets use.
+    set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS "${_plist}")
+endfunction()

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -2,12 +2,11 @@
 # CPack packaging configuration for Endo Shell.
 
 # Common metadata
-set(CPACK_PACKAGE_NAME "endo")
-set(CPACK_PACKAGE_VENDOR "Endo Project")
-set(CPACK_PACKAGE_CONTACT "Christian Parpart <christian@parpart.family>")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
-    "A modern, cross-platform shell where functional programming meets everyday productivity")
-set(CPACK_PACKAGE_HOMEPAGE_URL "https://endo-lang.org/")
+set(CPACK_PACKAGE_NAME "${ENDO_PRODUCT_NAME}")
+set(CPACK_PACKAGE_VENDOR "${ENDO_PRODUCT_VENDOR}")
+set(CPACK_PACKAGE_CONTACT "${ENDO_PRODUCT_CONTACT}")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${ENDO_PRODUCT_DESCRIPTION}")
+set(CPACK_PACKAGE_HOMEPAGE_URL "${ENDO_PRODUCT_HOMEPAGE}")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
 
@@ -36,7 +35,7 @@ if(WIN32)
     # the generated CPackConfig.cmake, and a literal backslash there would form an
     # invalid CMake string escape (e.g. "Endo\0.1.135" -> bad escape '\0'). The WIX
     # generator splits on '/' and still emits the nested "Endo\<version>\" tree.
-    set(CPACK_PACKAGE_INSTALL_DIRECTORY "Endo/${PROJECT_VERSION}")
+    set(CPACK_PACKAGE_INSTALL_DIRECTORY "${ENDO_PRODUCT_DISPLAY_NAME}/${PROJECT_VERSION}")
 
     # WIX (.msi installer)
     # Stable GUID for MSI upgrade detection — must never change once published.
@@ -88,7 +87,7 @@ if(WIN32)
 elseif(APPLE)
     set(CPACK_GENERATOR "DragNDrop")
 
-    set(CPACK_DMG_VOLUME_NAME "Endo ${PROJECT_VERSION}")
+    set(CPACK_DMG_VOLUME_NAME "${ENDO_PRODUCT_DISPLAY_NAME} ${PROJECT_VERSION}")
 
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CPACK_GENERATOR "DEB;RPM")
@@ -98,7 +97,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CPACK_DEBIAN_PACKAGE_SECTION "shells")
     set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
     set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-    set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://endo-lang.org/")
+    set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${ENDO_PRODUCT_HOMEPAGE}")
     set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 
     # Emit a separate debug-symbols package (endo-dbgsym_<ver>_<arch>.ddeb) and ship
@@ -108,9 +107,9 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CPACK_DEBIAN_DEBUGINFO_PACKAGE ON)
 
     # RPM
-    set(CPACK_RPM_PACKAGE_LICENSE "Apache-2.0")
+    set(CPACK_RPM_PACKAGE_LICENSE "${ENDO_PRODUCT_LICENSE_SPDX}")
     set(CPACK_RPM_PACKAGE_GROUP "System Environment/Shells")
-    set(CPACK_RPM_PACKAGE_URL "https://endo-lang.org/")
+    set(CPACK_RPM_PACKAGE_URL "${ENDO_PRODUCT_HOMEPAGE}")
     set(CPACK_RPM_PACKAGE_AUTOREQ ON)
     set(CPACK_RPM_FILE_NAME RPM-DEFAULT)
 

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -77,10 +77,19 @@ if(WIN32)
         TYPE SHA1 UPPER)
     configure_file("${CMAKE_SOURCE_DIR}/cmake/wix-env-path.wxs.in"
                    "${CMAKE_BINARY_DIR}/wix-env-path.wxs" @ONLY)
+
+    # Pin INSTALL_ROOT to this version's directory on an upgrade, cancelling the
+    # remembered-install-location search CPack generates into properties.wxi.
+    # Without it an upgrade writes the new version's files into the OLD version's
+    # directory and RemoveExistingProducts then deletes them. See the fragment.
+    configure_file("${CMAKE_SOURCE_DIR}/cmake/wix-install-root.wxs.in"
+                   "${CMAKE_BINARY_DIR}/wix-install-root.wxs" @ONLY)
+
     # wix-legacy-path-cleanup.wxs is static (frozen GUID, version-independent) and
     # is used verbatim — it must not go through configure_file.
     set(CPACK_WIX_EXTRA_SOURCES
         "${CMAKE_BINARY_DIR}/wix-env-path.wxs"
+        "${CMAKE_BINARY_DIR}/wix-install-root.wxs"
         "${CMAKE_SOURCE_DIR}/cmake/wix-legacy-path-cleanup.wxs")
     set(CPACK_WIX_PATCH_FILE "${CMAKE_SOURCE_DIR}/cmake/wix-path-env.xml")
 

--- a/cmake/PedanticCompiler.cmake
+++ b/cmake/PedanticCompiler.cmake
@@ -1,8 +1,13 @@
 ## Sets pedantic compiler warnings for a target.
+##
+## Every option below is scoped to $<COMPILE_LANGUAGE:CXX>. target_compile_options
+## applies to EVERY language a target compiles, and a target carrying the Windows
+## VERSIONINFO resource also compiles RC -- where rc.exe treats an unknown switch
+## as a fatal RC1106. Nothing here means anything to a resource compiler.
 
 function(set_pedantic_compiler_warnings target)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(${target} PRIVATE
+        set(_warnings
             -Werror
             -Wextra
             -Wpedantic
@@ -22,18 +27,19 @@ function(set_pedantic_compiler_warnings target)
         if(MSVC)
             # clang-cl interprets -Wall as MSVC's /Wall, which maps to Clang's -Weverything.
             # Use /W4 instead, which correctly maps to Clang's -Wall -Wextra.
-            target_compile_options(${target} PRIVATE /W4)
+            list(APPEND _warnings /W4)
             # Suppress backward-compatibility warnings irrelevant for a C++23 codebase.
-            target_compile_options(${target} PRIVATE
+            list(APPEND _warnings
                 -Wno-c++98-compat-pedantic
                 -Wno-pre-c++14-compat
                 -Wno-pre-c++17-compat
                 -Wno-pre-c++20-compat-pedantic
             )
         else()
-            target_compile_options(${target} PRIVATE -Wall)
+            list(APPEND _warnings -Wall)
         endif()
+        target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_warnings}>)
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        target_compile_options(${target} PRIVATE /W4 /WX /utf-8)
+        target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/W4;/WX;/utf-8>)
     endif()
 endfunction()

--- a/cmake/ProjectMetadata.cmake
+++ b/cmake/ProjectMetadata.cmake
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Endo's product identity, declared once.
+#
+# Four consumers repeat these strings into four different metadata formats --
+# CPack (cmake/Packaging.cmake), the Win32 VERSIONINFO resource
+# (cmake/WindowsVersionResource.cmake), the macOS __TEXT,__info_plist section
+# (cmake/MacOSInfoPlist.cmake) and the ELF .note.package note
+# (cmake/ElfPackageMetadata.cmake). Declaring them here is what keeps
+# "Endo Project" from being spelled four ways, and the homepage from drifting
+# between the three CPack variables that already carry it.
+#
+# Two things are deliberately out of scope. Version numbers, which come from the
+# record endo_get_version_information() builds (cmake/Version.cmake). And strings
+# the C++ compiles in -- the docs URL and tagline in src/shell/HelpPrinter.cpp --
+# which would have to travel through src/shell/EndoVersion.hpp.in to get here;
+# worth doing if they drift, not worth a bridge today.
+
+set(ENDO_PRODUCT_NAME "endo")
+set(ENDO_PRODUCT_DISPLAY_NAME "Endo")
+set(ENDO_PRODUCT_VENDOR "Endo Project")
+set(ENDO_PRODUCT_CONTACT "Christian Parpart <christian@parpart.family>")
+set(ENDO_PRODUCT_DESCRIPTION
+    "A modern, cross-platform shell where functional programming meets everyday productivity")
+set(ENDO_PRODUCT_HOMEPAGE "https://endo-lang.org/")
+set(ENDO_PRODUCT_LICENSE_SPDX "Apache-2.0")
+
+# Hardcoded rather than derived from string(TIMESTAMP): a copyright year that
+# follows the wall clock makes two builds of the same commit differ. 2022 is the
+# first commit in this repository.
+set(ENDO_PRODUCT_COPYRIGHT "Copyright (C) 2022-2026 Christian Parpart")
+
+# Reverse-DNS of ENDO_PRODUCT_HOMEPAGE. endo is a CLI tool rather than a bundle,
+# so nothing enforces this -- it is what `otool -P` prints and what any future
+# codesigning would read.
+set(ENDO_PRODUCT_BUNDLE_ID "org.endo-lang.endo")

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -28,7 +28,11 @@ function(enable_sanitizers target)
     endif()
 
     if(SANITIZER_FLAGS)
-        target_compile_options(${target} PRIVATE ${SANITIZER_FLAGS})
+        # Scoped to CXX: target_compile_options applies to EVERY language of the
+        # target, and endo-bin carries an RC source on Windows. clang-cl matches
+        # the Clang guard above, so an unscoped -fsanitize=address would reach
+        # rc.exe, which treats an unknown switch as a fatal RC1106.
+        target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SANITIZER_FLAGS}>)
         target_link_options(${target} PRIVATE ${SANITIZER_FLAGS})
     endif()
 endfunction()

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# CMake function to extract version triple and full version string from the source code repository.
+# CMake function to derive Endo's version record from the source repository.
 #
 # The following locations are checked in order:
 # 1.) /version.txt file
@@ -8,18 +8,41 @@
 #
 include("${CMAKE_CURRENT_LIST_DIR}/VersionParse.cmake")
 
-function(GetVersionInformation VersionTripleVar VersionStringVar)
-    find_package(Git QUIET)
+## @brief Derive Endo's version record from the best available source.
+##
+## Every source fills the SAME record (see ENDO_VERSION_RECORD_FIELDS in
+## VersionParse.cmake), so no consumer ever has to branch on which one answered
+## -- that is the point of having a record rather than loose strings. NUMERIC is
+## what project()/CPack/MSI use; the unfolded MAJOR/MINOR/PATCH/COMMITS and QUAD
+## are what the OS-level metadata stamped into the binary uses.
+##
+## Each source shapes its input into something a VersionParse.cmake parser
+## understands rather than assembling a record by hand, so the numbering policy
+## and the 16-bit clamping are spelled exactly once.
+##
+## @param out_prefix Variable-name prefix receiving the record, e.g.
+##                   `endo_get_version_information(ENDO_VERSION)` yields
+##                   ENDO_VERSION_NUMERIC, ENDO_VERSION_QUAD, and so on.
+function(endo_get_version_information out_prefix)
+    endo_clear_version_record()
 
     if(EXISTS "${CMAKE_SOURCE_DIR}/version.txt")
         # 1.) /version.txt file
-        file(READ "${CMAKE_SOURCE_DIR}/version.txt" version_text)
-        string(STRIP "${version_text}" version_text)
-        string(REGEX MATCH "^v?([0-9]*\\.[0-9]+\\.[0-9]+).*$" _ ${version_text})
-        set(THE_VERSION ${CMAKE_MATCH_1})
-        set(THE_VERSION_STRING "${version_text}")
-        set(THE_SOURCE "${CMAKE_SOURCE_DIR}/version.txt")
-    elseif(GIT_FOUND)
+        file(READ "${CMAKE_SOURCE_DIR}/version.txt" _version_text)
+        string(STRIP "${_version_text}" _version_text)
+        endo_parse_version_file("${_version_text}" _file)
+        if(_file_OK)
+            endo_adopt_version_record(_file)
+            set(_SOURCE "${CMAKE_SOURCE_DIR}/version.txt")
+        else()
+            message(WARNING
+                "Endo: version.txt ('${_version_text}') is not X.Y.Z-shaped; ignoring it.")
+        endif()
+    else()
+        find_package(Git QUIET)
+    endif()
+
+    if(NOT _OK AND GIT_FOUND)
         # Use a long describe so untagged (development / CI) builds still get a
         # version that increases per commit within a release line. Format:
         # v<maj>.<min>.<patch>[-<pre>]-<n>-g<sha>[-dirty], where <n> is the number
@@ -35,14 +58,15 @@ function(GetVersionInformation VersionTripleVar VersionStringVar)
             ERROR_QUIET
             RESULT_VARIABLE GIT_RESULT
         )
-        set(_parsed_ok FALSE)
         if(GIT_RESULT EQUAL 0)
-            endo_parse_git_describe("${GIT_DESCRIBE}"
-                _parsed_ok THE_VERSION THE_VERSION_STRING THE_SOURCE)
+            endo_parse_git_describe("${GIT_DESCRIBE}" _git)
+            if(_git_OK)
+                endo_adopt_version_record(_git)
+                message(STATUS "Derived version '${_NUMERIC}' (${_HUMAN}) from ${_SOURCE}.")
+            endif()
         endif()
-        if(_parsed_ok)
-            message(STATUS "Derived version '${THE_VERSION}' (${THE_VERSION_STRING}) from ${THE_SOURCE}.")
-        else()
+
+        if(NOT _OK)
             # No parseable v* tag reachable (e.g. shallow clone without tags, or a
             # tag that is not v<MAJOR>.<MINOR>.<PATCH>-shaped). Fall back to the
             # total commit count so CI builds remain unique and ordered. This is a
@@ -64,13 +88,17 @@ function(GetVersionInformation VersionTripleVar VersionStringVar)
                 ERROR_QUIET
             )
             if(GIT_COUNT_RESULT EQUAL 0 AND NOT "${GIT_COMMIT_COUNT}" STREQUAL "")
-                endo_clamp_msi_build("${GIT_COMMIT_COUNT}" _count_build)
-                set(THE_VERSION "0.0.${_count_build}")
-                set(THE_VERSION_STRING "0.0.0-${GIT_COMMIT_COUNT}-g${GIT_SHORT_SHA}")
-                set(THE_SOURCE "git commit count (no v* tag found)")
+                # Shaped as a describe against an imaginary v0.0.0 tag rather than
+                # assembled field by field: the count then lands in the build field
+                # of NUMERIC (0.0.<count>, as this path has always produced) and in
+                # COMMITS -- never in PATCH -- and it is clamped by the same code
+                # as every other derived component.
+                endo_parse_git_describe("v0.0.0-${GIT_COMMIT_COUNT}-g${GIT_SHORT_SHA}" _count)
+                endo_adopt_version_record(_count)
+                set(_SOURCE "git commit count (no v* tag found)")
                 message(WARNING
                     "Endo: no parseable v* tag reachable; derived degraded version "
-                    "'${THE_VERSION}' from commit count. Tag a release "
+                    "'${_NUMERIC}' from commit count. Tag a release "
                     "(v<MAJOR>.<MINOR>.<PATCH>) or fetch tags "
                     "(git fetch --tags / actions/checkout fetch-depth: 0).")
             else()
@@ -80,17 +108,17 @@ function(GetVersionInformation VersionTripleVar VersionStringVar)
         endif()
     endif()
 
-    if("${THE_VERSION}" STREQUAL "" OR "${THE_VERSION_STRING}" STREQUAL "")
-        set(THE_VERSION "0.0.0")
-        set(THE_VERSION_STRING "0.0.0")
-        set(THE_SOURCE "default fallback")
-        message(STATUS "Warning: No version.txt or matching git tag found. Defaulting to ${THE_VERSION}.")
+    if(NOT _OK)
+        endo_parse_version_file("0.0.0" _default)
+        endo_adopt_version_record(_default)
+        set(_SOURCE "default fallback")
+        message(STATUS "Warning: No version.txt or matching git tag found. Defaulting to ${_NUMERIC}.")
     endif()
 
-    message(STATUS "[Version] version source: ${THE_SOURCE}")
-    message(STATUS "[Version] version triple: ${THE_VERSION}")
-    message(STATUS "[Version] version string: ${THE_VERSION_STRING}")
+    message(STATUS "[Version] version source: ${_SOURCE}")
+    message(STATUS "[Version] version triple: ${_NUMERIC}")
+    message(STATUS "[Version] version string: ${_HUMAN}")
+    message(STATUS "[Version] version quad:   ${_QUAD} (dirty: ${_DIRTY})")
 
-    set(${VersionTripleVar} "${THE_VERSION}" PARENT_SCOPE)
-    set(${VersionStringVar} "${THE_VERSION_STRING}" PARENT_SCOPE)
+    endo_publish_version_record(${out_prefix})
 endfunction()

--- a/cmake/VersionParse.cmake
+++ b/cmake/VersionParse.cmake
@@ -1,41 +1,128 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Pure, side-effect-free parsing of `git describe` output into an Endo version.
+# Pure, side-effect-free parsing of Endo's version sources into a version record.
 #
 # Kept separate from Version.cmake (which performs the actual git invocations) so
 # the parsing logic can be unit-tested in isolation via `cmake -P` with mock
 # inputs and no git dependency. See cmake/tests/TestVersionParse.cmake.
 
-# Maximum value of an MSI ProductVersion build field. The Windows Installer
-# compares only major.minor.build (each capped); a larger value is rejected by
-# the WiX toolset or silently wraps, breaking upgrade detection.
-set(ENDO_MSI_BUILD_FIELD_MAX 65535)
+# The clamp for a version component that lands in a 16-bit field: the MSI
+# ProductVersion build field and every field of a Windows VERSIONINFO
+# FILEVERSION/PRODUCTVERSION. One constant, because it is one limit.
+#
+# Only the derived components are clamped -- the commit distance and the folded
+# build number. A tag's own MAJOR/MINOR/PATCH pass through untouched: a project
+# that tags v65536.0.0 has a different problem than this file can solve.
+set(ENDO_VERSION_FIELD_MAX 65535)
 
-# Clamp a numeric build component to the MSI build-field limit, warning if it
+# The version record: the complete set of fields every parser below produces.
+# One list drives clearing, copying, publishing and (in the unit test) assertion,
+# so a new field is one entry here rather than an edit to every parser, every
+# consumer and every test row.
+#
+#   OK          TRUE when the input parsed.
+#   NUMERIC     "major.minor.build" -- the triple project()/CPack/MSI consume.
+#               How `build` is derived is per-source policy, not a fixed rule.
+#   HUMAN       Human-readable version string.
+#   SOURCE      Short description of where the version came from.
+#   MAJOR       The tag's major, never folded.
+#   MINOR       The tag's minor, never folded.
+#   PATCH       The tag's patch, never folded.
+#   COMMITS     Commits since the tag; 0 exactly on a tag. Clamped, because it
+#               lands in a 16-bit VERSIONINFO field. The true count survives in
+#               HUMAN.
+#   QUAD        "major.minor.patch.commits" -- the four-field form the OS-level
+#               binary metadata reports. Composed here, where the components are
+#               known, rather than by each of its consumers.
+#   SHA         Short commit sha, without the describe's leading "g".
+#   DIRTY       TRUE when the working tree was modified.
+#   PRERELEASE  The tag's pre-release/build suffix ("-rc1"), or "".
+set(ENDO_VERSION_RECORD_FIELDS
+    OK NUMERIC HUMAN SOURCE MAJOR MINOR PATCH COMMITS QUAD SHA DIRTY PRERELEASE)
+
+# Reset every record field to its "nothing parsed" value.
+#
+# The parsers build their record in these bare _<FIELD> locals and write them
+# only on a path that also sets _OK, so a rejected parse publishes nothing but
+# these defaults.
+#
+# Macros rather than functions: these all have to touch the *calling function's*
+# scope, and a nested function() would put PARENT_SCOPE one level short.
+macro(endo_clear_version_record)
+    foreach(_record_field IN LISTS ENDO_VERSION_RECORD_FIELDS)
+        set(_${_record_field} "")
+    endforeach()
+    set(_OK FALSE)
+    set(_DIRTY FALSE)
+    set(_COMMITS 0)
+endmacro()
+
+# Publish the record built up in the local _<FIELD> variables under @p prefix.
+macro(endo_publish_version_record prefix)
+    foreach(_record_field IN LISTS ENDO_VERSION_RECORD_FIELDS)
+        set(${prefix}_${_record_field} "${_${_record_field}}" PARENT_SCOPE)
+    endforeach()
+endmacro()
+
+# Adopt a record another parser published under @p prefix as this scope's own
+# local _<FIELD> variables -- the inverse of endo_publish_version_record().
+macro(endo_adopt_version_record prefix)
+    foreach(_record_field IN LISTS ENDO_VERSION_RECORD_FIELDS)
+        set(_${_record_field} "${${prefix}_${_record_field}}")
+    endforeach()
+endmacro()
+
+# Publish an empty record under @p prefix and return from the calling function.
+# A macro so that the return() leaves the *parser*, keeping its guard clauses
+# flat instead of nesting the whole body inside them.
+macro(endo_reject_version_record prefix)
+    endo_clear_version_record()
+    endo_publish_version_record(${prefix})
+    return()
+endmacro()
+
+## @brief Fails the configure unless a parsed version record exists under @p prefix.
+##
+## The mechanisms that stamp version metadata onto a binary are useless without
+## one, and a missing record means they were called before
+## endo_get_version_information() -- an ordering mistake worth naming rather than
+## silently embedding an empty version.
+## @param prefix  The record prefix to check.
+## @param context What is asking, for the error message.
+macro(endo_require_version_record prefix context)
+    if(NOT ${prefix}_OK)
+        message(FATAL_ERROR
+            "${context}: no version record under '${prefix}'. "
+            "endo_get_version_information() must run before this is called.")
+    endif()
+endmacro()
+
+# Clamp a numeric version component to the 16-bit field limit, warning if it
 # overflows.
-# @param value     The candidate build number.
-# @param out_var   Name of the variable to receive the clamped value.
-function(endo_clamp_msi_build value out_var)
-    if(value GREATER ${ENDO_MSI_BUILD_FIELD_MAX})
+# @param value    The candidate number.
+# @param what     What the number is, for the warning text.
+# @param out_var  Name of the variable to receive the clamped value.
+function(endo_clamp_version_field value what out_var)
+    if(value GREATER ${ENDO_VERSION_FIELD_MAX})
         message(WARNING
-            "Endo: derived MSI build number ${value} exceeds ${ENDO_MSI_BUILD_FIELD_MAX}; "
-            "clamping (Windows Installer ProductVersion build-field limit).")
-        set(${out_var} "${ENDO_MSI_BUILD_FIELD_MAX}" PARENT_SCOPE)
+            "Endo: derived ${what} ${value} exceeds ${ENDO_VERSION_FIELD_MAX}; clamping "
+            "(16-bit version-field limit: MSI ProductVersion and Win32 VERSIONINFO alike).")
+        set(${out_var} "${ENDO_VERSION_FIELD_MAX}" PARENT_SCOPE)
     else()
         set(${out_var} "${value}" PARENT_SCOPE)
     endif()
 endfunction()
 
 # Parse the output of `git describe --tags --long --match "v*" --dirty` into a
-# numeric version triple and a human-readable string.
+# version record.
 #
 # Accepted shape: v<major>.<minor>.<patch>[<suffix>]-<commits>-g<sha>[-dirty]
 # where <suffix> is any optional pre-release/build metadata (e.g. "-rc1"); it is
-# preserved in the human string but ignored for the numeric triple. The two-step
-# match (peel the "-<commits>-g<sha>" trailer first, then parse the tag core)
-# makes pre-release tags parse correctly instead of being silently dropped.
+# reported separately and ignored for the numeric triple. The two-step match
+# (peel the "-<commits>-g<sha>" trailer first, then parse the tag core) makes
+# pre-release tags parse correctly instead of being silently dropped.
 #
-# Numbering:
+# NUMERIC policy for this source:
 #   * Exactly on a clean tag (commits == 0, not dirty) -> the clean tag version.
 #   * Otherwise (development build, or dirty on a tag)  -> patch + commits folded
 #     into the build field, so each commit yields a unique, increasing version
@@ -43,51 +130,109 @@ endfunction()
 #     what users install; CI/dev MSIs are not distributed, so cross-tag ordering
 #     is intentionally not guaranteed.)
 #
-# @param describe      The git-describe string to parse.
-# @param out_ok        Receives TRUE if parsing succeeded, FALSE otherwise.
-# @param out_numeric   Receives the numeric triple "major.minor.build".
-# @param out_human     Receives the human-readable version string.
-# @param out_source    Receives a short description of the version source.
-function(endo_parse_git_describe describe out_ok out_numeric out_human out_source)
+# The components and QUAD are reported unfolded regardless, because the OS-level
+# metadata stamped into the binary wants the tag's own MAJOR.MINOR.PATCH plus the
+# commit distance in a fourth field -- one regex feeding both shapes rather than
+# a second parser for the second consumer.
+#
+# @param describe    The git-describe string to parse.
+# @param out_prefix  Variable-name prefix. Every field named in
+#                    ENDO_VERSION_RECORD_FIELDS is set in the caller's scope, on
+#                    success and on rejection alike, so a caller reusing one
+#                    prefix for two parses can never read the first parse's
+#                    leftovers.
+function(endo_parse_git_describe describe out_prefix)
+    endo_clear_version_record()
+
     # Step 1: peel the "-<commits>-g<sha>[-dirty]" describe trailer. Anchored at
     # the end so the greedy tag capture backtracks deterministically.
     if(NOT describe MATCHES "^(.+)-([0-9]+)-g([0-9a-f]+)(-dirty)?$")
-        set(${out_ok} FALSE PARENT_SCOPE)
-        return()
+        endo_reject_version_record(${out_prefix})
     endif()
     # Save the captures immediately: the next MATCHES clobbers CMAKE_MATCH_*.
     set(_tag "${CMAKE_MATCH_1}")
-    set(_commits "${CMAKE_MATCH_2}")
-    set(_sha "${CMAKE_MATCH_3}")
-    set(_dirty "${CMAKE_MATCH_4}")
+    set(_commit_count "${CMAKE_MATCH_2}")
+    set(_short_sha "${CMAKE_MATCH_3}")
+    set(_dirty_marker "${CMAKE_MATCH_4}")
 
     # Step 2: parse the numeric core from the tag; anything after the patch is
     # optional pre-release/build metadata kept only in the human string.
     if(NOT _tag MATCHES "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$")
-        set(${out_ok} FALSE PARENT_SCOPE)
-        return()
+        endo_reject_version_record(${out_prefix})
     endif()
-    set(_major "${CMAKE_MATCH_1}")
-    set(_minor "${CMAKE_MATCH_2}")
-    set(_patch "${CMAKE_MATCH_3}")
-    set(_suffix "${CMAKE_MATCH_4}")
 
-    if(_commits EQUAL 0 AND _dirty STREQUAL "")
-        # Exactly on a clean release tag.
-        set(${out_numeric} "${_major}.${_minor}.${_patch}" PARENT_SCOPE)
-        set(${out_human} "${_major}.${_minor}.${_patch}${_suffix}" PARENT_SCOPE)
-        set(${out_source} "git tag" PARENT_SCOPE)
-    else()
-        # Development build N commits past the tag (or a dirty checkout exactly on
-        # a tag, which folds to patch+0 == patch and so aliases the clean release
-        # numerically — acceptable because a dirty build is local-only, never
-        # released, and the "-dirty" marker is preserved in the human string).
-        math(EXPR _build "${_patch} + ${_commits}")
-        endo_clamp_msi_build("${_build}" _build)
-        set(${out_numeric} "${_major}.${_minor}.${_build}" PARENT_SCOPE)
-        set(${out_human}
-            "${_major}.${_minor}.${_patch}${_suffix}-${_commits}-g${_sha}${_dirty}" PARENT_SCOPE)
-        set(${out_source} "git describe (development build)" PARENT_SCOPE)
+    set(_OK TRUE)
+    set(_MAJOR "${CMAKE_MATCH_1}")
+    set(_MINOR "${CMAKE_MATCH_2}")
+    set(_PATCH "${CMAKE_MATCH_3}")
+    set(_PRERELEASE "${CMAKE_MATCH_4}")
+    set(_SHA "${_short_sha}")
+    if(NOT _dirty_marker STREQUAL "")
+        set(_DIRTY TRUE)
     endif()
-    set(${out_ok} TRUE PARENT_SCOPE)
+    endo_clamp_version_field("${_commit_count}" "commit count since tag" _COMMITS)
+    set(_QUAD "${_MAJOR}.${_MINOR}.${_PATCH}.${_COMMITS}")
+
+    if(_commit_count EQUAL 0 AND NOT _DIRTY)
+        # Exactly on a clean release tag.
+        set(_NUMERIC "${_MAJOR}.${_MINOR}.${_PATCH}")
+        set(_HUMAN "${_MAJOR}.${_MINOR}.${_PATCH}${_PRERELEASE}")
+        set(_SOURCE "git tag")
+    else()
+        # Development build N commits past the tag (or a dirty checkout exactly
+        # on a tag, which folds to patch+0 == patch and so aliases the clean
+        # release numerically -- acceptable because a dirty build is local-only,
+        # never released, and the "-dirty" marker is preserved in the human
+        # string).
+        math(EXPR _build "${_PATCH} + ${_commit_count}")
+        endo_clamp_version_field("${_build}" "MSI ProductVersion build field" _build)
+        set(_NUMERIC "${_MAJOR}.${_MINOR}.${_build}")
+        set(_HUMAN
+            "${_MAJOR}.${_MINOR}.${_PATCH}${_PRERELEASE}-${_commit_count}-g${_short_sha}${_dirty_marker}")
+        set(_SOURCE "git describe (development build)")
+    endif()
+
+    endo_publish_version_record(${out_prefix})
+endfunction()
+
+# Interpret the contents of ${CMAKE_SOURCE_DIR}/version.txt into the same record.
+#
+# The file is written by scripts/package-deb.sh and packaging/deb/Dockerfile and
+# holds a FULL describe string ("v0.1.0-312-gfcf09f3e"), because the Debian build
+# context excludes .git. So the describe parser does the work, and this function
+# overrides only the fields whose policy differs on this path -- above all
+# NUMERIC, which stays the UNFOLDED tag triple (0.1.0). That is what this path
+# has always produced and what the published .deb is versioned; adopting the
+# describe parser's folded value would silently move the .deb from 0.1.0 to
+# 0.1.312.
+#
+# A bare "X.Y.Z" that the describe parser rejects (the git-less fallback in
+# package-deb.sh) still parses, with zero commits.
+#
+# @param text        The stripped contents of version.txt.
+# @param out_prefix  As for endo_parse_git_describe().
+function(endo_parse_version_file text out_prefix)
+    endo_clear_version_record()
+
+    endo_parse_git_describe("${text}" _describe)
+    if(_describe_OK)
+        endo_adopt_version_record(_describe)
+    # "[0-9]+" for the major, not the historical "[0-9]*": the latter accepted
+    # ".1.0" and produced the triple ".1.0", which fails obscurely much later
+    # inside project(VERSION).
+    elseif(text MATCHES "^v?([0-9]+)\\.([0-9]+)\\.([0-9]+).*$")
+        set(_OK TRUE)
+        set(_MAJOR "${CMAKE_MATCH_1}")
+        set(_MINOR "${CMAKE_MATCH_2}")
+        set(_PATCH "${CMAKE_MATCH_3}")
+        set(_QUAD "${_MAJOR}.${_MINOR}.${_PATCH}.${_COMMITS}")
+    else()
+        endo_reject_version_record(${out_prefix})
+    endif()
+
+    set(_NUMERIC "${_MAJOR}.${_MINOR}.${_PATCH}")
+    set(_HUMAN "${text}")
+    set(_SOURCE "version.txt")
+
+    endo_publish_version_record(${out_prefix})
 endfunction()

--- a/cmake/WindowsVersionResource.cmake
+++ b/cmake/WindowsVersionResource.cmake
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Windows version metadata -- the VS_VERSION_INFO resource and the application
+# manifest -- as one concern.
+#
+# Both carry a version, so both live here: leaving the manifest behind was how
+# its assemblyIdentity froze at 0.1.0.0 while the rest of the build moved on.
+
+# The resource compiler. It sits at module scope rather than inside the function
+# because enable_language() is rejected inside a function(), and out of the
+# project() LANGUAGES list because it has to be conditional. This module is
+# include()d at directory scope, which is all enable_language() requires.
+#
+# WIN32 rather than MSVC: the .rc is self-contained, so windres accepts it too and
+# a MinGW build would get the resource as well. Enabling RC does not reach
+# cmake/CompileCache.cmake -- that module only ever fronts C and CXX -- so no
+# compiler-cache launcher is put in front of the resource compiler.
+if(WIN32)
+    enable_language(RC)
+endif()
+
+# Whether a version resource will actually be embedded. Exported so that the test
+# which reads the metadata back out of the binary can skip on the same condition
+# the stamping uses, rather than on an approximation of it.
+get_property(_endo_enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+if(WIN32 AND "RC" IN_LIST _endo_enabled_languages)
+    set(ENDO_HAS_VERSION_RESOURCE ON)
+else()
+    set(ENDO_HAS_VERSION_RESOURCE OFF)
+endif()
+
+## @brief Embeds Windows version metadata into @p target.
+##
+## Without it a Windows executable has no version metadata at all and every
+## reader -- Explorer, `Get-Command`, a crash reporter -- reports the synthesised
+## 0.0.0.0.
+##
+## Templates (EndoVersionInfo.rc.in, endo.manifest.in) are read from @p target's
+## own source directory, so this works from anywhere. A no-op off Windows, so
+## call sites need no guard of their own.
+##
+## @param target The executable to embed the metadata into.
+function(enable_windows_version_resource target)
+    if(NOT ENDO_HAS_VERSION_RESOURCE)
+        return()
+    endif()
+    endo_require_version_record(ENDO_VERSION "enable_windows_version_resource(${target})")
+
+    get_target_property(_source_dir ${target} SOURCE_DIR)
+
+    # VS_FF_PRERELEASE (0x2) for anything that is not exactly a clean release
+    # tag; VS_FF_PRIVATEBUILD (0x8) for a modified working tree.
+    set(_flags 0)
+    if(ENDO_VERSION_COMMITS GREATER 0 OR NOT ENDO_VERSION_PRERELEASE STREQUAL "")
+        math(EXPR _flags "${_flags} | 0x2")
+    endif()
+
+    # VS_FF_PRIVATEBUILD without a PrivateBuild string is a malformed
+    # VERSIONINFO, so the flag and the string are set together or not at all.
+    set(ENDO_RC_PRIVATE_BUILD_VALUE "")
+    if(ENDO_VERSION_DIRTY)
+        math(EXPR _flags "${_flags} | 0x8")
+        set(ENDO_RC_PRIVATE_BUILD_VALUE
+            "            VALUE \"PrivateBuild\",     \"built from a modified working tree\"")
+    endif()
+
+    # Both spellings are whole numbers computed here rather than an expression in
+    # the .rc: resource compilers differ in how much constant arithmetic they
+    # accept, and that is not a thing to discover on someone else's toolchain.
+    math(EXPR _flags_debug "${_flags} | 0x1") # VS_FF_DEBUG
+    math(EXPR _flags "${_flags}" OUTPUT_FORMAT HEXADECIMAL)
+    math(EXPR _flags_debug "${_flags_debug}" OUTPUT_FORMAT HEXADECIMAL)
+    set(ENDO_RC_FILEFLAGS "${_flags}L")
+    set(ENDO_RC_FILEFLAGS_DEBUG "${_flags_debug}L")
+
+    # FILEVERSION and PRODUCTVERSION want the quad comma-separated, so it is
+    # spelled once here rather than twice in the template.
+    string(REPLACE "." "," ENDO_RC_VERSION_FIELDS "${ENDO_VERSION_QUAD}")
+
+    set(_rc "${CMAKE_CURRENT_BINARY_DIR}/EndoVersionInfo.rc")
+    configure_file("${_source_dir}/EndoVersionInfo.rc.in" "${_rc}" @ONLY)
+    target_sources(${target} PRIVATE "${_rc}")
+
+    # Scoped to RC: an unscoped definition would also land on every C++
+    # translation unit, and the Debug bit is the one flag a multi-config
+    # generator can still change after the .rc was configured.
+    target_compile_definitions(${target} PRIVATE
+        $<$<AND:$<COMPILE_LANGUAGE:RC>,$<CONFIG:Debug>>:ENDO_RC_DEBUG_BUILD>)
+
+    # The manifest is only consumed by the MSVC-style linker, which embeds it via
+    # /MANIFESTINPUT -- so a MinGW build gets the resource above but no manifest,
+    # rather than a configured file nothing reads. Note the resource deliberately
+    # carries no RT_MANIFEST entry of its own; two would collide.
+    if(MSVC)
+        set(_manifest "${CMAKE_CURRENT_BINARY_DIR}/endo.manifest")
+        configure_file("${_source_dir}/endo.manifest.in" "${_manifest}" @ONLY)
+        target_sources(${target} PRIVATE "${_manifest}")
+    endif()
+endfunction()

--- a/cmake/tests/TestBinaryVersionMetadata.cmake
+++ b/cmake/tests/TestBinaryVersionMetadata.cmake
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Asserts that the OS-level version metadata is actually IN the built binary --
+# not merely that CMake computed the right strings.
+#
+# All three mechanisms (a Win32 resource, a Mach-O section, an ELF note) are
+# applied by the LINKER, so a wrong flag produces a perfectly green build and a
+# silent 0.0.0.0. Only reading the value back out of the binary catches that,
+# which is exactly the regression this test exists for.
+#
+# Run via:
+#   cmake -DBINARY=<exe> -DTARGET_SYSTEM=<CMAKE_SYSTEM_NAME>
+#         -DEXPECT_FILE_VERSION=0.1.0.312 -DEXPECT_HUMAN_VERSION=0.1.0-312-g...
+#         -DHAVE_VERSION_RESOURCE=<bool> -DHAVE_PACKAGE_METADATA=<bool>
+#         -P cmake/tests/TestBinaryVersionMetadata.cmake
+#
+# Exits 77 (ctest SKIP_RETURN_CODE) whenever the platform has no probe, its gate
+# is off, or the probe tool is not installed: a developer without `readelf` is not
+# a failing build, and passing silently would be worse than either.
+
+cmake_minimum_required(VERSION 3.30 FATAL_ERROR)
+
+foreach(_required BINARY TARGET_SYSTEM EXPECT_FILE_VERSION EXPECT_HUMAN_VERSION)
+    if(NOT DEFINED ${_required})
+        message(FATAL_ERROR "binary-metadata: ${_required} must be set.")
+    endif()
+endforeach()
+
+if(NOT EXISTS "${BINARY}")
+    message(FATAL_ERROR "binary-metadata: '${BINARY}' does not exist.")
+endif()
+
+# One row per platform, keyed by CMAKE_SYSTEM_NAME so no lookup is needed.
+# Adding a platform is a row, not a branch -- including its skip condition, which
+# is the _gate field rather than an if() of its own.
+#   _probe_<system>_what   human name of the metadata under test
+#   _probe_<system>_gate   name of a variable that must be true, or "" for always
+#   _probe_<system>_tools  candidate programs, in preference order
+#   _probe_<system>_args   arguments; @BINARY@ is substituted
+#   _probe_<system>_expect substrings the output must ALL contain
+#   _probe_<system>_reject substrings the output must NOT contain
+
+# FileVersionRaw as well as FileVersion: the string block and the binary
+# FILEVERSION are separate fields of a VERSIONINFO and can disagree.
+set(_probe_Windows_what "Win32 VERSIONINFO resource")
+set(_probe_Windows_gate "HAVE_VERSION_RESOURCE")
+set(_probe_Windows_tools "pwsh;powershell")
+# No ';' anywhere in the -Command payload: these argument strings are CMake
+# lists, and a semicolon would split the command in half.
+set(_probe_Windows_args
+    "-NoProfile;-NonInteractive;-Command;(Get-Item '@BINARY@').VersionInfo | ForEach-Object { \"$($_.FileVersion) $($_.ProductVersion) $($_.FileVersionRaw)\" }")
+set(_probe_Windows_expect "${EXPECT_FILE_VERSION};${EXPECT_HUMAN_VERSION}")
+# The original bug, asserted directly.
+set(_probe_Windows_reject "0[.]0[.]0[.]0")
+
+# `otool -P` prints the __TEXT,__info_plist section as text; `otool -s` would
+# print a hex dump this script would then have to decode.
+set(_probe_Darwin_what "embedded __TEXT,__info_plist section")
+set(_probe_Darwin_gate "")
+set(_probe_Darwin_tools "otool")
+set(_probe_Darwin_args "-P;@BINARY@")
+set(_probe_Darwin_expect "CFBundleShortVersionString;CFBundleIdentifier;${EXPECT_FILE_VERSION}")
+set(_probe_Darwin_reject "")
+
+# `readelf -p <section>` string-dumps the section whether or not that binutils
+# recognises note type 0xcafe1a7e, which `readelf -n` older than 2.39 does not.
+set(_probe_Linux_what ".note.package ELF note")
+set(_probe_Linux_gate "HAVE_PACKAGE_METADATA")
+set(_probe_Linux_tools "readelf;eu-readelf")
+set(_probe_Linux_args "-p;.note.package;@BINARY@")
+set(_probe_Linux_expect "\"version\";${EXPECT_HUMAN_VERSION}")
+set(_probe_Linux_reject "")
+
+if(NOT DEFINED _probe_${TARGET_SYSTEM}_tools)
+    message(STATUS "binary-metadata: no probe for system '${TARGET_SYSTEM}'; skipping.")
+    cmake_language(EXIT 77)
+endif()
+
+set(_what "${_probe_${TARGET_SYSTEM}_what}")
+
+# The mechanism may have been switched off at configure time -- by a linker that
+# does not know --package-metadata, or by a build with no RC language. Either was
+# reported then; repeating it as a failure here would be noise.
+#
+# Nested rather than one `if(_gate AND DEFINED ${_gate} AND ...)`: a row with no
+# gate leaves _gate empty, `${_gate}` then expands to nothing, and CMake sees a
+# dangling DEFINED with no argument and aborts with "Unknown arguments
+# specified". Only the gate-less row hits it, so it passes everywhere a gate is
+# set and fails on macOS alone.
+set(_gate "${_probe_${TARGET_SYSTEM}_gate}")
+if(_gate)
+    if(DEFINED ${_gate} AND NOT ${_gate})
+        message(STATUS "binary-metadata: ${_gate} is off, so no ${_what} was embedded; skipping.")
+        cmake_language(EXIT 77)
+    endif()
+endif()
+
+find_program(_tool NAMES ${_probe_${TARGET_SYSTEM}_tools})
+if(NOT _tool)
+    message(STATUS
+        "binary-metadata: none of '${_probe_${TARGET_SYSTEM}_tools}' is installed, so the "
+        "${_what} cannot be read back; skipping.")
+    cmake_language(EXIT 77)
+endif()
+
+set(_args "")
+foreach(_arg IN LISTS _probe_${TARGET_SYSTEM}_args)
+    string(REPLACE "@BINARY@" "${BINARY}" _arg "${_arg}")
+    list(APPEND _args "${_arg}")
+endforeach()
+
+execute_process(
+    COMMAND "${_tool}" ${_args}
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE _stdout
+    ERROR_VARIABLE _stderr
+)
+if(NOT _result EQUAL 0)
+    message(FATAL_ERROR
+        "binary-metadata: reading the ${_what} from '${BINARY}' failed "
+        "(${_result}):\n${_stdout}${_stderr}")
+endif()
+
+# message(SEND_ERROR) is what makes `cmake -P` exit non-zero; the trailing
+# FATAL_ERROR only adds the context a bare "does not contain" line lacks.
+set(_failed FALSE)
+foreach(_want IN LISTS _probe_${TARGET_SYSTEM}_expect)
+    if(NOT _stdout MATCHES "${_want}")
+        message(SEND_ERROR "binary-metadata: the ${_what} does not contain '${_want}'.")
+        set(_failed TRUE)
+    endif()
+endforeach()
+foreach(_unwanted IN LISTS _probe_${TARGET_SYSTEM}_reject)
+    if(_stdout MATCHES "${_unwanted}")
+        message(SEND_ERROR "binary-metadata: the ${_what} still reports '${_unwanted}'.")
+        set(_failed TRUE)
+    endif()
+endforeach()
+
+if(_failed)
+    string(STRIP "${_stdout}" _stdout)
+    message(FATAL_ERROR
+        "binary-metadata: '${BINARY}' should report file version "
+        "'${EXPECT_FILE_VERSION}' and human version '${EXPECT_HUMAN_VERSION}'.\n"
+        "${_tool} said:\n${_stdout}")
+endif()
+
+message(STATUS "binary-metadata: ${_what} reports ${EXPECT_FILE_VERSION}.")

--- a/cmake/tests/TestVersionParse.cmake
+++ b/cmake/tests/TestVersionParse.cmake
@@ -1,11 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Unit test for endo_parse_git_describe() in cmake/VersionParse.cmake.
+# Unit test for the version parsers in cmake/VersionParse.cmake.
 # Pure CMake, no git required. Run via:
 #   cmake -P cmake/tests/TestVersionParse.cmake
 #
-# Data-driven: each row is "<describe>|<expected-numeric>". The sentinel value
-# "FAIL" means parsing is expected to be rejected (out_ok == FALSE).
+# Data-driven on two axes. Each table row is "<input>|<expectations>", where
+# <expectations> is a space-separated list of <FIELD>=<value> assertions naming
+# fields of the version record; a row asserts only the fields it mentions, so a
+# new record field means a new token on the rows that care -- not an edit to
+# every row, and not a new positional column. The sentinel "FAIL" in place of the
+# expectation list means the input must be rejected. And each SUITE is a row too,
+# naming the parser under test, so covering a third parser is one more line
+# rather than a second copy of the loop.
+#
+# Values may contain neither a space (the assertion separator) nor a "|" (the
+# field separator). No describe string or version component ever does.
 
 # Required: a -P script starts with no policy baseline, and with CMP0007 unset the
 # list() commands drop empty elements. The empty-input row below splits to ";FAIL",
@@ -14,43 +23,119 @@ cmake_minimum_required(VERSION 3.30 FATAL_ERROR)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../VersionParse.cmake")
 
-set(_cases
-    "v0.1.0-0-gabc1234|0.1.0"             # clean release tag
-    "v1.2.3-5-gabc1234|1.2.8"             # development build: patch + commits
-    "v1.2.3-0-gabc1234-dirty|1.2.3"       # dirty on a tag: folds to patch+0 (documented alias)
-    "v1.2.3-rc1-5-gabc1234|1.2.8"         # pre-release suffix tolerated (kept only in human string)
-    "v10.20.30-rc.2-7-gdeadbee|10.20.37"  # dotted pre-release, multi-digit components
-    "v1.2.0-70000-gabc1234|1.2.65535"     # MSI build-field overflow clamped
-    "v0.0.0-0-g0000000|0.0.0"             # zero version
-    "garbage|FAIL"                        # not a describe string
-    "v1.2-5-gabc1234|FAIL"                # tag missing the patch component
-    "|FAIL"                               # empty input
+# `git describe` inputs.
+set(_describe_cases
+    # clean release tag
+    "v0.1.0-0-gabc1234|OK=TRUE NUMERIC=0.1.0 HUMAN=0.1.0 QUAD=0.1.0.0 MAJOR=0 MINOR=1 PATCH=0 COMMITS=0 SHA=abc1234 DIRTY=FALSE PRERELEASE="
+    # the shape this repository actually builds from
+    "v0.1.0-312-gfcf09f3e|NUMERIC=0.1.312 QUAD=0.1.0.312 HUMAN=0.1.0-312-gfcf09f3e DIRTY=FALSE"
+    # development build: patch + commits folded into NUMERIC, QUAD stays unfolded
+    "v1.2.3-5-gabc1234|NUMERIC=1.2.8 QUAD=1.2.3.5 MAJOR=1 MINOR=2 PATCH=3 COMMITS=5"
+    # dirty on a tag: folds to patch+0 (documented alias), but DIRTY is reported
+    "v1.2.3-0-gabc1234-dirty|NUMERIC=1.2.3 QUAD=1.2.3.0 DIRTY=TRUE"
+    # pre-release suffix tolerated: kept out of NUMERIC, reported in PRERELEASE
+    "v1.2.3-rc1-5-gabc1234|NUMERIC=1.2.8 QUAD=1.2.3.5 PRERELEASE=-rc1"
+    # dotted pre-release, multi-digit components
+    "v10.20.30-rc.2-7-gdeadbee|NUMERIC=10.20.37 QUAD=10.20.30.7 PRERELEASE=-rc.2"
+    # both 16-bit fields clamp independently -- the folded build AND the commit
+    # count that becomes the fourth VERSIONINFO field. The true count survives in
+    # HUMAN, which is what makes clamping acceptable.
+    "v1.2.0-70000-gabc1234|NUMERIC=1.2.65535 QUAD=1.2.0.65535 COMMITS=65535 HUMAN=1.2.0-70000-gabc1234"
+    # zero version
+    "v0.0.0-0-g0000000|NUMERIC=0.0.0 QUAD=0.0.0.0"
+    "garbage|FAIL"                # not a describe string
+    "v1.2-5-gabc1234|FAIL"        # tag missing the patch component
+    "|FAIL"                       # empty input
 )
 
-set(_failures 0)
-foreach(_case IN LISTS _cases)
-    string(REPLACE "|" ";" _parts "${_case}")
-    list(GET _parts 0 _describe)
-    list(GET _parts 1 _expected)
+# version.txt contents (the Debian / tarball path).
+#
+# NUMERIC must stay the UNFOLDED tag triple here: the published .deb is versioned
+# 0.1.0, and a refactor that "unified" this path with the describe path would move
+# it to 0.1.312 without a single other test going red. This table is that test.
+set(_version_file_cases
+    "v0.1.0-312-gfcf09f3e|OK=TRUE NUMERIC=0.1.0 QUAD=0.1.0.312 MAJOR=0 MINOR=1 PATCH=0 COMMITS=312 SHA=fcf09f3e"
+    "v1.2.3-rc1-5-gabc1234|NUMERIC=1.2.3 QUAD=1.2.3.5 PRERELEASE=-rc1"
+    # a bare triple: the describe parser rejects it, components fall back to it
+    "0.1.0|NUMERIC=0.1.0 QUAD=0.1.0.0 MAJOR=0 MINOR=1 PATCH=0 COMMITS=0 SHA= DIRTY=FALSE"
+    # package-deb.sh's git-less fallback
+    "0.0.0|NUMERIC=0.0.0 QUAD=0.0.0.0"
+    "not-a-version|FAIL"
+    ".1.0|FAIL"                   # a missing major must be rejected, not yield ".1.0"
+    "|FAIL"
+)
 
-    endo_parse_git_describe("${_describe}" _ok _numeric _human _source)
+# One row per parser: "<label>/<function>/<table variable>".
+set(_suites
+    "describe/endo_parse_git_describe/_describe_cases"
+    "version.txt/endo_parse_version_file/_version_file_cases"
+)
 
-    if(_expected STREQUAL "FAIL")
-        if(_ok)
-            message(SEND_ERROR "FAIL: '${_describe}' expected rejection but parsed to '${_numeric}'.")
-            math(EXPR _failures "${_failures} + 1")
+# Check one parsed record against one row's expectations. A failed assertion is
+# reported with message(SEND_ERROR), which is what makes `cmake -P` exit non-zero
+# -- there is no separate failure counter to keep in step.
+# @param label        What is under test, for failure messages.
+# @param input        The row's input.
+# @param prefix       The record prefix the parser wrote.
+# @param expectations The row's assertion list, or "FAIL".
+function(check_version_record label input prefix expectations)
+    if(expectations STREQUAL "FAIL")
+        if(${prefix}_OK)
+            message(SEND_ERROR "FAIL: ${label} '${input}' expected rejection but parsed.")
         endif()
-    elseif(NOT _ok)
-        message(SEND_ERROR "FAIL: '${_describe}' expected '${_expected}' but was rejected.")
-        math(EXPR _failures "${_failures} + 1")
-    elseif(NOT _numeric STREQUAL _expected)
-        message(SEND_ERROR "FAIL: '${_describe}' expected '${_expected}' but got '${_numeric}'.")
-        math(EXPR _failures "${_failures} + 1")
+        return()
     endif()
+
+    if(NOT ${prefix}_OK)
+        message(SEND_ERROR "FAIL: ${label} '${input}' was rejected but should parse.")
+        return()
+    endif()
+
+    string(REPLACE " " ";" _assertions "${expectations}")
+    foreach(_assertion IN LISTS _assertions)
+        if(NOT _assertion MATCHES "^([A-Z_]+)=(.*)$")
+            message(FATAL_ERROR "${label}: malformed expectation '${_assertion}' in row '${input}'.")
+        endif()
+        set(_key "${CMAKE_MATCH_1}")
+        set(_want "${CMAKE_MATCH_2}")
+
+        # A misspelled field name must fail loudly rather than assert nothing --
+        # that is the one way a name-addressed table can quietly stop testing.
+        if(NOT _key IN_LIST ENDO_VERSION_RECORD_FIELDS)
+            message(FATAL_ERROR "${label}: '${_key}' is not a version-record field (row '${input}').")
+        endif()
+
+        if(NOT "${${prefix}_${_key}}" STREQUAL "${_want}")
+            message(SEND_ERROR
+                "FAIL: ${label} '${input}' ${_key}: expected '${_want}' but got '${${prefix}_${_key}}'.")
+        endif()
+    endforeach()
+endfunction()
+
+set(_total 0)
+foreach(_suite IN LISTS _suites)
+    string(REPLACE "/" ";" _suite_parts "${_suite}")
+    list(GET _suite_parts 0 _label)
+    list(GET _suite_parts 1 _parser)
+    list(GET _suite_parts 2 _table)
+
+    foreach(_case IN LISTS ${_table})
+        string(REPLACE "|" ";" _parts "${_case}")
+        list(GET _parts 0 _input)
+        list(GET _parts 1 _expectations)
+        cmake_language(CALL ${_parser} "${_input}" _record)
+        check_version_record("${_label}" "${_input}" _record "${_expectations}")
+        math(EXPR _total "${_total} + 1")
+    endforeach()
 endforeach()
 
-list(LENGTH _cases _total)
-if(_failures GREATER 0)
-    message(FATAL_ERROR "version-parse: ${_failures}/${_total} case(s) failed.")
+# A rejected parse must leave no field of an earlier successful parse behind: the
+# record is reused under one prefix by cmake/Version.cmake's fallback chain.
+endo_parse_git_describe("v9.9.9-9-gfeedbee" _reused)
+endo_parse_git_describe("garbage" _reused)
+if(NOT _reused_MAJOR STREQUAL "")
+    message(SEND_ERROR "FAIL: a rejected parse left MAJOR='${_reused_MAJOR}' from the previous one.")
 endif()
-message(STATUS "version-parse: all ${_total} cases passed.")
+math(EXPR _total "${_total} + 1")
+
+message(STATUS "version-parse: ${_total} cases checked.")

--- a/cmake/wix-install-root.wxs.in
+++ b/cmake/wix-install-root.wxs.in
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SPDX-License-Identifier: Apache-2.0
+
+  WIX source fragment: pins INSTALL_ROOT to THIS version's directory when an
+  upgrade is detected.
+
+  Without this, an MSI upgrade installs into the OLD version's directory and then
+  deletes everything it just wrote. CPack generates, into properties.wxi:
+
+      <Property Id="INSTALL_ROOT" Secure="yes">
+        <RegistrySearch Id="FindInstallLocation" Root="HKLM"
+            Key="Software\...\Uninstall\[WIX_UPGRADE_DETECTED]"
+            Name="InstallLocation" Type="raw"/>
+      </Property>
+
+  That search remembers where the previous version went, so a reinstall lands in
+  the directory the user originally chose. It is the right behaviour for a fixed
+  install directory and destructive for a per-version one: AppSearch assigns the
+  old path to the public property INSTALL_ROOT, a public property outranks the
+  Directory table's per-version default, so the new version's files are written
+  into the old version's directory — and MajorUpgrade (scheduled
+  afterInstallExecute) then removes the old product, deleting them. The result is
+  a registered product with no files and no PATH entry.
+
+  Conditioned on WIX_UPGRADE_DETECTED so it only fires when FindRelatedProducts
+  found an earlier product. A fresh install is untouched, and so is the install
+  directory a user picks in the WixUI_InstallDir dialog. In maintenance mode
+  FindRelatedProducts does not run, so a repair keeps its cached directory.
+
+  The one behaviour this gives up: a user who installed an earlier version to a
+  non-default location is moved back under Program Files by an upgrade. Today
+  that user ends up with nothing installed at all, so this is strictly better —
+  but it is the reason to prefer a stable INSTALL_ROOT if the install layout is
+  ever revisited.
+
+  Sequenced into both the UI and the execute sequence so a silent /qn install and
+  an interactive one behave identically.
+
+  Configured by CMake (configure_file, @ONLY) into the build tree: the value needs
+  both the product display name and the version, which are single-sourced in
+  cmake/ProjectMetadata.cmake and the version record. Compiled as an extra source
+  via CPACK_WIX_EXTRA_SOURCES and pulled in by the CustomActionRef in
+  cmake/wix-template.wxs.
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <CustomAction Id="EndoOverrideInstallRoot"
+                      Property="INSTALL_ROOT"
+                      Value="[ProgramFiles64Folder]@ENDO_PRODUCT_DISPLAY_NAME@\@PROJECT_VERSION@"
+                      Execute="immediate"
+                      Return="check"/>
+
+        <InstallUISequence>
+            <Custom Action="EndoOverrideInstallRoot" After="AppSearch">WIX_UPGRADE_DETECTED</Custom>
+        </InstallUISequence>
+        <InstallExecuteSequence>
+            <Custom Action="EndoOverrideInstallRoot" After="AppSearch">WIX_UPGRADE_DETECTED</Custom>
+        </InstallExecuteSequence>
+    </Fragment>
+</Wix>

--- a/cmake/wix-template.wxs
+++ b/cmake/wix-template.wxs
@@ -21,6 +21,12 @@
        silently deferred to the next reboot instead of prompting the user to
        close applications or forcing a restart.
 
+    3. A "latest" directory junction beside the versioned install directories,
+       repointed on every install. Per-version directories solve the locked-binary
+       upgrade, but they leave no fixed path to configure a terminal with, and
+       Windows Terminal does not resolve a bare "endo.exe" through PATH the way the
+       Env_PATH component allows. See the custom actions below.
+
   Keep this template in lockstep with the WiX toolset version used in CI (v3).
   If CI moves to WiX v4, re-base this on the v4 default template and migrate the
   env-path fragment (cmake/wix-env-path.wxs.in) to the v4 schema as well.
@@ -58,6 +64,66 @@
              prompting to close applications or forcing a restart. -->
         <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable"/>
         <Property Id="REBOOT" Value="ReallySuppress"/>
+
+        <!-- "latest" junction: C:\Program Files\Endo\latest -> the version being
+             installed, giving terminals a path that survives upgrades.
+
+             A custom action because Windows Installer has no declarative way to
+             create a link, which costs us everything MSI would otherwise do for
+             free: the junction is not reference-counted, not repaired, and not
+             removed unless we remove it. Deferred + Impersonate="no" so it runs
+             in the elevated phase and may write under Program Files. Being a
+             type-34 (directory + ExeCommand) action, the command line is
+             formatted when the install script is written, so [INSTALL_ROOT] and
+             [INSTALL_PREFIX_1] resolve even though it executes deferred.
+
+             A junction rather than a symlink: /J never needs
+             SeCreateSymbolicLinkPrivilege, so a user can also recreate it by
+             hand without a Developer Mode or elevation caveat.
+
+             mklink refuses to overwrite, so the link is removed first. `rmdir`
+             without /s deletes the junction only and never recurses into the
+             directory it points at.
+
+             INSTALL_PREFIX_1 is CPack's directory ID for the parent of the
+             versioned install root — it exists because
+             CPACK_PACKAGE_INSTALL_DIRECTORY has two components ("Endo/<version>").
+             Collapsing that to one component would remove this ID. -->
+        <CustomAction Id="EndoCreateLatestLink"
+            Directory="INSTALL_PREFIX_1"
+            Execute="deferred"
+            Impersonate="no"
+            Return="ignore"
+            ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /c rmdir &quot;[INSTALL_PREFIX_1]latest&quot; 2&gt;nul &amp; mklink /J &quot;[INSTALL_PREFIX_1]latest&quot; &quot;[INSTALL_ROOT]&quot;"/>
+
+        <CustomAction Id="EndoRemoveLatestLink"
+            Directory="INSTALL_PREFIX_1"
+            Execute="deferred"
+            Impersonate="no"
+            Return="ignore"
+            ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /c rmdir &quot;[INSTALL_PREFIX_1]latest&quot;"/>
+
+        <!-- On rollback the link is removed rather than restored: the target it
+             pointed at before this install is not recorded anywhere, and no link
+             beats one dangling at a directory the rollback just deleted. -->
+        <CustomAction Id="EndoRollbackLatestLink"
+            Directory="INSTALL_PREFIX_1"
+            Execute="rollback"
+            Impersonate="no"
+            Return="ignore"
+            ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /c rmdir &quot;[INSTALL_PREFIX_1]latest&quot;"/>
+
+        <InstallExecuteSequence>
+            <Custom Action="EndoRollbackLatestLink" After="InstallFiles">NOT REMOVE</Custom>
+            <Custom Action="EndoCreateLatestLink" After="EndoRollbackLatestLink">NOT REMOVE</Custom>
+            <!-- NOT UPGRADINGPRODUCTCODE is load-bearing. MajorUpgrade above is
+                 scheduled afterInstallExecute, so during an upgrade the OLD
+                 product is uninstalled after the new files (and the new junction)
+                 are already in place. Without this condition that uninstall would
+                 delete the junction the new install just created, and every
+                 upgrade would end with no "latest" at all. -->
+            <Custom Action="EndoRemoveLatestLink" Before="RemoveFiles">REMOVE="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>
+        </InstallExecuteSequence>
 
         <WixVariable Id="WixUILicenseRtf" Value="$(var.CPACK_WIX_LICENSE_RTF)"/>
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALL_ROOT"/>

--- a/cmake/wix-template.wxs
+++ b/cmake/wix-template.wxs
@@ -141,6 +141,11 @@
         <WixVariable Id="WixUIDialogBmp" Value="$(var.CPACK_WIX_UI_DIALOG)"/>
         <?endif?>
 
+        <!-- Pulls in cmake/wix-install-root.wxs.in's fragment, which pins
+             INSTALL_ROOT to this version's directory on an upgrade. A fragment
+             is only linked in if something references it. -->
+        <CustomActionRef Id="EndoOverrideInstallRoot"/>
+
         <FeatureRef Id="ProductFeature"/>
 
         <UIRef Id="$(var.CPACK_WIX_UI_REF)" />

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -122,3 +122,40 @@ welcome. See [Contributing](contributing.md) for details.
 Endo follows [Semantic Versioning](https://semver.org/). Until the 1.0 release, the API
 and language syntax may change between minor versions. After 1.0, backward compatibility
 will be maintained within major versions.
+
+### Version metadata in the binary
+
+`endo --version` prints the full descriptive version, for example
+`0.1.0-312-gfcf09f3e` — release tag `v0.1.0`, 312 commits past it, at commit
+`fcf09f3e`. The same information is embedded as OS-level metadata, so tools that
+never run the binary can read it too:
+
+| Platform | Mechanism | How to read it |
+|----------|-----------|----------------|
+| Windows | `VS_VERSION_INFO` resource | `(Get-Command endo.exe).Version` |
+| macOS | embedded `__TEXT,__info_plist` section | `otool -P $(which endo)` |
+| Linux | `.note.package` ELF note ([ELF package metadata](https://systemd.io/ELF_PACKAGE_METADATA/)) | `readelf -p .note.package $(which endo)` |
+
+The embedded numeric version has **four** fields —
+`MAJOR.MINOR.PATCH.COMMITS`, so `0.1.0.312` above. The first three are the
+release tag's own components; the fourth is the number of commits since that
+tag, and is `0` for a release build.
+
+This deliberately differs from the version the **packages** carry (`0.1.312` for
+the same build — the MSI `ProductVersion`, the `Program Files\Endo\<version>\`
+directory, the `.deb`/`.rpm` version). Windows Installer compares only three
+fields, so the packaged version has to fold the commit distance into the patch
+field to stay unique and increasing between releases. Binary metadata has a
+fourth field available and uses it, which keeps the release's real patch number
+visible. Releases built from a clean tag are unambiguous either way: `0.1.0`
+and `0.1.0.0`.
+
+Both are derived at **configure** time from `git describe`. Committing without
+re-running CMake leaves the previous commit count embedded until the next
+configure.
+
+The Linux note's `type` field defaults to `cmake`; a distribution build can set
+`-DENDO_PACKAGE_METADATA_TYPE=deb` (or `rpm`, …) to identify the packaging it
+belongs to. The note is only emitted when the linker supports
+`--package-metadata` (GNU ld 2.39+, LLVM lld 15+); configure says so when it
+does not.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -86,6 +86,23 @@ version, and the previous version's files are removed automatically (on the next
 it was still in use). See
 [Platform Differences](shell/platform-differences.md#windows) for setup details.
 
+#### Configuring a terminal to launch Endo
+
+The version-specific directory means an absolute path such as
+`C:\Program Files\Endo\1.2.3\bin\endo.exe` goes stale on the next upgrade. Use the
+`latest` link the installer maintains beside the version directories instead:
+
+```
+C:\Program Files\Endo\latest\bin\endo.exe
+```
+
+It is a directory junction, repointed at the version being installed on every install and
+removed on uninstall, so a terminal profile configured against it keeps working across
+upgrades. Windows Terminal needs this: it does not resolve a bare `endo.exe` through
+`PATH`. Anything that *does* resolve through `PATH` — a login shell, `cmd`, PowerShell —
+can simply use `endo`, since the installer puts the current version's `bin` first on the
+system `PATH`.
+
 If you are upgrading from a pre-`.msi` Endo that was installed with the old `.exe`
 (NSIS) installer, the `.msi` automatically removes that installer's leftover
 `C:\Program Files\Endo\bin` entry from `PATH`. Its files (directly under

--- a/packaging/deb/Dockerfile
+++ b/packaging/deb/Dockerfile
@@ -77,6 +77,7 @@ RUN cmake --preset clang-deb \
         -DCMAKE_C_COMPILER=clang-21 \
         -DCMAKE_CXX_COMPILER=clang++-21 \
         -DENDO_ENABLE_AGENT=ON \
+        -DENDO_PACKAGE_METADATA_TYPE=deb \
     && cmake --build --preset clang-deb \
     && cpack --preset clang-deb
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,33 @@ if(_need_fetch)
     endif()
 endif()
 
+# contour::tracy — an adaptation to the vendored sources, not a feature of endo.
+#
+# crispy and vtparser link contour::tracy unconditionally: their call sites use
+# Tracy's macros whether or not profiling is compiled in, which is what lets
+# contour keep the instrumentation out of the #ifdef business. Contour defines
+# the target in its own cmake/Tracy.cmake, which endo does not vendor, so without
+# a definition here the generate step fails with "Target ... links to
+# contour::tracy but the target was not found".
+#
+# Endo compiles no Tracy instrumentation, so this is contour's own DISABLED
+# shape of the target: an INTERFACE library contributing nothing but the no-op
+# header shim that ships inside the vendored crispy checkout. SYSTEM so the stub
+# can never contribute a warning to a -Werror build, and BUILD_INTERFACE because
+# nothing installs it. If endo ever wants real profiling, that is a new option
+# here rather than an edit under src/crispy.
+set(_contour_tracy_stub "${CMAKE_CURRENT_SOURCE_DIR}/crispy/tracy-stub")
+if(NOT IS_DIRECTORY "${_contour_tracy_stub}")
+    message(FATAL_ERROR
+        "Vendored crispy has no tracy-stub directory (${_contour_tracy_stub}). "
+        "Upstream contour moved the no-op Tracy shim; adapt this target to its new "
+        "location rather than editing src/crispy.")
+endif()
+add_library(contour_tracy INTERFACE)
+add_library(contour::tracy ALIAS contour_tracy)
+target_include_directories(contour_tracy SYSTEM INTERFACE
+    $<BUILD_INTERFACE:${_contour_tracy_stub}>)
+
 add_subdirectory(CoreVM)
 add_subdirectory(crispy)
 set_target_properties(crispy-core PROPERTIES SYSTEM TRUE)

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -3,9 +3,9 @@
 # It depends on the endo language library for parsing and IR generation.
 
 # Generate the build-derived version header (build/src/shell/EndoVersion.hpp),
-# includable as <shell/EndoVersion.hpp>. ENDO_VERSION_STRING / ENDO_VERSION are
-# set at top scope by GetVersionInformation() and are visible here via the
-# add_subdirectory() scope. (Re-runs at configure time, not on every commit.)
+# includable as <shell/EndoVersion.hpp>. The ENDO_VERSION_* record it substitutes
+# is published at top scope by endo_get_version_information() and is visible here
+# via the add_subdirectory() scope. (Re-runs at configure time, not per commit.)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/EndoVersion.hpp.in
                ${CMAKE_CURRENT_BINARY_DIR}/EndoVersion.hpp @ONLY)
 
@@ -291,10 +291,7 @@ endif()
 add_executable(endo-bin
     main.cpp
 )
-if(MSVC)
-    target_sources(endo-bin PRIVATE endo.manifest)
-endif()
-set_target_properties(endo-bin PROPERTIES OUTPUT_NAME endo)
+set_target_properties(endo-bin PROPERTIES OUTPUT_NAME ${ENDO_PRODUCT_NAME})
 target_link_libraries(endo-bin PUBLIC endo-shell endo-lsp endo-dap)
 enable_static_linking(endo-bin)
 
@@ -417,6 +414,37 @@ if(ENDO_TESTING AND UNIX AND NOT EMSCRIPTEN)
     )
     set_tests_properties(installed-binary PROPERTIES TIMEOUT 120)
 endif()
+
+# Reads the OS-level version metadata back out of the binary the linker just
+# produced. The build-tree binary is the right subject here (unlike
+# installed-binary, which exists to exercise INSTALL_RPATH): every one of the
+# three mechanisms is applied at link time, so if it is not in the build-tree
+# binary it is nowhere. Skips itself where the platform has no probe or the
+# probe tool is missing -- see cmake/tests/TestBinaryVersionMetadata.cmake.
+if(ENDO_TESTING AND NOT EMSCRIPTEN)
+    add_test(
+        NAME binary-version-metadata
+        COMMAND ${CMAKE_COMMAND}
+            -DBINARY=$<TARGET_FILE:endo-bin>
+            -DTARGET_SYSTEM=${CMAKE_SYSTEM_NAME}
+            -DEXPECT_FILE_VERSION=${ENDO_VERSION_QUAD}
+            -DEXPECT_HUMAN_VERSION=${ENDO_VERSION_HUMAN}
+            -DHAVE_VERSION_RESOURCE=$<BOOL:${ENDO_HAS_VERSION_RESOURCE}>
+            -DHAVE_PACKAGE_METADATA=$<BOOL:${ENDO_HAS_ELF_PACKAGE_METADATA}>
+            -P ${CMAKE_SOURCE_DIR}/cmake/tests/TestBinaryVersionMetadata.cmake
+    )
+    set_tests_properties(binary-version-metadata PROPERTIES
+        SKIP_RETURN_CODE 77
+        TIMEOUT 60)
+endif()
+
+# OS-level version metadata, so the shipped executable reports its version to the
+# OS and not just to `endo --version`. Each of these is a no-op off its platform.
+# The Windows one also configures and attaches endo.manifest, which carries a
+# version too.
+enable_windows_version_resource(endo-bin)
+enable_macos_info_plist(endo-bin)
+enable_elf_package_metadata(endo-bin)
 
 # Enable sanitizers and clang-tidy for all targets
 enable_sanitizers(endo-shell)

--- a/src/shell/EndoInfo.plist.in
+++ b/src/shell/EndoInfo.plist.in
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  SPDX-License-Identifier: Apache-2.0
+
+  Embedded into endo's __TEXT,__info_plist section by enable_macos_info_plist()
+  (cmake/MacOSInfoPlist.cmake). endo is a CLI tool and not an .app bundle, so
+  there is no Contents/Info.plist to put this in -- the section IS the
+  Info.plist, and `otool -P endo` prints it.
+
+  Every value is XML character data: keep the strings free of & and < or they
+  have to be escaped here. ENDO_PRODUCT_CONTACT is deliberately absent for
+  exactly that reason (it contains <>).
+-->
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>@ENDO_PRODUCT_BUNDLE_ID@</string>
+    <key>CFBundleName</key>
+    <string>@ENDO_PRODUCT_DISPLAY_NAME@</string>
+    <key>CFBundleExecutable</key>
+    <string>@ENDO_PRODUCT_NAME@</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <!-- The clean tag triple, which is what a release is called. -->
+    <key>CFBundleShortVersionString</key>
+    <string>@ENDO_VERSION_MAJOR@.@ENDO_VERSION_MINOR@.@ENDO_VERSION_PATCH@</string>
+    <!--
+      The build, identical to the Windows FileVersion. Apple documents
+      CFBundleVersion as up to three period-separated integers; that limit is
+      enforced by App Store submission validation, not by the loader or plutil,
+      and endo is a Homebrew/DMG CLI tool that never goes through review. The
+      four-field form buys exact symmetry with Windows at no cost here.
+    -->
+    <key>CFBundleVersion</key>
+    <string>@ENDO_VERSION_QUAD@</string>
+    <key>CFBundleGetInfoString</key>
+    <string>@ENDO_VERSION_HUMAN@</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>@ENDO_PRODUCT_COPYRIGHT@</string>
+</dict>
+</plist>

--- a/src/shell/EndoVersion.hpp.in
+++ b/src/shell/EndoVersion.hpp.in
@@ -8,12 +8,12 @@ namespace endo
 
 /// Human-readable build version string (e.g. "0.1.128-gabc1234").
 /// Derived at configure time from a git tag / describe / version.txt by
-/// GetVersionInformation() in cmake/Version.cmake (ENDO_VERSION_STRING).
-inline constexpr std::string_view EndoVersionString = "@ENDO_VERSION_STRING@";
+/// endo_get_version_information() in cmake/Version.cmake (ENDO_VERSION_HUMAN).
+inline constexpr std::string_view EndoVersionString = "@ENDO_VERSION_HUMAN@";
 
 /// Numeric version triple (major.minor.patch), e.g. "0.1.128".
 /// Matches the CMake project() version and the Windows MSI ProductVersion
-/// (ENDO_VERSION).
-inline constexpr std::string_view EndoVersionNumber = "@ENDO_VERSION@";
+/// (ENDO_VERSION_NUMERIC).
+inline constexpr std::string_view EndoVersionNumber = "@ENDO_VERSION_NUMERIC@";
 
 } // namespace endo

--- a/src/shell/EndoVersionInfo.rc.in
+++ b/src/shell/EndoVersionInfo.rc.in
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Win32 VERSIONINFO resource for endo.exe -- what makes
+// `(Get-Command endo.exe).Version` report something other than 0.0.0.0.
+//
+// Configured at CONFIGURE time by enable_windows_version_resource()
+// (cmake/WindowsVersionResource.cmake) from the version record
+// (cmake/Version.cmake) and cmake/ProjectMetadata.cmake. Nothing here is
+// spelled a second time.
+//
+// FILEVERSION is <tag major>.<tag minor>.<tag patch>.<commits since tag>, which
+// is NOT the three-field ENDO_VERSION that CPack and the MSI use: MSI
+// ProductVersion has only three fields, so it folds the commit distance into the
+// patch. See docs/releases.md.
+//
+// It deliberately carries NO `1 24 "endo.manifest"` entry: CMake feeds
+// endo.manifest to the MSVC linker via /MANIFESTINPUT and the linker embeds it
+// as RT_MANIFEST id 1 itself; a second one from here would collide.
+//
+// Self-contained -- no `#include <winver.h>` -- so rc.exe, llvm-rc and windres
+// all accept it without depending on the resource compiler's preprocessor
+// finding the Windows SDK include directory.
+//
+// ASCII only: rc.exe reads a BOM-less file as ANSI, so a non-ASCII vendor or
+// copyright string would need /c65001 added to CMAKE_RC_FLAGS. Keep the strings
+// ASCII and the question does not arise.
+
+#define VS_VERSION_INFO      1
+#define VS_FFI_FILEFLAGSMASK 0x0000003FL
+#define VOS_NT_WINDOWS32     0x00040004L
+#define VFT_APP              0x00000001L
+#define VFT2_UNKNOWN         0x00000000L
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION    @ENDO_RC_VERSION_FIELDS@
+ PRODUCTVERSION @ENDO_RC_VERSION_FIELDS@
+ FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef ENDO_RC_DEBUG_BUILD
+ FILEFLAGS @ENDO_RC_FILEFLAGS_DEBUG@
+#else
+ FILEFLAGS @ENDO_RC_FILEFLAGS@
+#endif
+ FILEOS VOS_NT_WINDOWS32
+ FILETYPE VFT_APP
+ FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        // 0409 = U.S. English, 04B0 = 1200 = Unicode. Must agree with the
+        // Translation value below or the shell reads no strings at all.
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "CompanyName",      "@ENDO_PRODUCT_VENDOR@"
+            VALUE "FileDescription",  "@ENDO_PRODUCT_DESCRIPTION@"
+            VALUE "FileVersion",      "@ENDO_VERSION_QUAD@"
+            VALUE "InternalName",     "@ENDO_PRODUCT_NAME@"
+            VALUE "LegalCopyright",   "@ENDO_PRODUCT_COPYRIGHT@"
+            VALUE "OriginalFilename", "@ENDO_PRODUCT_NAME@.exe"
+            VALUE "ProductName",      "@ENDO_PRODUCT_DISPLAY_NAME@"
+            // The human describe string, deliberately: the numeric FileVersion
+            // above already carries the machine-comparable form.
+            VALUE "ProductVersion",   "@ENDO_VERSION_HUMAN@"
+            VALUE "Comments",         "@ENDO_PRODUCT_HOMEPAGE@"
+@ENDO_RC_PRIVATE_BUILD_VALUE@
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/src/shell/endo.manifest.in
+++ b/src/shell/endo.manifest.in
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <assemblyIdentity type="win32" name="endo" version="0.1.0.0"/>
+  <assemblyIdentity type="win32" name="@ENDO_PRODUCT_NAME@"
+                    version="@ENDO_VERSION_QUAD@"/>
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>


### PR DESCRIPTION
`(Get-Command endo.exe).Version` reported `0.0.0.0` — not a wrong version, but no version at all. The executable carried no `VS_VERSION_INFO` resource, so the version reached the binary only as a C++ string constant that `endo --version` prints, invisible to the OS, Explorer, a package manager or a crash reporter. Fixing that surfaced two further problems with the Windows install: the per-version install directory leaves no stable path to configure a terminal profile with, and MSI upgrades were silently broken.

## Changes

**Version metadata is embedded on all three platforms**, driven by the version CMake already derives from `git describe`:

- Windows — a `VS_VERSION_INFO` resource (`enable_language(RC)` plus a configured `.rc`), with `VS_FF_PRERELEASE` for development builds, `VS_FF_PRIVATEBUILD` for a dirty tree and `VS_FF_DEBUG` for Debug.
- macOS — an embedded `__TEXT,__info_plist` section, which is how a non-bundle CLI tool carries `CFBundleShortVersionString` / `CFBundleVersion`. `-current_version` is not an option: ld64 accepts it only for a dylib.
- Linux — a `.note.package` ELF note per the [systemd ELF package metadata](https://systemd.io/ELF_PACKAGE_METADATA/) spec, emitted through `-Xlinker` and gated on a `check_linker_flag` probe. Not `-Wl,` and not CMake's `LINKER:` prefix: both split their payload on every comma, and the value is JSON.

`FILEVERSION` is the release tag's own `MAJOR.MINOR.PATCH` plus the commit distance, so a build 313 commits past `v0.1.0` reports `0.1.0.313` and a release reports `0.1.0.0`. That deliberately differs from the version the *packages* carry (`0.1.313`): Windows Installer compares only three fields, so the packaged version folds the commit distance into the patch. Nothing CPack consumes changed — the MSI `ProductVersion`, upgrade code, install directory, per-version PATH component GUID and the `.deb`/`.rpm` versions are byte-identical.

**One parser feeds both shapes.** `endo_parse_git_describe()` now publishes a version record under a caller-chosen prefix rather than four positional out-params, and the `version.txt` path the `.deb` build uses became a testable `endo_parse_version_file()` that keeps its unfolded triple. Product identity strings that the resource, the plist, the ELF note and CPack all need are declared once in `cmake/ProjectMetadata.cmake`.

**A `latest` junction for terminal profiles.** Per-version directories are what let an upgrade lay the new binary down without touching the locked one a running shell holds, and they are also why an absolute path goes stale every release. `C:\Program Files\Endo\latest` is now a directory junction repointed on every install and removed on uninstall, so a profile configured against `latest\bin\endo.exe` keeps working. Windows Terminal needs it — it does not resolve a bare `endo.exe` through `PATH`. A junction rather than a symlink because `/J` never needs `SeCreateSymbolicLinkPrivilege`.

**MSI upgrades were broken and are fixed.** Installing over an existing version left a registered product with no files and no `PATH` entry. CPack generates a remembered-install-location search into `properties.wxi`; `AppSearch` assigned the *old* version's directory to the public property `INSTALL_ROOT`, which outranks the Directory table, so the new version's files were written into the old version's directory — and `RemoveExistingProducts`, scheduled `afterInstallExecute`, then deleted exactly those files. `INSTALL_ROOT` is now pinned back to this version's directory right after `AppSearch`, conditioned on `WIX_UPGRADE_DETECTED` so fresh installs and the `WixUI_InstallDir` chooser are untouched. Latent since the per-version directory landed in 6f1cfe88; **not in any release**, as `v0.1.0` still used the unversioned `Endo` directory.

**Collateral fixes.** `src/shell/endo.manifest` became a template — its `assemblyIdentity` version had frozen at `0.1.0.0`, and one executable should not claim two versions. `Sanitizers`, `PedanticCompiler` and `Coverage` now scope their compile options to `$<COMPILE_LANGUAGE:CXX>`: `target_compile_options` applies to every language of a target, `endo-bin` now compiles an RC source, and `rc.exe` treats an unknown switch as a fatal `RC1106` — so `clangcl-debug -DENABLE_ASAN=ON` would have started failing.

## Trade-offs worth a reviewer's attention

The upgrade fix gives up relocating an upgrade to a non-default directory a user chose for an earlier version; they are moved back under `Program Files`. Today such a user ends up with nothing installed at all, so it is strictly better — but the cleaner shape is a stable `INSTALL_ROOT` with the version in the install destinations, which would change the portable ZIP layout and is left out here.

The version is still derived at **configure** time, which the project chose deliberately to keep the compile cache useful. A reconfigure therefore needs a second build before the regenerated resource is linked in; `binary-version-metadata` fails loudly when the binary and CMake disagree, and `release.yml` already runs `ctest` before `cpack`, so a stale binary cannot reach a package.
